### PR TITLE
refactor: Fixing some optional linters

### DIFF
--- a/PhysLean/ClassicalMechanics/Pendulum/CoplanarDoublePendulum.lean
+++ b/PhysLean/ClassicalMechanics/Pendulum/CoplanarDoublePendulum.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Shlok Vaibhav Singh. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Shlok Vaibhav Singh
 -/
-/-   {LnL_1.5.1}
+/- {LnL_1.5.1}
 Source:
 Textbook: Landau and Lifshitz, Mechanics, 3rd Edition
 Chapter 1 The Equations of motion
@@ -29,15 +29,15 @@ y2 = - l1 cos(φ1) - l2 cos(φ2)
 
 b) The Lagrangian is obtained by writing down the kinetic and potential energies
 first in terms of cartesian coordinates and their time derivates and then substituting
-the coordinates and derivatives with transformations obtained in a):
+the coordinates and derivatives with transformations obtained in a) :
 
 L = T1 + T2 - V1 - V2 where
-T1 = 1/2 m1 (x1_dot^2 + y1_dot^2) = 1/2 m1 l1^2 φ1_dot^2  (Kinetic energy of m1)
+T1 = 1/2 m1 (x1_dot^2 + y1_dot^2) = 1/2 m1 l1^2 φ1_dot^2 (Kinetic energy of m1)
 Here and in next problems, _dot denotes time derivate
-V1 = m1 g y1 = - m1 g l1 cos(φ1)                          (Potential energy of m1)
+V1 = m1 g y1 = - m1 g l1 cos(φ1) (Potential energy of m1)
 T2 = 1/2 m2 (x2_dot^2 + y2_dot^2)
 = 1/2 m2 [l1^2 φ1_dot^2 + l2^2 φ2_dot^2 + 2 l1 l2 φ1_dot φ2_dot cos(φ1 - φ2)] (Kinetic energy of m2)
-V2 = m2 g y2 = - m2 g [l1 cos(φ1) + l2 cos(φ2)]                     (Potential energy of m2)
+V2 = m2 g y2 = - m2 g [l1 cos(φ1) + l2 cos(φ2)] (Potential energy of m2)
 
 so that the Lagrangian becomes:
 L = 1/2 (m1 + m2) l1^2 φ1_dot^2 + 1/2 m2 l2^2 φ2_dot^2 + m2 l1 l2 φ1_dot φ2_dot cos(φ1 - φ2)

--- a/PhysLean/ClassicalMechanics/Pendulum/MiscellaneousPendulumPivotMotions.lean
+++ b/PhysLean/ClassicalMechanics/Pendulum/MiscellaneousPendulumPivotMotions.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Shlok Vaibhav Singh. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Shlok Vaibhav Singh
 -/
-/-   {LnL_1.5.3}
+/- {LnL_1.5.3}
 Source:
 Textbook: Landau and Lifshitz, Mechanics, 3rd Edition
 Chapter 1 The Equations of motion
@@ -18,7 +18,7 @@ Description: The pendulum moves uniformally in a vertical circle of radius a and
 Solution:
 The coordinates of m can be expressed as:
 x = a cos(γ t) + l sin(φ)
-y = a sin(γ t) - l cos(φ)       (where generalized coordinate, φ, is the angle the string makes
+y = a sin(γ t) - l cos(φ) (where generalized coordinate, φ, is the angle the string makes
 with vertical, γ is angle with horizontal)
 
 L = T - V where
@@ -30,19 +30,18 @@ Like wise, m g a sin(γ t) in V can be ignored since its contribution to the act
 Let us note that the total derivate of a l cos(φ - γ t) is:
 d/dt [a l cos(φ - γ t)] = - a l sin(φ - γ t) φ_dot + a l γ sin(φ - γ t)
 Rearraging the terms, the lagrangian can be written as:
-L = 1/2 m l^2 φ_dot^2 + m a l γ^2 sin(φ - γ t)  + m g l cos(φ) - m γ d/dt [a l cos(φ - γ t)]
+L = 1/2 m l^2 φ_dot^2 + m a l γ^2 sin(φ - γ t) + m g l cos(φ) - m γ d/dt [a l cos(φ - γ t)]
 
 Since lagrangians differing by a total time derivate lead to the same equations of motion
 we can ignore the last term. So that the final lagrangian becomes:
-L = 1/2 m l^2 φ_dot^2 + m a l γ^2 sin(φ - γ t)  + m g l cos(φ)
-
+L = 1/2 m l^2 φ_dot^2 + m a l γ^2 sin(φ - γ t) + m g l cos(φ)
 
 Part b)
 Description: The point of support oscillates horizontally according to the law x = a cos(γ t).
 Solution:
 The coordinates of m can be expressed as:
 x = a cos(γ t) + l sin(φ)
