### PR TITLE
Refactor CarriesDimension

### DIFF
--- a/PhysLean/Units/Basic.lean
+++ b/PhysLean/Units/Basic.lean
@@ -270,27 +270,23 @@ The latter is need to prevent a typeclass diamond.
 
 -/
 
-/-- A type `M` carries a dimension `d` if every element of `M` is supposed to have
-  this dimension. For example, the type `Time` will carry a dimension `T𝓭`. -/
-class CarriesDimension (M : Type) extends MulAction ℝ≥0 M where
+class HasDim (M : Type) where
   /-- The dimension carried by a type `M`. -/
   d : Dimension
+
+alias dim := HasDim.d
+
+/-- A type `M` carries a dimension `d` if every element of `M` is supposed to have
+  this dimension. For example, the type `Time` will carry a dimension `T𝓭`. -/
+class CarriesDimension (M : Type) extends HasDim M, MulAction ℝ≥0 M
 
 /-- A module `M` carries a dimension `d` if every element of `M` is supposed to have
   this dimension.
   This is defined in addition to `CarriesDimension` to prevent a type-casting diamond. -/
-class ModuleCarriesDimension (M : Type) [AddCommMonoid M] [Module ℝ M] where
-  /-- The dimension carried by a module `M`. -/
-  d : Dimension
+class ModuleCarriesDimension (M : Type) [AddCommMonoid M] [Module ℝ M] extends HasDim M
 
 instance {M : Type} [AddCommMonoid M] [Module ℝ M] [ModuleCarriesDimension M] :
     CarriesDimension M where
-  d := ModuleCarriesDimension.d M
-
-@[simp]
-lemma ModuleCarriesDimension.d_eq_CarriesDimension_d {M : Type} [AddCommMonoid M] [Module ℝ M]
-    [ModuleCarriesDimension M] :
-    ModuleCarriesDimension.d M = CarriesDimension.d M := rfl
 
 /-!
 
@@ -310,11 +306,11 @@ and a type
 /-- A quantity of type `M` which depends on a choice of units `UnitChoices` is said to be
   of dimension `d` if it scales by `UnitChoices.dimScale u1 u2 d` under a change in units. -/
 def HasDimension {M : Type} [CarriesDimension M] (f : UnitChoices → M) : Prop :=
-  ∀ u1 u2 : UnitChoices, f u2 = UnitChoices.dimScale u1 u2 (CarriesDimension.d M) • f u1
+  ∀ u1 u2 : UnitChoices, f u2 = UnitChoices.dimScale u1 u2 (dim M) • f u1
 
 lemma hasDimension_iff {M : Type} [CarriesDimension M] (f : UnitChoices → M) :
     HasDimension f ↔ ∀ u1 u2 : UnitChoices, f u2 =
-    UnitChoices.dimScale u1 u2 (CarriesDimension.d M) • f u1 := by
+    UnitChoices.dimScale u1 u2 (dim M) • f u1 := by
   rfl
 
 /-- The subtype of functions `UnitChoices → M`, for which `M` carries a dimension,
