### PR TITLE
feat: Units of charge

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -11,6 +11,7 @@ import PhysLean.CondensedMatter.TightBindingChain.Basic
 import PhysLean.Cosmology.Basic
 import PhysLean.Cosmology.FLRW.Basic
 import PhysLean.Electromagnetism.Basic
+import PhysLean.Electromagnetism.Charge.ChargeUnit
 import PhysLean.Electromagnetism.Electrostatics.Basic
 import PhysLean.Electromagnetism.Electrostatics.OneDimension.PointParticle
 import PhysLean.Electromagnetism.Electrostatics.OneDimension.Vacuum

--- a/PhysLean/Electromagnetism/Charge/ChargeUnit.lean
+++ b/PhysLean/Electromagnetism/Charge/ChargeUnit.lean
@@ -3,8 +3,9 @@ Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
-import Mathlib.Geometry.Manifold.Diffeomorph
-import PhysLean.SpaceAndTime.Time.Basic
+import Mathlib.Algebra.EuclideanDomain.Basic
+import Mathlib.Algebra.EuclideanDomain.Field
+import Mathlib.Analysis.RCLike.Basic
 import PhysLean.Meta.TODO.Basic
 /-!
 

--- a/PhysLean/Electromagnetism/Charge/ChargeUnit.lean
+++ b/PhysLean/Electromagnetism/Charge/ChargeUnit.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import Mathlib.Geometry.Manifold.Diffeomorph
+import PhysLean.SpaceAndTime.Time.Basic
+import PhysLean.Meta.TODO.Basic
+/-!
+
+# The units of charge
+
+A unit of charge correspondings to a choice of translationally-invariant
+metric on the charge manifold (to be defined diffeomorphic to `ℝ`).
+Such a choice is (non-canonically) equivalent to a
+choice of positive real number. We define the type `ChargeUnit` to be equivalent to the
+positive reals.
+
+We assume that the charge manifold is already defined with an orientation, with the
+electron being in the negative direction.
+
+
+On `ChargeUnit` there is an instance of division giving a real number, corresponding to the
+ratio of the two scales of temperature unit.
+
+To define specific charge units, we first axiomise the existence of a
+a given charge unit, and then construct all other charge units from it.
+We choose to axiomise the
+existence of the charge unit of the coulomb, and construct all other charge units from that.
+
+-/
+
+
+/-- The choices of translationally-invariant metrics on the charge-manifold.
+  Such a choice corresponds to a choice of units for charge.
+  This assumes that an orientation has already being picked on the charge manifold. -/
+structure ChargeUnit where
+  /-- The underlying scale of the unit. -/
+  val : ℝ
+  property : 0 < val
+
+namespace ChargeUnit
+
+@[simp]
+lemma val_neq_zero (x : ChargeUnit) : x.val ≠ 0 := by
+  exact Ne.symm (ne_of_lt x.property)
+
+lemma val_pos (x : ChargeUnit) : 0 < x.val := x.property
+
+instance : Inhabited ChargeUnit where
+  default := ⟨1, by norm_num⟩
+
+/-!
+
+## Division of ChargeUnit
+
+-/
+
+noncomputable instance : HDiv ChargeUnit ChargeUnit ℝ where
+  hDiv x t := x.val / t.val
+
+lemma div_eq_val (x y : ChargeUnit) :
+    x / y = x.val / y.val := rfl
+
+@[simp]
+lemma div_pos (x y : ChargeUnit) :
+    (0 : ℝ) < x / y := by
+  simpa [div_eq_val] using _root_.div_pos x.val_pos y.val_pos
+
+@[simp]
+lemma div_self (x : ChargeUnit) :
+    x / x = (1 : ℝ) := by
+  simp [div_eq_val, x.val_neq_zero]
+
+lemma div_symm (x y : ChargeUnit) :
+    x / y = (y / x)⁻¹ := by
+  rw [div_eq_val, inv_eq_one_div, div_eq_val]
+  simp
+
+/-!
+
+## The scaling of a charge unit
+
+-/
+
+/-- The scaling of a charge unit by a positive real. -/
+def scale (r : ℝ) (x : ChargeUnit) (hr : 0 < r := by norm_num) : ChargeUnit :=
+  ⟨r * x.val, mul_pos hr x.val_pos⟩
+
+@[simp]
+lemma scale_div_self (x : ChargeUnit) (r : ℝ) (hr : 0 < r) :
+    scale r x hr / x = r := by
+  simp [scale, div_eq_val]
+
+@[simp]
+lemma scale_one (x : ChargeUnit) : scale 1 x = x := by
+  simp [scale, mul_one]
+
+@[simp]
+lemma scale_div_scale (x1 x2 : ChargeUnit) {r1 r2 : ℝ} (hr1 : 0 < r1) (hr2 : 0 < r2) :
+    scale r1 x1 hr1 / scale r2 x2 hr2 = r1 / r2 * (x1 / x2) := by
+  simp [scale, div_eq_val]
+  field_simp
+
+@[simp]
+lemma scale_scale (x : ChargeUnit) (r1 r2 : ℝ) (hr1 : 0 < r1) (hr2 : 0 < r2) :
+    scale r1 (scale r2 x hr2) hr1 = scale (r1 * r2) x (mul_pos hr1 hr2) := by
+  simp [scale]
+  ring
+
+/-!
+
+## Specific choices of charge units
+
+To define a specific charge units, we must first axiomise the existence of a
+a given charge unit, and then construct all other charge units from it.
+We choose to axiomise the existence of the charge unit of coulomb.
+
+We need an axiom since this relates something to something in the physical world.
+
+-/
+
+/-- The axiom corresponding to the definition of a charge unit of coulomb. -/
+axiom coulombs : ChargeUnit
+
+/-- The charge unit of a elementryCharge (1.602176634×10−19 coulomb). -/
+noncomputable def elementaryCharge : ChargeUnit := scale (1.602176634e-19) coulombs
+
+end ChargeUnit