-y = - l cos(φ)       (where generalized coordinate, φ, is the angle the string makes with vertical)
+y = - l cos(φ) (where generalized coordinate, φ, is the angle the string makes with vertical)
 
 so that x_dot = - a γ sin(γ t) + l φ_dot cos(φ) and y_dot = l φ_dot sin(φ)
 L = T - V where
@@ -63,17 +62,17 @@ Description: The point of support oscillates vertically according to the law y =
 Solution:
 The coordinates of m can be expressed as:
 x = l sin(φ)
-y = a cos(γ t) - l cos(φ)  (where generalized coordinate, φ, is angle string makes with vertical)
+y = a cos(γ t) - l cos(φ) (where generalized coordinate, φ, is angle string makes with vertical)
 L = T - V where
 T = 1/2 m (x_dot^2 + y_dot^2)
 = 1/2 m [l^2 φ_dot^2 + a^2 γ^2 sin^2(γ t) - 2 a l γ sin(γ t) φ_dot sin(φ)]
 V = m g y = m g [a cos(γ t) - l cos(φ)]
 We can ignore the constant term 1/2 m a^2 γ^2 sin^2(γ t) in T as it does not lead to variation.
-Likewise, m g a cos(γ t) in V can be ignored since its contribution to the action  is constant
+Likewise, m g a cos(γ t) in V can be ignored since its contribution to the action is constant
 The time derivative of cos(φ) sin(γ t) is:
 d/dt [cos(φ) sin(γ t)] = - φ_dot sin(φ) sin(γ t) + γ cos(φ) cos(γ t)
 substituting this in the lagrangian, we get:
-L = 1/2 m l^2 φ_dot^2 + m g l cos(φ) - m a l γ^2  cos(φ) cos(γ t) + m a l γ d/dt [cos(φ) cos(γ t)]
+L = 1/2 m l^2 φ_dot^2 + m g l cos(φ) - m a l γ^2 cos(φ) cos(γ t) + m a l γ d/dt [cos(φ) cos(γ t)]
 Ignoring the total time derivate term, the final lagrangian becomes:
-L = 1/2 m l^2 φ_dot^2 + m g l cos(φ) - m a l γ^2  cos(φ) cos(γ t)
+L = 1/2 m l^2 φ_dot^2 + m g l cos(φ) - m a l γ^2 cos(φ) cos(γ t)
 -/

--- a/PhysLean/ClassicalMechanics/Pendulum/SlidingPendulum.lean
+++ b/PhysLean/ClassicalMechanics/Pendulum/SlidingPendulum.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Shlok Vaibhav Singh. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Shlok Vaibhav Singh
 -/
-/-   {LnL_1.5.2}
+/- {LnL_1.5.2}
 Source:
 Textbook: Landau and Lifshitz, Mechanics, 3rd Edition
 Chapter 1 The Equations of motion
@@ -24,11 +24,11 @@ being the angle the string makes with vertical.
 
 The Lagrangian is obtained as:
 L = T1 + T2 - V1 - V2 where
-T1 = 1/2 m1 x1_dot^2  (Kinetic energy of m1)
+T1 = 1/2 m1 x1_dot^2 (Kinetic energy of m1)
 V1 = 0
 T2 = 1/2 m2 (x2_dot^2 + y2_dot^2) = 1/2 m2 [l^2 φ_dot^2 + x1_dot^2 + 2 l φ_dot x1_dot cos(φ)]
 (Kinetic energy of m2)
-V2 = m2 g y2 = - m2 g l cos(φ)                     (Potential energy of m2)
+V2 = m2 g y2 = - m2 g l cos(φ) (Potential energy of m2)
 So that
 L = 1/2 (m1 + m2) x1_dot^2 + 1/2 m2 (l^2 φ_dot^2 + 2 l φ_dot x1_dot cos(φ)) + m2 g l cos(φ)
 


### PR DESCRIPTION
In this PR I fix some of the linters which are not enforced by github, and are in that sense optional, but are enforced by `lake exe lint_all`. This PR will be quickly merged.