### PR TITLE
feat: Infinite well submodule

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -203,9 +203,11 @@ import PhysLean.QuantumMechanics.OneDimension.HarmonicOscillator.Eigenfunction
 import PhysLean.QuantumMechanics.OneDimension.HarmonicOscillator.TISE
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Basic
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Gaussians
+import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.InfiniteWell
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PlaneWaves
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PositionStates
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.SchwartzSubmodule
+import PhysLean.QuantumMechanics.OneDimension.Operators.Commutation
 import PhysLean.QuantumMechanics.OneDimension.Operators.Momentum
 import PhysLean.QuantumMechanics.OneDimension.Operators.Parity
 import PhysLean.QuantumMechanics.OneDimension.Operators.Position

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean
@@ -166,6 +166,10 @@ lemma mk_eq_iff {f g : ℝ → ℂ} {hf : MemHS f} {hg : MemHS g} :
     mk hf = mk hg ↔ f =ᵐ[volume] g := by
   simp [mk]
 
+lemma ext_iff {f g : HilbertSpace} :
+    f = g ↔ (f : ℝ → ℂ) =ᶠ[ae volume] (g : ℝ → ℂ) := by
+  exact Lp.ext_iff
+
 end HilbertSpace
 end
 end OneDimension

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/InfiniteWell.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/InfiniteWell.lean
@@ -53,7 +53,7 @@ def infiniteWellSubmodule (a b : ℝ) : Submodule ℂ HilbertSpace where
     refine ⟨(Lp.coeFn_add ψ1 ψ2).trans (h1ae.add h2ae),
       h1c.add h2c, ?_, fun x hx => (h1d x hx).add (h2d x hx)⟩
     intro x
-    simp
+    simp only [Function.mem_support, Pi.add_apply, ne_eq, Set.mem_Ioo]
     intro h
     by_cases h1 : ¬ ψ1' x = 0 <;> by_cases h2 : ¬ ψ2' x = 0
     · exact h1s h1
@@ -66,7 +66,8 @@ def infiniteWellSubmodule (a b : ℝ) : Submodule ℂ HilbertSpace where
     refine ⟨(Lp.coeFn_smul c ψ).trans (hae.const_smul c), hc.const_smul c, ?_,
       fun x hx => (hd x hx).const_smul c⟩
     intro x
-    simp
+    simp only [Function.mem_support, Pi.smul_apply, smul_eq_mul, ne_eq, mul_eq_zero, not_or,
+      Set.mem_Ioo, and_imp]
     intro h
     simp at hs
     exact hs x
@@ -86,7 +87,7 @@ def infiniteWellFunSubmodule (a b : ℝ) : Submodule ℂ (ℝ → ℂ) where
     refine ⟨
       h1.1.add h2.1, ?_, fun x hx => (h1.2.2 x hx).add (h2.2.2 x hx)⟩
     intro x
-    simp
+    simp only [Function.mem_support, Pi.add_apply, ne_eq, Set.mem_Ioo]
     intro h
     have h1s := h1.2.1
     have h2s := h2.2.1
@@ -99,7 +100,8 @@ def infiniteWellFunSubmodule (a b : ℝ) : Submodule ℂ (ℝ → ℂ) where
     refine ⟨h.1.const_smul c, ?_,
       fun x hx => (h.2.2 x hx).const_smul c⟩
     intro x
-    simp
+    simp only [Function.mem_support, Pi.smul_apply, smul_eq_mul, ne_eq, mul_eq_zero, not_or,
+      Set.mem_Ioo, and_imp]
     intro hc
     have hs := h.2.1
     simp at hs
@@ -175,9 +177,9 @@ def infiniteWellSubmoduleEquiv {a b : ℝ} :
   invFun ψ := ⟨HilbertSpace.mk (memHS_of_infiniteWellFunSubmodule ψ),
     ⟨ψ, ⟨coe_mk_ae (memHS_of_infiniteWellFunSubmodule ψ), ψ.2.1, ψ.2.2.1, ψ.2.2.2⟩⟩⟩
   left_inv ψ := by
-    simp
+    simp only [Function.support_subset_iff, ne_eq, Set.mem_Ioo, and_imp]
     ext1