@@ -356,7 +352,7 @@ noncomputable def CarriesDimension.toDimensionful {M : Type} [CarriesDimension M
     (u : UnitChoices) :
     M ≃ Dimensionful M where
   toFun m := {
-    val := fun u1 => (u.dimScale u1 (CarriesDimension.d M)) • m
+    val := fun u1 => (u.dimScale u1 (dim M)) • m
     property := fun u1 u2 => by
       simp [smul_smul]
       rw [mul_comm, UnitChoices.dimScale_transitive]}
@@ -370,4 +366,4 @@ noncomputable def CarriesDimension.toDimensionful {M : Type} [CarriesDimension M
 
 lemma CarriesDimension.toDimensionful_apply_apply
     {M : Type} [CarriesDimension M] (u1 u2 : UnitChoices) (m : M) :
-    (toDimensionful u1 m).1 u2 = (u1.dimScale u2 (CarriesDimension.d M)) • m := by rfl
+    (toDimensionful u1 m).1 u2 = (u1.dimScale u2 (dim M)) • m := by rfl

--- a/PhysLean/Units/Basic.lean
+++ b/PhysLean/Units/Basic.lean
@@ -263,15 +263,15 @@ end UnitChoices
 
 Dimensions are assigned to types with the following type-classes
 
-- `CarriesDimension` for a type carrying an instance of `MulAction ℝ≥0 M`
-- `ModuleCarriesDimension` for a type carrying an instance of `Module ℝ M`.
-
-The latter is need to prevent a typeclass diamond.
+- `HasDim` for any type `M` with an associated dimension
+- `CarriesDimension` for a type that also has an instance of `MulAction ℝ≥0 M`
 
 -/
 
+/-- This typeclass indicates that there is a dimension `dim M : Dimension`
+  associated with the type `M`. -/
 class HasDim (M : Type) where
-  /-- The dimension carried by a type `M`. -/
+  /-- The dimension associated with a type `M`. -/
   d : Dimension
 
 alias dim := HasDim.d

--- a/PhysLean/Units/Basic.lean
+++ b/PhysLean/Units/Basic.lean
@@ -278,15 +278,12 @@ alias dim := HasDim.d
 
 /-- A type `M` carries a dimension `d` if every element of `M` is supposed to have
   this dimension. For example, the type `Time` will carry a dimension `T𝓭`. -/
-class CarriesDimension (M : Type) extends HasDim M, MulAction ℝ≥0 M
+class abbrev CarriesDimension (M : Type) := HasDim M, MulAction ℝ≥0 M
 
 /-- A module `M` carries a dimension `d` if every element of `M` is supposed to have
   this dimension.
   This is defined in addition to `CarriesDimension` to prevent a type-casting diamond. -/
 class ModuleCarriesDimension (M : Type) [AddCommMonoid M] [Module ℝ M] extends HasDim M
-
-instance {M : Type} [AddCommMonoid M] [Module ℝ M] [ModuleCarriesDimension M] :
-    CarriesDimension M where
 
 /-!
 

--- a/PhysLean/Units/Basic.lean
+++ b/PhysLean/Units/Basic.lean
@@ -280,11 +280,6 @@ alias dim := HasDim.d
   this dimension. For example, the type `Time` will carry a dimension `T𝓭`. -/
 class abbrev CarriesDimension (M : Type) := HasDim M, MulAction ℝ≥0 M
 
-/-- A module `M` carries a dimension `d` if every element of `M` is supposed to have
-  this dimension.
-  This is defined in addition to `CarriesDimension` to prevent a type-casting diamond. -/
-class ModuleCarriesDimension (M : Type) [AddCommMonoid M] [Module ℝ M] extends HasDim M
-
 /-!
 
 ## Terms of the current dimension

--- a/PhysLean/Units/Examples.lean
+++ b/PhysLean/Units/Examples.lean
@@ -16,7 +16,7 @@ should not be used in the proofs of any other results other then those in this f
 -/
 
 namespace UnitExamples
-open Dimension CarriesDimension UnitChoices UnitDependent
+open Dimension CarriesDimension UnitChoices UnitDependent HasDim
 /-!
 
 ## Defining a length dependent on units

--- a/PhysLean/Units/FDeriv.lean
+++ b/PhysLean/Units/FDeriv.lean
@@ -24,10 +24,10 @@ in which the derivative is taken.
 open UnitDependent CarriesDimension NNReal
 
 variable {M1 M2 : Type} [NormedAddCommGroup M1] [NormedSpace ℝ M1]
-    [ContinuousConstSMul ℝ M1] [ModuleCarriesDimension M1]
+    [ContinuousConstSMul ℝ M1] [HasDim M1]
     [NormedAddCommGroup M2] [NormedSpace ℝ M2]
     [SMulCommClass ℝ ℝ M2] [ContinuousConstSMul ℝ M2]
-    [ModuleCarriesDimension M2]
+    [HasDim M2]
 
 lemma fderiv_apply_scaleUnit (u1 u2 : UnitChoices) (x dm : M1)
     (f : M1 → M2) (hf : IsDimensionallyCorrect f) (f_diff : Differentiable ℝ f) :
@@ -50,7 +50,7 @@ lemma fderiv_isDimensionallyCorrect (f : M1 → M2) (hf : IsDimensionallyCorrect
   ext m'
   simp only [ContinuousLinearUnitDependent.scaleUnit_apply_fun]
   rw [fderiv_apply_scaleUnit u1 u2 m (scaleUnit u2 u1 m') f hf f_diff]
-  simp only [ModuleCarriesDimension.scaleUnit_apply, map_smul]
+  simp only [HasDim.scaleUnit_apply', map_smul]
   simp only [← smul_def, smul_smul]
   trans (1 : ℝ≥0) • (fderiv ℝ f m) m'
   · congr

--- a/PhysLean/Units/FDeriv.lean
+++ b/PhysLean/Units/FDeriv.lean
@@ -32,10 +32,10 @@ variable {M1 M2 : Type} [NormedAddCommGroup M1] [NormedSpace ℝ M1]
 lemma fderiv_apply_scaleUnit (u1 u2 : UnitChoices) (x dm : M1)
     (f : M1 → M2) (hf : IsDimensionallyCorrect f) (f_diff : Differentiable ℝ f) :
     fderiv ℝ f (scaleUnit u2 u1 x) dm =
-    u2.dimScale u1 (d M2) • u1.dimScale u2 (d M1) • fderiv ℝ f x dm := by
+    u2.dimScale u1 (dim M2) • u1.dimScale u2 (dim M1) • fderiv ℝ f x dm := by
   conv_lhs => rw [← hf u2 u1]
-  change (fderiv ℝ ((u2.dimScale u1 (d M2)).1 • fun mx => f
-      ((u1.dimScale u2 (d M1)).1 • mx)) ((u2.dimScale u1 (d M1)).1 • x)) dm = _
+  change (fderiv ℝ ((u2.dimScale u1 (dim M2)).1 • fun mx => f
+      ((u1.dimScale u2 (dim M1)).1 • mx)) ((u2.dimScale u1 (dim M1)).1 • x)) dm = _
   rw [fderiv_const_smul (by fun_prop), fderiv_comp_smul]
   simp [smul_smul]
   rfl
@@ -54,8 +54,8 @@ lemma fderiv_isDimensionallyCorrect (f : M1 → M2) (hf : IsDimensionallyCorrect
   simp only [← smul_def, smul_smul]
   trans (1 : ℝ≥0) • (fderiv ℝ f m) m'
   · congr
-    trans (u1.dimScale u2 (d M2) * u2.dimScale u1 (d M2))
-      * (u2.dimScale u1 (d M1) * u1.dimScale u2 (d M1))
+    trans (u1.dimScale u2 (dim M2) * u2.dimScale u1 (dim M2))
+      * (u2.dimScale u1 (dim M1) * u1.dimScale u2 (dim M1))
     · simp
     simp
   simp
@@ -68,7 +68,7 @@ lemma fderiv_isDimensionallyCorrect (f : M1 → M2) (hf : IsDimensionallyCorrect
   quantities are considered dimensionful. -/
 lemma fderiv_dimension_const_direction (dm : M1) (f : M1 → M2) (hf : IsDimensionallyCorrect f)
     (f_diff : Differentiable ℝ f) :
-    IsDimensionallyCorrect (fun x (v : WithDim (d M2 * (d M1)⁻¹) M2) =>
+    IsDimensionallyCorrect (fun x (v : WithDim (dim M2 * (dim M1)⁻¹) M2) =>
       fderiv ℝ f x dm = v.1) := by
   simp [isDimensionallyCorrect_fun_iff, funext_iff, WithDim.scaleUnit_val,
     fderiv_apply_scaleUnit _ _ _ dm f hf f_diff,

--- a/PhysLean/Units/FDeriv.lean
+++ b/PhysLean/Units/FDeriv.lean
@@ -50,15 +50,7 @@ lemma fderiv_isDimensionallyCorrect (f : M1 → M2) (hf : IsDimensionallyCorrect
   ext m'
   simp only [ContinuousLinearUnitDependent.scaleUnit_apply_fun]
   rw [fderiv_apply_scaleUnit u1 u2 m (scaleUnit u2 u1 m') f hf f_diff]
-  simp only [HasDim.scaleUnit_apply', map_smul]
-  simp only [← smul_def, smul_smul]
-  trans (1 : ℝ≥0) • (fderiv ℝ f m) m'
-  · congr
-    trans (u1.dimScale u2 (dim M2) * u2.dimScale u1 (dim M2))
-      * (u2.dimScale u1 (dim M1) * u1.dimScale u2 (dim M1))
-    · simp
-    simp
-  simp
+  simp [HasDim.scaleUnit_apply, smul_smul]
 
 /-- The expression `fderiv ℝ f x dm = v.1` for a fixed `dm` and for
   `v` with dimension `d M2 * (d M1)⁻¹` is dimensionally correct. This is the

--- a/PhysLean/Units/Integral.lean
+++ b/PhysLean/Units/Integral.lean
@@ -15,12 +15,12 @@ In this module we prove that the dimensional properties of the integral.
 
 open UnitDependent NNReal
 variable (M : Type)
-    [NormedAddCommGroup M] [NormedSpace ℝ M] [ModuleCarriesDimension M]
+    [NormedAddCommGroup M] [NormedSpace ℝ M] [HasDim M]
     [MeasurableSpace M] [self : MeasurableConstSMul ℝ M]
 
 open MeasureTheory
 noncomputable instance (M : Type)
-    [NormedAddCommGroup M] [NormedSpace ℝ M] [ModuleCarriesDimension M]
+    [NormedAddCommGroup M] [NormedSpace ℝ M] [HasDim M]
     [MeasurableSpace M] [self : MeasurableConstSMul ℝ M] :
       MulUnitDependent (MeasureTheory.Measure M) where
   scaleUnit u1 u2 μ := μ.map (fun m => scaleUnit u1 u2 m)
@@ -29,7 +29,7 @@ noncomputable instance (M : Type)
     congr 1
     funext m
     simp [scaleUnit_trans]
-    simp [CarriesDimension.scaleUnit_apply']
+    simp [HasDim.scaleUnit_apply']
     · exact measurable_const_smul (α := M) ↑(u2.dimScale u3 (dim M)).1
     · exact measurable_const_smul (α := M) ↑(u1.dimScale u2 (dim M)).1
   scaleUnit_trans' u1 u2 u3 μ := by
@@ -37,7 +37,7 @@ noncomputable instance (M : Type)
     congr 1
     funext m
     simp [scaleUnit_trans']
-    simp [CarriesDimension.scaleUnit_apply']
+    simp [HasDim.scaleUnit_apply']
     · exact measurable_const_smul (α := M) ↑(u1.dimScale u2 (dim M)).1
     · exact measurable_const_smul (α := M) ↑(u2.dimScale u3 (dim M)).1
   scaleUnit_id u μ := by
@@ -45,10 +45,10 @@ noncomputable instance (M : Type)
   scaleUnit_mul u1 u2 r μ := by
     simp
 
-variable {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M] [ModuleCarriesDimension M]
+variable {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M] [HasDim M]
     [MeasurableSpace M] [MeasurableConstSMul ℝ M]
     {G : Type}
-    [NormedAddCommGroup G] [NormedSpace ℝ G] [ModuleCarriesDimension G]
+    [NormedAddCommGroup G] [NormedSpace ℝ G] [HasDim G]
 
 lemma scaleUnit_measure (u1 u2 : UnitChoices) (μ : MeasureTheory.Measure M) :
     scaleUnit u1 u2 μ = μ.map (fun m => scaleUnit u1 u2 m) := by rfl
@@ -96,7 +96,7 @@ lemma integral_isDimensionallyCorrect (d : Dimension) :
     /- What remains is a simple cancellation of the dimensional scales. -/
     _ = (u1.dimScale u2 (dim G)) • ((u2.dimScale u1 d) •
         u2.dimScale u1 (dim G * d⁻¹) • ∫ (x : M), f x ∂ μ) := by
-      rw [← CarriesDimension.scaleUnit_apply]
+      rw [← HasDim.scaleUnit_apply]
     _ = (u1.dimScale u2 (dim G) * (u2.dimScale u1 d) *
         u2.dimScale u1 (dim G * d⁻¹)) • ∫ (x : M), f x ∂ μ := by
       simp [smul_smul]

--- a/PhysLean/Units/Integral.lean
+++ b/PhysLean/Units/Integral.lean
@@ -29,7 +29,7 @@ noncomputable instance (M : Type)
     congr 1
     funext m
     simp [scaleUnit_trans]
-    simp [HasDim.scaleUnit_apply']
+    simp [HasDim.scaleUnit_apply]
     · exact measurable_const_smul (α := M) ↑(u2.dimScale u3 (dim M)).1
     · exact measurable_const_smul (α := M) ↑(u1.dimScale u2 (dim M)).1
   scaleUnit_trans' u1 u2 u3 μ := by
@@ -37,7 +37,7 @@ noncomputable instance (M : Type)
     congr 1
     funext m
     simp [scaleUnit_trans']
-    simp [HasDim.scaleUnit_apply']
+    simp [HasDim.scaleUnit_apply]
     · exact measurable_const_smul (α := M) ↑(u1.dimScale u2 (dim M)).1
     · exact measurable_const_smul (α := M) ↑(u2.dimScale u3 (dim M)).1
   scaleUnit_id u μ := by

--- a/PhysLean/Units/Integral.lean
+++ b/PhysLean/Units/Integral.lean
@@ -30,16 +30,16 @@ noncomputable instance (M : Type)
     funext m
     simp [scaleUnit_trans]
     simp [CarriesDimension.scaleUnit_apply']
-    · exact measurable_const_smul (α := M) ↑(u2.dimScale u3 (CarriesDimension.d M)).1
-    · exact measurable_const_smul (α := M) ↑(u1.dimScale u2 (CarriesDimension.d M)).1
+    · exact measurable_const_smul (α := M) ↑(u2.dimScale u3 (dim M)).1
+    · exact measurable_const_smul (α := M) ↑(u1.dimScale u2 (dim M)).1
   scaleUnit_trans' u1 u2 u3 μ := by
     rw [Measure.map_map]
     congr 1
     funext m
     simp [scaleUnit_trans']
     simp [CarriesDimension.scaleUnit_apply']
-    · exact measurable_const_smul (α := M) ↑(u1.dimScale u2 (CarriesDimension.d M)).1
-    · exact measurable_const_smul (α := M) ↑(u2.dimScale u3 (CarriesDimension.d M)).1
+    · exact measurable_const_smul (α := M) ↑(u1.dimScale u2 (dim M)).1
+    · exact measurable_const_smul (α := M) ↑(u2.dimScale u3 (dim M)).1
   scaleUnit_id u μ := by
     simp [scaleUnit_id]
   scaleUnit_mul u1 u2 r μ := by
@@ -67,7 +67,7 @@ fun (μ : DimSet (MeasureTheory.Measure M) d)
   is dimensionally correct. -/
 lemma integral_isDimensionallyCorrect (d : Dimension) :
     IsDimensionallyCorrect (fun (μ : DimSet (MeasureTheory.Measure M) d)
-      (f : DimSet (M → G) (CarriesDimension.d G * d⁻¹)) ↦ ∫ x, f.1 x ∂μ.1) := by
+      (f : DimSet (M → G) (dim G * d⁻¹)) ↦ ∫ x, f.1 x ∂μ.1) := by
   intro u1 u2
   funext ⟨μ, hμ⟩ ⟨f, hf⟩
   /- We have to prove that
@@ -88,20 +88,20 @@ lemma integral_isDimensionallyCorrect (d : Dimension) :
     /- Since we assumed `f` has dimension `CarriesDimension.d G * d⁻¹`, `(scaleUnit u2 f u1)`
       is equal to `u2.dimScale u1 (CarriesDimension.d G * d⁻¹) • f`. -/
     _ = scaleUnit u1 u2 (u2.dimScale u1 d •
-      u2.dimScale u1 (CarriesDimension.d G * d⁻¹) • ∫ (x : M), f x ∂ μ) := by
+      u2.dimScale u1 (dim G * d⁻¹) • ∫ (x : M), f x ∂ μ) := by
       rw [hf]
       congr
       erw [MeasureTheory.integral_smul]
       rfl
     /- What remains is a simple cancellation of the dimensional scales. -/
-    _ = (u1.dimScale u2 (CarriesDimension.d G)) • ((u2.dimScale u1 d) •
-        u2.dimScale u1 (CarriesDimension.d G * d⁻¹) • ∫ (x : M), f x ∂ μ) := by
+    _ = (u1.dimScale u2 (dim G)) • ((u2.dimScale u1 d) •
+        u2.dimScale u1 (dim G * d⁻¹) • ∫ (x : M), f x ∂ μ) := by
       rw [← CarriesDimension.scaleUnit_apply]
-    _ = (u1.dimScale u2 (CarriesDimension.d G) * (u2.dimScale u1 d) *
-        u2.dimScale u1 (CarriesDimension.d G * d⁻¹)) • ∫ (x : M), f x ∂ μ := by
+    _ = (u1.dimScale u2 (dim G) * (u2.dimScale u1 d) *
+        u2.dimScale u1 (dim G * d⁻¹)) • ∫ (x : M), f x ∂ μ := by
       simp [smul_smul]
       ring_nf
-    _ = ((u1.dimScale u2 (CarriesDimension.d G) * u2.dimScale u1 (CarriesDimension.d G))
+    _ = ((u1.dimScale u2 (dim G) * u2.dimScale u1 (dim G))
         * (u2.dimScale u1 d * u1.dimScale u2 d)) • ∫ (x : M), f x ∂ μ := by
       congr 1
       conv_lhs => simp only [map_mul]

--- a/PhysLean/Units/UnitDependent.lean
+++ b/PhysLean/Units/UnitDependent.lean
@@ -252,12 +252,6 @@ lemma HasDim.scaleUnit_apply {M : Type} [CarriesDimension M]
     scaleUnit u1 u2 m = (u1.dimScale u2 (dim M)) • m := by
   simp [scaleUnit, toDimensionful_apply_apply]
 
-lemma HasDim.scaleUnit_apply' {M : Type} [MulAction ℝ M] [HasDim M]
-    (u1 u2 : UnitChoices) (m : M) :
-    scaleUnit u1 u2 m = ((u1.dimScale u2 (dim M) : ℝ) • m : M) := by
-  simp [scaleUnit, toDimensionful_apply_apply]
-  rfl
-
 noncomputable instance {M : Type} [AddCommMonoid M] [Module ℝ M] [HasDim M] :
     LinearUnitDependent M where
   scaleUnit_add u1 u2 m1 m2 := by

--- a/PhysLean/Units/UnitDependent.lean
+++ b/PhysLean/Units/UnitDependent.lean
@@ -229,7 +229,7 @@ lemma UnitChoices.dimScale_scaleUnit {u1 u2 u : UnitChoices} (d : Dimension) :
 lemma Dimensionful.of_scaleUnit {M : Type} [CarriesDimension M] {u1 u2 u : UnitChoices}
     (c : Dimensionful M) :
     c.1 (scaleUnit u1 u2 u) =
-    u1.dimScale u2 (CarriesDimension.d M) • c.1 (u) := by
+    u1.dimScale u2 (dim M) • c.1 (u) := by
   rw [c.2 u (scaleUnit u1 u2 u)]
   congr 1
   simp
@@ -245,17 +245,17 @@ noncomputable instance {M1 : Type} [CarriesDimension M1] : MulUnitDependent M1 w
     simp [toDimensionful, UnitChoices.dimScale_self]
   scaleUnit_mul u1 u2 r m := by
     simp [toDimensionful]
-    exact smul_comm (u1.dimScale u2 (d M1)) r m
+    exact smul_comm (u1.dimScale u2 (dim M1)) r m
 
 lemma CarriesDimension.scaleUnit_apply {M : Type} [CarriesDimension M]
     (u1 u2 : UnitChoices) (m : M) :
-    scaleUnit u1 u2 m = (u1.dimScale u2 (d M)) • m := by
+    scaleUnit u1 u2 m = (u1.dimScale u2 (dim M)) • m := by
   simp [scaleUnit, toDimensionful_apply_apply]
 
 lemma CarriesDimension.scaleUnit_apply' {M : Type} [AddCommMonoid M] [Module ℝ M]
     [ModuleCarriesDimension M]
     (u1 u2 : UnitChoices) (m : M) :
-    scaleUnit u1 u2 m = ((u1.dimScale u2 (d M) : ℝ) • m : M) := by
+    scaleUnit u1 u2 m = ((u1.dimScale u2 (dim M) : ℝ) • m : M) := by
   simp [scaleUnit, toDimensionful_apply_apply]
   rfl
 
@@ -280,13 +280,13 @@ noncomputable instance {M : Type} [AddCommMonoid M] [Module ℝ M]
     conv =>
       enter [1, m]
       rw [toDimensionful_apply_apply]
-    change Continuous fun m => (u1.dimScale u2 (d M)).1 • m
+    change Continuous fun m => (u1.dimScale u2 (dim M)).1 • m
     apply Continuous.const_smul
     exact continuous_id'
 
 lemma ModuleCarriesDimension.scaleUnit_apply {M : Type} [AddCommMonoid M] [Module ℝ M]
     [ModuleCarriesDimension M] (u1 u2 : UnitChoices) (m : M) :
-    scaleUnit u1 u2 m = ((u1.dimScale u2 (d M) : ℝ) • m : M) := by
+    scaleUnit u1 u2 m = ((u1.dimScale u2 (dim M) : ℝ) • m : M) := by
   simp [scaleUnit, toDimensionful_apply_apply]
 
   rfl

--- a/PhysLean/Units/UnitDependent.lean
+++ b/PhysLean/Units/UnitDependent.lean
@@ -247,20 +247,19 @@ noncomputable instance {M1 : Type} [CarriesDimension M1] : MulUnitDependent M1 w
     simp [toDimensionful]
     exact smul_comm (u1.dimScale u2 (dim M1)) r m
 
-lemma CarriesDimension.scaleUnit_apply {M : Type} [CarriesDimension M]
+lemma HasDim.scaleUnit_apply {M : Type} [CarriesDimension M]
     (u1 u2 : UnitChoices) (m : M) :
     scaleUnit u1 u2 m = (u1.dimScale u2 (dim M)) • m := by
   simp [scaleUnit, toDimensionful_apply_apply]
 
-lemma CarriesDimension.scaleUnit_apply' {M : Type} [AddCommMonoid M] [Module ℝ M]
-    [ModuleCarriesDimension M]
+lemma HasDim.scaleUnit_apply' {M : Type} [MulAction ℝ M] [HasDim M]
     (u1 u2 : UnitChoices) (m : M) :
     scaleUnit u1 u2 m = ((u1.dimScale u2 (dim M) : ℝ) • m : M) := by
   simp [scaleUnit, toDimensionful_apply_apply]
   rfl
 
-noncomputable instance {M : Type} [AddCommMonoid M] [Module ℝ M]
-    [ModuleCarriesDimension M] : LinearUnitDependent M where
+noncomputable instance {M : Type} [AddCommMonoid M] [Module ℝ M] [HasDim M] :
+    LinearUnitDependent M where
   scaleUnit_add u1 u2 m1 m2 := by
     change (toDimensionful u1 (m1 + m2)).1 u2 = _
     rw [toDimensionful_apply_apply]
@@ -273,7 +272,7 @@ noncomputable instance {M : Type} [AddCommMonoid M] [Module ℝ M]
     rfl
 
 noncomputable instance {M : Type} [AddCommMonoid M] [Module ℝ M]
-    [ModuleCarriesDimension M] [TopologicalSpace M]
+    [HasDim M] [TopologicalSpace M]
     [ContinuousConstSMul ℝ M] : ContinuousLinearUnitDependent M where
   scaleUnit_cont u1 u2 := by
     change Continuous fun m => (toDimensionful u1 m).1 u2
@@ -283,13 +282,6 @@ noncomputable instance {M : Type} [AddCommMonoid M] [Module ℝ M]
     change Continuous fun m => (u1.dimScale u2 (dim M)).1 • m
     apply Continuous.const_smul
     exact continuous_id'
-
-lemma ModuleCarriesDimension.scaleUnit_apply {M : Type} [AddCommMonoid M] [Module ℝ M]
-    [ModuleCarriesDimension M] (u1 u2 : UnitChoices) (m : M) :
-    scaleUnit u1 u2 m = ((u1.dimScale u2 (dim M) : ℝ) • m : M) := by
-  simp [scaleUnit, toDimensionful_apply_apply]
-
-  rfl
 
 /-!
 
@@ -576,7 +568,7 @@ instance (M : Type) [MulAction ℝ≥0 M] [MulUnitDependent M] (d : Dimension) :
 lemma scaleUnit_dimSet_val {M : Type} [MulAction ℝ≥0 M] [MulUnitDependent M] (d : Dimension)
     (m : DimSet M d) (u1 u2 : UnitChoices) :
     (scaleUnit u1 u2 m).1 = scaleUnit u1 u2 m.1 := by
-  rw [scaleUnit_apply, m.2]
+  rw [HasDim.scaleUnit_apply, m.2]
   rfl
 
 lemma DimSet.mem_iff {M : Type} [MulAction ℝ≥0 M] [MulUnitDependent M] (d : Dimension) (m : M) :

--- a/PhysLean/Units/WithDim/Basic.lean
+++ b/PhysLean/Units/WithDim/Basic.lean
@@ -15,21 +15,24 @@ WithDim is the type `M` which carrying the dimension `d`.
 open NNReal
 
 /-- The type `M` carrying an instance of a dimension `d`. -/
-structure WithDim (d : Dimension) (M : Type) [MulAction ℝ≥0 M] where
+structure WithDim (d : Dimension) (M : Type) where
   /-- The underlying value of `M`. -/
   val : M
 
 namespace WithDim
 
 @[ext]
-lemma ext {d M} [MulAction ℝ≥0 M] (x1 x2 : WithDim d M) (h : x1.val = x2.val) : x1 = x2 := by
+lemma ext {d M} (x1 x2 : WithDim d M) (h : x1.val = x2.val) : x1 = x2 := by
   cases x1
   cases x2
   simp_all
 
-instance (d : Dimension) (M : Type) [inst : MulAction ℝ≥0 M] :
-    HasDim (WithDim d M) where
+instance (d : Dimension) (M : Type) : HasDim (WithDim d M) where
   d := d
+
+@[simp]
+lemma dim_apply (d : Dimension) (M : Type) :
+    dim (WithDim d M) = d := rfl
 
 instance (d : Dimension) (M : Type) [MulAction ℝ≥0 M] : MulAction ℝ≥0 (WithDim d M) where
   smul a m := ⟨a • m.val⟩
@@ -44,11 +47,6 @@ lemma smul_val {d : Dimension} {M : Type} [MulAction ℝ≥0 M] (a : ℝ≥0) (m
 
 instance (d : Dimension) (M : Type) [inst : MulAction ℝ≥0 M] :
     CarriesDimension (WithDim d M) where
-  d := d
-
-@[simp]
-lemma carriesDimension_d (d : Dimension) (M : Type) [MulAction ℝ≥0 M] :
-    (dim (WithDim d M)) = d := rfl
 
 instance {d1 d2 : Dimension} :
     HMul (WithDim d1 ℝ) (WithDim d2 ℝ) (WithDim (d1 * d2) ℝ) where
@@ -62,9 +60,9 @@ instance {d1 d2 : Dimension} :
   mul_dim m1 m2 := by
     intro u1 u2
     ext
-    simp only [withDim_hMul_val, carriesDimension_d, map_mul, smul_val]
+    simp only [withDim_hMul_val, dim_apply, map_mul, smul_val]
     rw [m1.2 u1, m2.2 u1]
-    simp only [carriesDimension_d, smul_val, Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
+    simp only [dim_apply, smul_val, Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
     rw [smul_smul]
     congr 1
     rw [mul_comm]
@@ -144,14 +142,12 @@ lemma scaleUnit_dim_eq_zero {d : Dimension} (m : WithDim d ℝ) (u1 u2 : UnitCho
 set_option linter.unusedVariables false in
 /-- The casting from `WithDim d M` to `WithDim d2 M` when `d = d2`. -/
 @[nolint unusedArguments]
-def cast {d d2 : Dimension} {M : Type} [MulAction ℝ≥0 M] (m : WithDim d M)
+def cast {d d2 : Dimension} {M : Type} (m : WithDim d M)
     (h : d = d2 := by ext <;> {simp; try ring}) : WithDim d2 M := ⟨m.val⟩
 
 @[simp]
-lemma cast_refl {d : Dimension} {M : Type} [MulAction ℝ≥0 M] (m : WithDim d M) :
-    cast m rfl = m := by
-  ext
-  rfl
+lemma cast_refl {d : Dimension} {M : Type} (m : WithDim d M) :
+    cast m rfl = m := rfl
 
 @[simp]
 lemma cast_scaleUnit {d d2 : Dimension} {M : Type} [MulAction ℝ≥0 M] (m : WithDim d M)

--- a/PhysLean/Units/WithDim/Basic.lean
+++ b/PhysLean/Units/WithDim/Basic.lean
@@ -27,6 +27,10 @@ lemma ext {d M} [MulAction ℝ≥0 M] (x1 x2 : WithDim d M) (h : x1.val = x2.val
   cases x2
   simp_all
 
+instance (d : Dimension) (M : Type) [inst : MulAction ℝ≥0 M] :
+    HasDim (WithDim d M) where
+  d := d
+
 instance (d : Dimension) (M : Type) [MulAction ℝ≥0 M] : MulAction ℝ≥0 (WithDim d M) where
   smul a m := ⟨a • m.val⟩
   one_smul m := ext _ _ (one_smul ℝ≥0 m.val)
@@ -44,7 +48,7 @@ instance (d : Dimension) (M : Type) [inst : MulAction ℝ≥0 M] :
 
 @[simp]
 lemma carriesDimension_d (d : Dimension) (M : Type) [MulAction ℝ≥0 M] :
-    CarriesDimension.d (WithDim d M) = d := rfl
+    (dim (WithDim d M)) = d := rfl
 
 instance {d1 d2 : Dimension} :
     HMul (WithDim d1 ℝ) (WithDim d2 ℝ) (WithDim (d1 * d2) ℝ) where

--- a/PhysLean/Units/WithDim/Basic.lean
+++ b/PhysLean/Units/WithDim/Basic.lean
@@ -45,9 +45,6 @@ instance (d : Dimension) (M : Type) [MulAction ℝ≥0 M] : MulAction ℝ≥0 (W
 lemma smul_val {d : Dimension} {M : Type} [MulAction ℝ≥0 M] (a : ℝ≥0) (m : WithDim d M) :
     (a • m).val = a • m.val := rfl
 
-instance (d : Dimension) (M : Type) [inst : MulAction ℝ≥0 M] :
-    CarriesDimension (WithDim d M) where
-
 instance {d1 d2 : Dimension} :
     HMul (WithDim d1 ℝ) (WithDim d2 ℝ) (WithDim (d1 * d2) ℝ) where
   hMul m1 m2 := ⟨m1.val * m2.val⟩


### PR DESCRIPTION
This refactors `CarriesDimension` by adding a generic `HasDim` class, together with a `dim M` notation. 

`CarriesDimension` becomes simply the combination of `HasDim` and `MulAction ℝ≥0 M`, and `ModuleCarriesDimension` can be entirely removed since the `Module` instance implies `MulAction`. Also, `WithDim` doesn't require `MulAction` any more, for consistency.