### PR TITLE
feat: extensionality property of variational adjoint

### DIFF
--- a/PhysLean/Mathematics/VariationalCalculus/Basic.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/Basic.lean
@@ -48,7 +48,7 @@ lemma fundamental_theorem_of_variational_calculus {f : X → V}
 weakened to `Continuous f`.
 
 The proof is by contradiction, assume that there is `x₀` such that `f x₀` then you can easily
- construct `g` test function with support on the neighborhood of `x₀` such that `⟪f x, g x⟫ ≥ 0`. -/
+construct `g` test function with support on the neighborhood of `x₀` such that `⟪f x, g x⟫ ≥ 0`. -/
 semiformal_result "FIE3I" fundamental_theorem_of_variational_calculus' {f : X → V}
     (μ : Measure X) [IsFiniteMeasureOnCompacts μ] [μ.IsOpenPosMeasure]
     [OpensMeasurableSpace X]

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
@@ -133,7 +133,7 @@ protected lemma deriv :
         refine mem_interior_iff_mem_nhds.mp ?_
         rw [@mem_interior]
         use Metric.thickening 1 K
-        simp
+        simp only [subset_refl, true_and]
         apply And.intro
         · exact Metric.isOpen_thickening
         · rw [@Metric.mem_thickening_iff_exists_edist_lt]

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
@@ -52,7 +52,6 @@ structure HasVarAdjoint
   ext : ∀ (K : Set X) (_ : IsCompact K), ∃ L : Set X,
     IsCompact L ∧ K ⊆ L ∧ ∀ (φ φ' : X → V), (∀ x ∈ L, φ x = φ' x) → ∀ x ∈ K, F' φ x = F' φ' x
 
-
 namespace HasVarAdjoint
 
 variable {μ : Measure X}
@@ -82,7 +81,6 @@ lemma comp {F : (X → V) → (X → W)} {G : (X → U) → (X → V)} {F' G'}
     · exact sK'.trans sK''
     · intro φ φ' hφ
       apply h' _ _ (fun _ hx' => h'' _ _ hφ _ hx')
-
 
 protected lemma deriv :
     HasVarAdjoint (fun φ : ℝ → ℝ => deriv φ) (fun φ x => - deriv φ x) where