-    simp
+    simp only
     apply ext_iff.mpr
     apply (coe_mk_ae _).trans
     simpa using (Classical.choose_spec ψ.2).1.symm

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/InfiniteWell.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/InfiniteWell.lean
@@ -1,0 +1,256 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PlaneWaves
+import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PositionStates
+import PhysLean.QuantumMechanics.PlanckConstant
+import PhysLean.Meta.TODO.Basic
+/-!
+
+# The infinite well submodule
+
+The submodule of the Hilbert space spanned by functions
+`ℝ → ℂ` which are continuous, supported in the interval `(a, b)`, and
+are smooth in the interior of the interval.
+
+This is the submodule on which the Hamiltonian operator of the infinite potential
+wel is defined on as an unbounded operator.
+
+The submodule itself is `infiniteWellSubmodule` which is equivalent
+through `infiniteWellSubmoduleEquiv` to the submodule of functions
+`ℝ → ℂ` which are continuous, supported in the interval `(a, b)`, and
+are smooth in the interior of the interval, which is `infiniteWellFunSubmodule`.
+
+-/
+
+namespace QuantumMechanics
+
+namespace OneDimension
+noncomputable section
+open Constants
+open HilbertSpace
+open MeasureTheory
+
+/-- The submodule of the Hilbert space of those wavefunctions which are
+  continuous, supported on `(a, b)` and are smooth in the interior of this interval. -/
+def infiniteWellSubmodule (a b : ℝ) : Submodule ℂ HilbertSpace where
+  carrier ψ := ∃ ψ' : ℝ → ℂ,
+    ψ =ᶠ[ae volume] ψ' ∧
+    Continuous ψ' ∧
+    Function.support ψ' ⊆ Set.Ioo a b
+    ∧ ∀ x ∈ Set.Ioo a b, ContDiffAt ℝ ⊤ ψ' x
+  zero_mem' := by
+    use 0
+    exact ⟨Lp.coeFn_zero ℂ 2 volume, continuous_zero,
+      Function.support_subset_iff'.mpr fun x => congrFun rfl, fun x hx =>
+        ContDiff.contDiffAt contDiff_zero_fun⟩
+  add_mem' {ψ1 ψ2} h1 h2 := by
+    obtain ⟨ψ1', h1ae, h1c, h1s, h1d⟩ := h1
+    obtain ⟨ψ2', h2ae, h2c, h2s, h2d⟩ := h2
+    use ψ1' + ψ2'
+    refine ⟨(Lp.coeFn_add ψ1 ψ2).trans (h1ae.add h2ae),
+      h1c.add h2c, ?_, fun x hx => (h1d x hx).add (h2d x hx)⟩
+    intro x
+    simp
+    intro h
+    by_cases h1 : ¬ ψ1' x = 0 <;> by_cases h2 : ¬ ψ2' x = 0
+    · exact h1s h1
+    · exact h1s h1
+    · exact h2s h2
+    · simp_all
+  smul_mem' c ψ h := by
+    obtain ⟨ψ', hae, hc, hs, hd⟩ := h
+    use c • ψ'
+    refine ⟨(Lp.coeFn_smul c ψ).trans (hae.const_smul c), hc.const_smul c, ?_,
+      fun x hx => (hd x hx).const_smul c⟩
+    intro x
+    simp
+    intro h
+    simp at hs
+    exact hs x
+
+/-- The submodule of the `ℝ → ℂ` of those functions which are
+  continuous, supported on `(a, b)` and are smooth in the interior of this interval. -/
+def infiniteWellFunSubmodule (a b : ℝ) : Submodule ℂ (ℝ → ℂ) where
+  carrier ψ :=
+    Continuous ψ ∧
+    Function.support ψ ⊆ Set.Ioo a b
+    ∧ ∀ x ∈ Set.Ioo a b, ContDiffAt ℝ ⊤ ψ x
+  zero_mem' := by
+    exact ⟨continuous_zero,
+      Function.support_subset_iff'.mpr fun x => congrFun rfl, fun x hx =>
+        ContDiff.contDiffAt contDiff_zero_fun⟩
+  add_mem' {ψ1 ψ2} h1 h2 := by
+    refine ⟨
+      h1.1.add h2.1, ?_, fun x hx => (h1.2.2 x hx).add (h2.2.2 x hx)⟩
+    intro x
+    simp
+    intro h
+    have h1s := h1.2.1
+    have h2s := h2.2.1
+    by_cases h1 : ¬ ψ1 x = 0 <;> by_cases h2 : ¬ ψ2 x = 0
+    · exact h1s h1
+    · exact h1s h1
+    · exact h2s h2
+    · simp_all
+  smul_mem' c ψ h := by
+    refine ⟨h.1.const_smul c, ?_,
+      fun x hx => (h.2.2 x hx).const_smul c⟩
+    intro x
+    simp
+    intro hc
+    have hs := h.2.1
+    simp at hs
+    exact hs x
+
+lemma continuous_of_infiniteWellFunSubmodule {a b : ℝ} (ψ : infiniteWellFunSubmodule a b) :
+    Continuous ψ.1 := ψ.2.1
+
+lemma memHS_of_infiniteWellFunSubmodule {a b : ℝ} (ψ : infiniteWellFunSubmodule a b) :
+    MemHS ψ := by
+  rw [memHS_iff]
+  refine ⟨?_, ?_⟩
+  · refine Continuous.aestronglyMeasurable ?_
+    exact continuous_of_infiniteWellFunSubmodule ψ
+  · rw [← MeasureTheory.integrableOn_iff_integrable_of_support_subset (s := Set.Icc a b)]
+    · apply MeasureTheory.LocallyIntegrableOn.integrableOn_isCompact
+      · apply ContinuousOn.locallyIntegrableOn
+        · have h1 := continuous_of_infiniteWellFunSubmodule ψ
+          fun_prop
+        · exact measurableSet_Icc
+      · exact isCompact_Icc
+    · simp
+      intro x hx
+      have hs := ψ.2.2.1
+      simp at hs
+      exact ⟨le_of_lt (hs x hx).1, le_of_lt (hs x hx).2⟩
+
+lemma sin_mem_infiniteWellFunSubmodule :
+    (fun x => if x ∈ Set.Ioo (-1) 1 then Real.sin (Real.pi * x) else (0 : ℂ) : ℝ → ℂ)
+    ∈ infiniteWellFunSubmodule (-1) 1 := by
+  refine ⟨?_, ?_, ?_⟩
+  · refine continuous_if ?_ ?_ ?_
+    · intro a ha
+      have h1 : frontier (Set.Ioo (-1) (1 : ℝ)) = {-1, 1} := by
+        rw [frontier_Ioo]
+        simp
+      erw [h1] at ha
+      simp at ha
+      rcases ha with rfl | rfl
+      · simp
+      · simp
+    · fun_prop
+    · fun_prop
+  · simp
+    intro x h1 h2 h
+    simp_all
+  · intro x hx
+    apply ContDiffAt.congr_of_eventuallyEq (f := (fun x => Real.sin (Real.pi * x) : ℝ → ℂ))
+    · refine ContDiffAt.fun_comp x ?_ ?_
+      · apply ContDiff.contDiffAt
+        change ContDiff ℝ ⊤ Complex.ofRealCLM
+        fun_prop
+      · apply ContDiff.contDiffAt
+        apply ContDiff.sin
+        fun_prop
+    · rw [Filter.eventuallyEq_iff_exists_mem]
+      use Set.Ioo (-1) 1
+      constructor
+      · simp at hx
+        exact Ioo_mem_nhds hx.1 hx.2
+      · intro x hx
+        simp at hx
+        simp_all
+
+/-- The equivalence between the submodule of the Hilbert space and the submodule
+  of functions `ℝ → ℂ` which are continuous, supported on `(a, b)` and are smooth within
+  this interval. -/
+def infiniteWellSubmoduleEquiv {a b : ℝ} :
+    infiniteWellSubmodule a b ≃ₗ[ℂ] infiniteWellFunSubmodule a b where
+  toFun ψ := ⟨Classical.choose ψ.2,
+    have hs := Classical.choose_spec ψ.2
+    ⟨hs.2.1, hs.2.2.1, hs.2.2.2⟩⟩
+  invFun ψ := ⟨HilbertSpace.mk (memHS_of_infiniteWellFunSubmodule ψ),
+    ⟨ψ, ⟨coe_mk_ae (memHS_of_infiniteWellFunSubmodule ψ), ψ.2.1, ψ.2.2.1, ψ.2.2.2⟩⟩⟩
+  left_inv ψ := by
+    simp
+    ext1
+    simp
+    apply ext_iff.mpr
+    apply (coe_mk_ae _).trans
+    simpa using (Classical.choose_spec ψ.2).1.symm
+  right_inv ψ := by
+    let ψ' : infiniteWellSubmodule a b := ⟨HilbertSpace.mk (memHS_of_infiniteWellFunSubmodule ψ),
+      ⟨ψ, ⟨coe_mk_ae (memHS_of_infiniteWellFunSubmodule ψ), ψ.2.1, ψ.2.2.1, ψ.2.2.2⟩⟩⟩
+    simp only [Function.support_subset_iff, ne_eq, Set.mem_Ioo]
+    ext1
+    simp only
+    rw [← Continuous.ae_eq_iff_eq (μ := MeasureTheory.volume)]
+    · trans (HilbertSpace.mk (memHS_of_infiniteWellFunSubmodule ψ) : ℝ → ℂ)
+      · simpa using (Classical.choose_spec ψ'.2).1.symm
+      · exact (coe_mk_ae _)
+    · change Continuous (Classical.choose ψ'.2)
+      exact (Classical.choose_spec ψ'.2).2.1
+    · exact ψ.2.1
+  map_add' ψ1 ψ2 := by
+    ext1
+    simp only [Submodule.coe_add, AddSubgroup.coe_add, Function.support_subset_iff, ne_eq,
+      Set.mem_Ioo, AddMemClass.mk_add_mk]
+    rw [← Continuous.ae_eq_iff_eq (μ := MeasureTheory.volume)]
+    · exact (Classical.choose_spec (ψ1 + ψ2).2).1.symm.trans <|
+        (MeasureTheory.AEEqFun.coeFn_add _ _).trans <|
+        (Classical.choose_spec ψ1.2).1.add (Classical.choose_spec ψ2.2).1
+    · exact (Classical.choose_spec (ψ1 + ψ2).2).2.1
+    · exact (Classical.choose_spec ψ1.2).2.1.add (Classical.choose_spec ψ2.2).2.1
+  map_smul' a ψ := by
+    ext1
+    rw [← Continuous.ae_eq_iff_eq (μ := MeasureTheory.volume)]
+    · exact (Classical.choose_spec (a • ψ).2).1.symm.trans <|
+        (MeasureTheory.AEEqFun.coeFn_smul _ _).trans <|
+        (Classical.choose_spec ψ.2).1.const_smul a
+    · exact (Classical.choose_spec (a • ψ).2).2.1
+    · exact (Classical.choose_spec ψ.2).2.1.const_smul a
+
+/-- The construction of an element of the submodule `infiniteWellSubmodule a b` of
+  the hilbert space from a function `ℝ → ℂ` which is smooth and is zero at `a` and `b`. -/
+def infiniteWellSubmoduleOfSmooth {a b : ℝ} (h : a < b)
+    (f : ℝ → ℂ) (hf : ContDiff ℝ ⊤ f) (hf0 : f a = 0) (hf1 : f b = 0) :
+    infiniteWellSubmodule a b := infiniteWellSubmoduleEquiv.symm
+  ⟨(fun x => if x ∈ Set.Ioo a b then f x else (0 : ℂ)), by
+    refine ⟨?_, ?_, ?_⟩
+    · refine continuous_if ?_ ?_ ?_
+      · intro c hc
+        have h1 : frontier (Set.Ioo a b) = {a, b} := by
+          rw [frontier_Ioo]
+          exact h
+        erw [h1] at hc
+        simp at hc
+        rcases hc with rfl | rfl
+        · exact hf0
+        · exact hf1
+      · have h1 := hf.continuous
+        fun_prop
+      · fun_prop
+    · simp
+      intro x h1 h2 h
+      simp_all
+    · intro x hx
+      apply ContDiffAt.congr_of_eventuallyEq (f := f)
+      · exact ContDiff.contDiffAt hf
+      · rw [Filter.eventuallyEq_iff_exists_mem]
+        use Set.Ioo a b
+        constructor
+        · simp at hx
+          exact Ioo_mem_nhds hx.1 hx.2
+        · intro x hx
+          simp at hx
+          simp_all⟩
+
+TODO "GZYDF" "Define the momentum operator on the infinite well submodule of the Hilbert space
+  in one-dimension."
+
+end
+end OneDimension
+end QuantumMechanics

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/SchwartzSubmodule.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/SchwartzSubmodule.lean
@@ -85,6 +85,29 @@ def inclDualSchwartzSubmodule: HilbertSpace →ₛₗ[starRingEnd ℂ] Module.Du
 lemma inclDualSchwartzSubmodule_injective : Function.Injective inclDualSchwartzSubmodule := by
   sorry
 
+open InnerProductSpace
+
+lemma schwartzSubmodule_coe_ae_schwartzSubmoduleEquiv (ψ : schwartzSubmodule) :
+    ψ.1 =ᶠ[ae volume] (schwartzSubmoduleEquiv ψ) := by
+  simp only [schwartzSubmoduleEquiv, Submodule.top_coe, Set.mem_univ, SchwartzMap.toLpCLM_apply,
+    true_and, LinearEquiv.coe_mk, AddHom.coe_mk]
+  rw [← (Classical.choose_spec ψ.2).2]
+  simpa using SchwartzMap.coeFn_toLp _ 2 volume
+
+lemma inner_schwartzSubmodule (ψ1 ψ2 : schwartzSubmodule) :
+    ⟪ψ1, ψ2⟫_ℂ = ∫ x : ℝ, starRingEnd ℂ ((schwartzSubmoduleEquiv ψ1) x) *
+      (schwartzSubmoduleEquiv ψ2) x := by
+  simp only [Submodule.coe_inner]
+  apply MeasureTheory.integral_congr_ae
+  have h1 : ψ1.1 =ᶠ[ae volume] (schwartzSubmoduleEquiv ψ1) :=
+    schwartzSubmodule_coe_ae_schwartzSubmoduleEquiv ψ1
+  have h2 : ψ2.1 =ᶠ[ae volume] (schwartzSubmoduleEquiv ψ2) :=
+    schwartzSubmodule_coe_ae_schwartzSubmoduleEquiv ψ2
+  filter_upwards [h1, h2] with _ h1 h2
+  rw [h1, h2]
+  simp
+  ring
+
 end HilbertSpace
 end
 end OneDimension

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/SchwartzSubmodule.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/SchwartzSubmodule.lean
@@ -105,7 +105,7 @@ lemma inner_schwartzSubmodule (ψ1 ψ2 : schwartzSubmodule) :
     schwartzSubmodule_coe_ae_schwartzSubmoduleEquiv ψ2
   filter_upwards [h1, h2] with _ h1 h2
   rw [h1, h2]
-  simp
+  simp only [RCLike.inner_apply]
   ring
 
 end HilbertSpace

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Commutation.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.QuantumMechanics.OneDimension.Operators.Position
+import PhysLean.QuantumMechanics.OneDimension.Operators.Momentum
+/-!
+
+# Commutation relations
+
+The commutation relations between different operators.
+
+-/
+
+namespace QuantumMechanics
+
+namespace OneDimension
+noncomputable section
+open Constants
+open HilbertSpace
+
+/-!
+
+## Commutation relation betwen position and momentum operators
+
+-/
+
+lemma positionOperatorSchwartz_commutation_momentumOperatorSchwartz
+    (ψ : schwartzSubmodule) : positionOperatorSchwartz (momentumOperatorSchwartz ψ)
+    - momentumOperatorSchwartz (positionOperatorSchwartz ψ)
+    = (Complex.I * ℏ) • ψ := by
+  apply schwartzSubmoduleEquiv.injective
+  simp
+  ext x
+  simp [schwartzSubmoduleEquiv_momentumOperatorSchwartz_apply,
+    schwartzSubmoduleEquiv_positionOperatorSchwartz]
+  rw [deriv_fun_mul]
+  have h1 : deriv Complex.ofReal x = 1 := by
+    change deriv Complex.ofRealCLM x = _
+    simp
+  rw [h1]
+  ring
+  · change DifferentiableAt ℝ Complex.ofRealCLM x
+    fun_prop
+  · exact SchwartzMap.differentiableAt (schwartzSubmoduleEquiv ψ)
+
+lemma positionOperatorSchwartz_momentumOperatorSchwartz_eq (ψ : schwartzSubmodule) :
+    positionOperatorSchwartz (momentumOperatorSchwartz ψ)
+    = momentumOperatorSchwartz (positionOperatorSchwartz ψ)
+    + (Complex.I * ℏ) • ψ := by
+  rw [← positionOperatorSchwartz_commutation_momentumOperatorSchwartz]
+  simp
+
+lemma momentumOperatorSchwartz_positionOperatorSchwartz_eq (ψ : schwartzSubmodule) :
+    momentumOperatorSchwartz (positionOperatorSchwartz ψ)
+    = positionOperatorSchwartz (momentumOperatorSchwartz ψ)
+    - (Complex.I * ℏ) • ψ := by
+  rw [← positionOperatorSchwartz_commutation_momentumOperatorSchwartz]
+  simp
+
+end
+end OneDimension
+end QuantumMechanics

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Commutation.lean
@@ -31,7 +31,7 @@ lemma positionOperatorSchwartz_commutation_momentumOperatorSchwartz
     - momentumOperatorSchwartz (positionOperatorSchwartz ψ)
     = (Complex.I * ℏ) • ψ := by
   apply schwartzSubmoduleEquiv.injective
-  simp
+  simp only [map_sub, map_smul]
   ext x
   simp [schwartzSubmoduleEquiv_momentumOperatorSchwartz_apply,
     schwartzSubmoduleEquiv_positionOperatorSchwartz]

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Parity.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Parity.lean
@@ -99,6 +99,25 @@ lemma parityOperatorSchwartz_parityOperatorSchwartz (ψ : schwartzSubmodule) :
   ext x
   simp [parityOperatorSchwartz]
 
+/-!
+
+## Parity operator is hermitian
+
+-/
+
+open InnerProductSpace
+
+lemma parityOperatorSchwartz_hermitian (ψ1 ψ2 : schwartzSubmodule) :
+    ⟪parityOperatorSchwartz ψ1, ψ2⟫_ℂ = ⟪ψ1, parityOperatorSchwartz ψ2⟫_ℂ := by
+  rw [inner_schwartzSubmodule, inner_schwartzSubmodule]
+  simp [parityOperatorSchwartz]
+  let f (x : ℝ) :=
+    (starRingEnd ℂ) ((schwartzSubmoduleEquiv ψ1) (-x)) * (schwartzSubmoduleEquiv ψ2) x
+  change ∫ (x : ℝ), f x = _
+  trans ∫ (x : ℝ), f (- x)
+  · exact Eq.symm (integral_neg_eq_self f volume)
+  · simp [f]
+
 open InnerProductSpace
 
 end HilbertSpace

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Position.lean
@@ -157,6 +157,18 @@ def positionOperatorSchwartz : schwartzSubmodule →ₗ[ℂ] schwartzSubmodule w
       rw [smul_comm]
     rfl
 
+lemma schwartzSubmoduleEquiv_positionOperatorSchwartz (ψ : schwartzSubmodule) :
+    schwartzSubmoduleEquiv (positionOperatorSchwartz ψ) =
+    fun x => x * (schwartzSubmoduleEquiv ψ) x := by
+  simp [positionOperatorSchwartz]
+  rfl
+
+lemma schwartzSubmoduleEquiv_positionOperatorSchwartz_apply (ψ : schwartzSubmodule) (x : ℝ) :
+    schwartzSubmoduleEquiv (positionOperatorSchwartz ψ) x =
+    x * (schwartzSubmoduleEquiv ψ) x := by
+  simp [positionOperatorSchwartz]
+  rfl
+
 /-- The unbounded position operator, whose domain is Schwartz maps. -/
 def positionOperatorUnbounded : HilbertSpace →ₗ.[ℂ] HilbertSpace where
   domain := schwartzSubmodule
@@ -188,6 +200,21 @@ lemma positionStates_generalized_eigenvector_positionOperatorSchwartz
   change (schwartzSubmoduleEquiv (schwartzSubmoduleEquiv.symm _)) x = _
   simp only [LinearEquiv.apply_symm_apply]
   rfl
+
+/-!
+
+## Position operator hermitian
+
+-/
+open InnerProductSpace
+
+lemma positionOperatorSchwartz_hermitian (ψ1 ψ2 : schwartzSubmodule) :
+    ⟪positionOperatorSchwartz ψ1, ψ2⟫_ℂ = ⟪ψ1, positionOperatorSchwartz ψ2⟫_ℂ := by
+  rw [inner_schwartzSubmodule, inner_schwartzSubmodule]
+  congr
+  funext x
+  simp only [schwartzSubmoduleEquiv_positionOperatorSchwartz_apply, map_mul, Complex.conj_ofReal]
+  ring
 
 end
 end OneDimension


### PR DESCRIPTION
**Copilot summary:**

This pull request introduces several enhancements and new features to the `PhysLean` library, focusing on the Hilbert space submodules, operator properties, and commutation relations in quantum mechanics. The most significant changes include the addition of the infinite well submodule, new lemmas proving hermitian properties of various operators, and commutation relations between position and momentum operators.

### Hilbert Space Submodules:

* **Infinite Well Submodule:** Added definitions for `infiniteWellSubmodule` and `infiniteWellFunSubmodule`, along with their equivalence (`infiniteWellSubmoduleEquiv`). These submodules represent wavefunctions that are continuous, supported within an interval, and smooth in the interior.
* **Construction of Infinite Well Submodule:** Introduced `infiniteWellSubmoduleOfSmooth`, which constructs elements of `infiniteWellSubmodule` from smooth functions that vanish at the interval boundaries.

### Operator Properties:

* **Hermitian Operators:** Proved hermitian properties for the momentum (`momentumOperatorSchwartz_hermitian`), parity (`parityOperatorSchwartz_hermitian`), and position (`positionOperatorSchwartz_hermitian`) operators on the Schwartz submodule. [[1]](diffhunk://#diff-add30a24bc44c06f3364ba0b31e0d5fd78b6864987e5fe97c1b799263a9eeb4aR153-R205) [[2]](diffhunk://#diff-ce9d80b7a7b5041d783cb0d61a2ac8dc8da0431b71a7dcf394f887b33b3b899cR102-R120) [[3]](diffhunk://#diff-2b5127e7fb36e2f6626e0638a3b6a9d7c6ccfc12698ae88df320ca0578dbe159R204-R218)

### Commutation Relations:

* **Position and Momentum Operators:** Added lemmas for the commutation relations between position and momentum operators, including `positionOperatorSchwartz_commutation_momentumOperatorSchwartz`, `positionOperatorSchwartz_momentumOperatorSchwartz_eq`, and `momentumOperatorSchwartz_positionOperatorSchwartz_eq`.

### Schwartz Submodule Enhancements:

* **Schwartz Submodule Equivalence:** Added lemma `schwartzSubmodule_coe_ae_schwartzSubmoduleEquiv` to establish equivalence between Schwartz submodule elements and their representations.
* **Inner Product Integration:** Introduced `inner_schwartzSubmodule` to express the inner product of Schwartz submodule elements as an integral.

### Miscellaneous Improvements:

* **Momentum Operator:** Added `schwartzSubmoduleEquiv_momentumOperatorSchwartz_apply` to simplify the application of the momentum operator on Schwartz submodule elements.
* **Position Operator:** Added `schwartzSubmoduleEquiv_positionOperatorSchwartz_apply` for the position operator's application on Schwartz submodule elements.
* **Additional Imports:** Included `Mathlib.Analysis.Calculus.FDeriv.Star` for derivative-related operations.

These changes significantly expand the functionality of the `PhysLean` library, providing robust tools for quantum mechanics computations and proofs.