### PR TITLE
feat: Update linter warnings

### DIFF
--- a/scripts/lint_all.lean
+++ b/scripts/lint_all.lean
@@ -4,9 +4,10 @@ Released under Apache 2.0 license.
 Authors: Joseph Tooby-Smith
 -/
 
-def main (_: List String) : IO UInt32 := do
+def main (args : List String) : IO UInt32 := do
 
   println! "\x1b[36m- Style lint \x1b[0m"
+  println! "\x1b[2mThis linter is not checked by GitHub but if you have time please fix these errors.\x1b[0m"
   let styleLint ← IO.Process.output {cmd := "lake", args := #["exe", "style_lint"]}
   println! styleLint.stdout
 
@@ -27,12 +28,18 @@ def main (_: List String) : IO UInt32 := do
   let todoCheck ← IO.Process.output {cmd := "lake", args := #["exe", "check_dup_tags"]}
   println! todoCheck.stdout
 
-  println! "\x1b[36m- Transitive imports \x1b[0m"
-  let todoCheck ← IO.Process.output {cmd := "lake", args := #["exe", "redundent_imports"]}
-  println! todoCheck.stdout
+  if ¬ "--fast" ∈ args then
+    println! "\x1b[36m- Transitive imports \x1b[0m"
+    println! "\x1b[2mExpect this linter may take a while to run, it can be skipped with
+        lake exe lint_all --fast\x1b[0m"
+    let redundentImports ← IO.Process.output {cmd := "lake", args := #["exe", "redundent_imports"]}
+    println! redundentImports.stdout
 
-  println! "\x1b[36m-Lean linter \x1b[0m"
-  let leanCheck ← IO.Process.output {cmd := "lake", args := #["exe", "runLinter", "PhysLean"]}
-  println! leanCheck.stdout
+    println! "\x1b[36m- Lean linter \x1b[0m"
+    println! "\x1b[2mExpect this linter may take a while to run, it can be skipped with
+      lake exe lint_all --fast"
+    println! "You can manually perform this linter by placing `#lint` at the end of the files you have modified.\x1b[0m"
+    let leanCheck ← IO.Process.output {cmd := "lake", args := #["exe", "runLinter", "PhysLean"]}
+    println! leanCheck.stdout
 
   pure 0


### PR DESCRIPTION
**Copilot summary**

This pull request updates the `scripts/lint_all.lean` script to improve its usability and provide more informative output for developers. The key changes include adding a new argument to the `main` function, introducing a conditional `--fast` flag to skip time-consuming linters, and enhancing the output messages to guide developers.

### Improved usability and output:

* Updated the `main` function to accept `args` instead of an unused parameter, enabling the script to process command-line arguments.
* Added a conditional check for the `--fast` flag to skip running the `redundent_imports` and `Lean linter` steps, which are time-intensive.
* Enhanced output messages to include explanations for the `--fast` flag and instructions for manually running the Lean linter with `#lint`.
* Added a message encouraging developers to fix style lint errors, even though it is not enforced by GitHub.