--- a/PhysLean/Units/Basic.lean
+++ b/PhysLean/Units/Basic.lean
@@ -30,7 +30,12 @@ From these fundamental choices one can construct all other units and dimensions.
 
 Units within PhysLean are implemented with the following convention:
 - The fundamental units, and the choices they correspond to, are defined within the
-  appropriate physics directory. (Not all of these are implemented yet.)
+  appropriate physics directory, in particular:
+  - `PhysLean/SpaceAndTime/Time/TimeUnit.lean`
+  - `PhysLean/SpaceAndTime/Space/LengthUnit.lean`
+  - `PhysLean/ClassicalMechanics/Mass/MassUnit.lean`
+  - `PhysLean/Electromagnetism/Charge/ChargeUnit.lean`
+  - `PhysLean/Thermodynamics/Temperature/TemperatureUnit.lean`
 - In this `Units` directory, we define the necessary structures and properties
   to work derived units and dimensions.
 


### PR DESCRIPTION
**Copilot summary**

This pull request introduces the concept of charge units (`ChargeUnit`) into the `PhysLean` library, along with supporting documentation and code updates. The most important changes include the addition of the `ChargeUnit` structure, associated operations, and axioms, as well as updates to documentation and imports to integrate this new feature.

### Addition of `ChargeUnit`:

* **New file `PhysLean/Electromagnetism/Charge/ChargeUnit.lean`:** Introduced the `ChargeUnit` structure, which represents a choice of translationally-invariant metrics on the charge manifold. Includes operations such as division, scaling, and specific charge units (e.g., coulombs and elementary charge).

### Integration into the codebase:

* **Updated import in `PhysLean.lean`:** Added `PhysLean.Electromagnetism.Charge.ChargeUnit` to the list of imports to make the `ChargeUnit` functionality accessible.
* **Documentation update in `PhysLean/Units/Basic.lean`:** Updated the description of fundamental units to include `ChargeUnit` and its corresponding file path.