@@ -157,22 +155,23 @@ lemma congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)} {
     exact h.adjoint φ ψ hφ hψ
   ext := h.ext
 
--- lemma congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)} {μ : Measure X}
---     (h : HasVarAdjoint F G' μ) (h' : ∀ φ, IsTestFunction φ → F' φ = G' φ) :
---     HasVarAdjoint F F' μ where
---   test_fun_preserving φ hφ := h.test_fun_preserving φ hφ
---   test_fun_preserving' φ hφ := by
---     rw [h' φ hφ]
---     exact h.test_fun_preserving' φ hφ
---   adjoint φ ψ hφ hψ := by
---     rw [h' ψ hψ]
---     exact h.adjoint φ ψ hφ hψ
---   ext := sorry
-
+/-
+lemma congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)} {μ : Measure X}
+    (h : HasVarAdjoint F G' μ) (h' : ∀ φ, IsTestFunction φ → F' φ = G' φ) :
+    HasVarAdjoint F F' μ where
+  test_fun_preserving φ hφ := h.test_fun_preserving φ hφ
+  test_fun_preserving' φ hφ := by
+    rw [h' φ hφ]
+    exact h.test_fun_preserving' φ hφ
+  adjoint φ ψ hφ hψ := by
+    rw [h' ψ hψ]
+    exact h.adjoint φ ψ hφ hψ
+  ext := sorry
+-/
 /-- Variational adjoint is unique only when applied to test functions. -/
-lemma unique_on_test_functions {F : (X → U) → (X → V)} {F' G'  : (X → V) → (X → U)}
+lemma unique_on_test_functions {F : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     {μ : Measure X} [IsFiniteMeasureOnCompacts μ] [μ.IsOpenPosMeasure]
-    [OpensMeasurableSpace X] (hF' : HasVarAdjoint F F' μ) (hG' : HasVarAdjoint F G' μ)  :
+    [OpensMeasurableSpace X] (hF' : HasVarAdjoint F F' μ) (hG' : HasVarAdjoint F G' μ) :
     ∀ φ, IsTestFunction φ → F' φ = G' φ := by
   obtain ⟨F_preserve_test, F'_preserve_test, F'_adjoint⟩ := hF'
   obtain ⟨F_preserve_test, G'_preserve_test, G'_adjoint⟩ := hG'
@@ -208,9 +207,9 @@ lemma unique_on_test_functions {F : (X → U) → (X → V)} {F' G'  : (X → V)
 lemma unique
     {X : Type*} [NormedAddCommGroup X] [InnerProductSpace ℝ X]
     [FiniteDimensional ℝ X] [MeasurableSpace X]
-    {F : (X → U) → (X → V)} {F' G'  : (X → V) → (X → U)}
+    {F : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     {μ : Measure X} [IsFiniteMeasureOnCompacts μ] [μ.IsOpenPosMeasure] [OpensMeasurableSpace X]
-    (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint F G' μ)  :
+    (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint F G' μ) :
     ∀ f, ContDiff ℝ ∞ f → F' f = G' f := by
 
   intro f hf; funext x
@@ -218,7 +217,7 @@ lemma unique
   obtain ⟨K, cK, sK, hK⟩ := hF.ext {x} (isCompact_singleton)
   obtain ⟨L, cL, sL, hL⟩ := hG.ext {x} (isCompact_singleton)
   -- have hK : x ∈ {x} K := by
-  --   exact? Set.mem_singleton x
+  -- exact? Set.mem_singleton x
   have hnonempty : Set.Nonempty (K ∪ L) := by
     apply Set.Nonempty.inl
     use x; simp_all only [Set.singleton_subset_iff, Set.mem_singleton_iff, forall_eq]
@@ -358,7 +357,6 @@ lemma add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
         intro x hx; apply hφ; simp_all
       simp +contextual (disch:=assumption) [h φ φ', h' φ φ']
 
-
 lemma sub {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
     (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint G G' μ) :
@@ -415,7 +413,6 @@ lemma mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → 
     intro K cK
     obtain ⟨L,cL,sL,h⟩ := hF.ext K cK
     exact ⟨L,cL,sL,by intro _ _ hφ _ _; apply h <;> simp_all⟩
-
 
 lemma smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
     {μ : Measure X}

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
@@ -49,7 +49,7 @@ structure HasVarAdjoint
   adjoint : ∀ φ ψ, IsTestFunction φ → IsTestFunction ψ →
     ∫ x, ⟪F φ x, ψ x⟫_ℝ ∂μ = ∫ x, ⟪φ x, F' ψ x⟫_ℝ ∂μ
   ext : ∀ (K : Set X) (_ : IsCompact K), ∃ L : Set X,
-    IsCompact L ∧ K ⊆ L ∧ ∀ (φ φ' : X → U), (∀ x ∈ L, φ x = φ' x) → ∀ x ∈ K, F φ x = F φ' x
+    IsCompact L ∧ K ⊆ L ∧ ∀ (φ φ' : X → V), (∀ x ∈ L, φ x = φ' x) → ∀ x ∈ K, F' φ x = F' φ' x
 
 
 namespace HasVarAdjoint
@@ -72,8 +72,8 @@ lemma comp {F : (X → V) → (X → W)} {G : (X → U) → (X → V)} {F' G'}
     rw [hG.adjoint _ _ hφ (hF.test_fun_preserving' _ hψ)]
   ext := by
     intro K cK
-    obtain ⟨K', cK', sK', h'⟩ := hF.ext K cK
-    obtain ⟨K'', cK'', sK'', h''⟩ := hG.ext K' cK'
+    obtain ⟨K', cK', sK', h'⟩ := hG.ext K cK
+    obtain ⟨K'', cK'', sK'', h''⟩ := hF.ext K' cK'
     use K''
     constructor
     · exact cK''
@@ -118,7 +118,17 @@ protected lemma deriv :
       · exact hφ
     · refine IsTestFunction.integrable ?_ _
       exact IsTestFunction.mul hψ hφ
-  ext := sorry
+  ext := by
+    intro K cK
+    use (Metric.cthickening 1 K)
+    constructor
+    · exact IsCompact.cthickening cK
+    constructor
+    · exact Metric.self_subset_cthickening K
+    · intro φ φ' hφ
+      have h : ∀ x ∈ K, φ =ᶠ[nhds x] φ' := sorry
+      intro x hx; congr 1
+      apply (h x hx).deriv_eq
 
 lemma congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)} {μ : Measure X}
     (h : HasVarAdjoint G F' μ) (h' : ∀ φ, IsTestFunction φ → F φ = G φ) :
@@ -130,19 +140,19 @@ lemma congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)} {
   adjoint φ ψ hφ hψ := by
     rw [h' φ hφ]
     exact h.adjoint φ ψ hφ hψ
-  ext := sorry
+  ext := h.ext
 
-lemma congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)} {μ : Measure X}
-    (h : HasVarAdjoint F G' μ) (h' : ∀ φ, IsTestFunction φ → F' φ = G' φ) :
-    HasVarAdjoint F F' μ where
-  test_fun_preserving φ hφ := h.test_fun_preserving φ hφ
-  test_fun_preserving' φ hφ := by
-    rw [h' φ hφ]
-    exact h.test_fun_preserving' φ hφ
-  adjoint φ ψ hφ hψ := by
-    rw [h' ψ hψ]
-    exact h.adjoint φ ψ hφ hψ
-  ext := sorry
+-- lemma congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)} {μ : Measure X}
+--     (h : HasVarAdjoint F G' μ) (h' : ∀ φ, IsTestFunction φ → F' φ = G' φ) :
+--     HasVarAdjoint F F' μ where
+--   test_fun_preserving φ hφ := h.test_fun_preserving φ hφ
+--   test_fun_preserving' φ hφ := by
+--     rw [h' φ hφ]
+--     exact h.test_fun_preserving' φ hφ
+--   adjoint φ ψ hφ hψ := by
+--     rw [h' ψ hψ]
+--     exact h.adjoint φ ψ hφ hψ
+--   ext := sorry
 
 /-- Variational adjoint is unique only when applied to test functions. -/
 lemma unique {F : (X → U) → (X → V)} {F' G'  : (X → V) → (X → U)}
@@ -200,7 +210,10 @@ lemma neg {F : (X → U) → (X → V)} {F' : (X → V) → (X → U)}
   adjoint _ _ _ _ := by
     simp [integral_neg]
     rw[hF.adjoint _ _ (by assumption) (by assumption)]
-  ext := sorry
+  ext := by
+    intro K cK
+    obtain ⟨L,cL,sL,h⟩ := hF.ext K cK
+    exact ⟨L,cL,sL,by intro _ _ _ _ _; congr 1; apply h <;> simp_all⟩
 
 lemma add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
@@ -246,7 +259,22 @@ lemma add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
       apply IsTestFunction.inner
       · (expose_names; exact hG.test_fun_preserving x h)
       · (expose_names; exact h_1)
-  ext := sorry
+  ext := by
+    intro K cK
+    obtain ⟨L,cL,sL,h⟩ := hF.ext K cK
+    obtain ⟨L',cL',sL',h'⟩ := hG.ext K cK
+    use L ∪ L'
+    constructor
+    · exact cL.union cL'
+    constructor
+    · exact Set.subset_union_of_subset_left sL _
+    · intro φ φ' hφ
+      have hL : ∀ x ∈ L, φ x = φ' x := by
+        intro x hx; apply hφ; simp_all
+      have hL' : ∀ x ∈ L', φ x = φ' x := by
+        intro x hx; apply hφ; simp_all
+      simp +contextual (disch:=assumption) [h φ φ', h' φ φ']
+
 
 lemma sub {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
@@ -275,7 +303,10 @@ lemma mul_left {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → �
     · apply IsTestFunction.mul_left
       · exact hψ
       · exact hψ'
-  ext := sorry
+  ext := by
+    intro K cK
+    obtain ⟨L,cL,sL,h⟩ := hF.ext K cK
+    exact ⟨L,cL,sL,by intro _ _ hφ _ _; apply h <;> simp_all⟩
 
 lemma mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → ℝ) → (X → ℝ)}
     {μ : Measure X}
@@ -297,7 +328,11 @@ lemma mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → 
     · apply IsTestFunction.mul_right
       · exact hψ'
       · exact hψ
-  ext := sorry
+  ext := by
+    intro K cK
+    obtain ⟨L,cL,sL,h⟩ := hF.ext K cK
+    exact ⟨L,cL,sL,by intro _ _ hφ _ _; apply h <;> simp_all⟩
+
 
 lemma smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
     {μ : Measure X}
@@ -315,7 +350,10 @@ lemma smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) �
     · rfl
     · exact hφ
     · simp; fun_prop
-  ext := sorry
+  ext := by
+    intro K cK
+    obtain ⟨L,cL,sL,h⟩ := hF.ext K cK
+    exact ⟨L,cL,sL,by intro _ _ hφ _ _; apply h <;> simp_all⟩
 
 lemma smul_right {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
     {μ : Measure X}
@@ -333,4 +371,7 @@ lemma smul_right {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) 
     · rfl
     · exact hφ
     · simp; fun_prop
-  ext := sorry
+  ext := by
+    intro K cK
+    obtain ⟨L,cL,sL,h⟩ := hF.ext K cK
+    exact ⟨L,cL,sL,by intro _ _ hφ _ _; apply h <;> simp_all⟩

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
@@ -48,6 +48,9 @@ structure HasVarAdjoint
   test_fun_preserving' : ∀ φ, IsTestFunction φ → IsTestFunction (F' φ)
   adjoint : ∀ φ ψ, IsTestFunction φ → IsTestFunction ψ →
     ∫ x, ⟪F φ x, ψ x⟫_ℝ ∂μ = ∫ x, ⟪φ x, F' ψ x⟫_ℝ ∂μ
+  ext : ∀ (K : Set X) (_ : IsCompact K), ∃ L : Set X,
+    IsCompact L ∧ K ⊆ L ∧ ∀ (φ φ' : X → U), (∀ x ∈ L, φ x = φ' x) → ∀ x ∈ K, F φ x = F φ' x
+
 
 namespace HasVarAdjoint
 
@@ -57,6 +60,7 @@ lemma id : HasVarAdjoint (fun φ : X → U => φ) (fun φ => φ) μ where
   test_fun_preserving _ hφ := hφ
   test_fun_preserving' _ hφ := hφ
   adjoint _ _ _ _ := rfl
+  ext := fun K cK => ⟨K,cK,subset_refl _,fun _ _ h => h⟩
 
 lemma comp {F : (X → V) → (X → W)} {G : (X → U) → (X → V)} {F' G'}
     (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint G G' μ) :
@@ -66,6 +70,18 @@ lemma comp {F : (X → V) → (X → W)} {G : (X → U) → (X → V)} {F' G'}
   adjoint φ ψ hφ hψ := by
     rw [hF.adjoint _ _ (hG.test_fun_preserving φ hφ) hψ]
     rw [hG.adjoint _ _ hφ (hF.test_fun_preserving' _ hψ)]
+  ext := by
+    intro K cK
+    obtain ⟨K', cK', sK', h'⟩ := hF.ext K cK
+    obtain ⟨K'', cK'', sK'', h''⟩ := hG.ext K' cK'
+    use K''
+    constructor
+    · exact cK''
+    constructor
+    · exact sK'.trans sK''
+    · intro φ φ' hφ
+      apply h' _ _ (fun _ hx' => h'' _ _ hφ _ hx')
+
 
 protected lemma deriv :
     HasVarAdjoint (fun φ : ℝ → ℝ => deriv φ) (fun φ x => - deriv φ x) where
@@ -102,6 +118,7 @@ protected lemma deriv :
       · exact hφ
     · refine IsTestFunction.integrable ?_ _
       exact IsTestFunction.mul hψ hφ
+  ext := sorry
 
 lemma congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)} {μ : Measure X}
     (h : HasVarAdjoint G F' μ) (h' : ∀ φ, IsTestFunction φ → F φ = G φ) :
@@ -113,6 +130,7 @@ lemma congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)} {
   adjoint φ ψ hφ hψ := by
     rw [h' φ hφ]
     exact h.adjoint φ ψ hφ hψ
+  ext := sorry
 
 lemma congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)} {μ : Measure X}
     (h : HasVarAdjoint F G' μ) (h' : ∀ φ, IsTestFunction φ → F' φ = G' φ) :
@@ -124,6 +142,7 @@ lemma congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)}
   adjoint φ ψ hφ hψ := by
     rw [h' ψ hψ]
     exact h.adjoint φ ψ hφ hψ
+  ext := sorry
 
 /-- Variational adjoint is unique only when applied to test functions. -/
 lemma unique {F : (X → U) → (X → V)} {F' G'  : (X → V) → (X → U)}
@@ -181,6 +200,7 @@ lemma neg {F : (X → U) → (X → V)} {F' : (X → V) → (X → U)}
   adjoint _ _ _ _ := by
     simp [integral_neg]
     rw[hF.adjoint _ _ (by assumption) (by assumption)]
+  ext := sorry
 
 lemma add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
@@ -226,6 +246,7 @@ lemma add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
       apply IsTestFunction.inner
       · (expose_names; exact hG.test_fun_preserving x h)
       · (expose_names; exact h_1)
+  ext := sorry
 
 lemma sub {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
@@ -254,6 +275,7 @@ lemma mul_left {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → �
     · apply IsTestFunction.mul_left
       · exact hψ
       · exact hψ'
+  ext := sorry
 
 lemma mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → ℝ) → (X → ℝ)}
     {μ : Measure X}
@@ -275,6 +297,7 @@ lemma mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → 
     · apply IsTestFunction.mul_right
       · exact hψ'
       · exact hψ
+  ext := sorry
 
 lemma smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
     {μ : Measure X}
@@ -292,6 +315,7 @@ lemma smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) �
     · rfl
     · exact hφ
     · simp; fun_prop
+  ext := sorry
 
 lemma smul_right {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
     {μ : Measure X}
@@ -309,3 +333,4 @@ lemma smul_right {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) 
     · rfl
     · exact hφ
     · simp; fun_prop
+  ext := sorry

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarGradient.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarGradient.lean
@@ -5,7 +5,6 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 -/
 import PhysLean.Mathematics.VariationalCalculus.HasVarAdjoint
 import Mathlib.Tactic.FunProp.Differentiable
-import Mathlib.Analysis.Calculus.BumpFunction.InnerProduct
 /-!
 
 # Variational gradient
@@ -124,7 +123,7 @@ lemma HasVarGradientAt.unique
     (by intros _ hx; unfold φ; rw[φ.one_of_mem_closedBall]; apply hφ'; simp[hx])
   have h' := hgrad' φ hφ
     (by intros _ hx; unfold φ; rw[φ.one_of_mem_closedBall]; apply hφ'; simp[hx])
-  rw[← h, ← h',hF.unique hG φ hφ]
+  rw[← h, ← h',hF.unique hG φ (ContDiffBump.contDiff φ)]
 
 /-- Variation of `S(x) = ∫ 1/2*m*‖ẋ‖² - V(x)` gives Newton's law of motion `δS(x) = - m*ẍ - V'(x)`-/
 lemma euler_lagrange_particle_1d (m : ℝ) (u V : ℝ → ℝ)


### PR DESCRIPTION
Adding extensionality property to variational adjoint saying that for `F φ x = F φ' x` we require `φ x = φ' x` to be equal on some larger set. This guarantees that `F φ x` can depend only on values `φ y` for `y` not too far away from `x`.

This property allows us to then show that `F f` has some meaningful value for `f` smooth functions.