### PR TITLE
feat: Remove axioms related to units

### DIFF
--- a/PhysLean/ClassicalMechanics/Mass/MassUnit.lean
+++ b/PhysLean/ClassicalMechanics/Mass/MassUnit.lean
@@ -18,8 +18,8 @@ positive reals.
 On `MassUnit` there is an instance of division giving a real number, corresponding to the
 ratio of the two scales of mass unit.
 
-To define specific mass units, we first axiomise the existence of a
-a given mass unit, and then construct all other mass units from it. We choose to axiomise the
+To define specific mass units, we first state the existence of a
+a given mass unit, and then construct all other mass units from it. We choose to state the
 existence of the mass unit of kilograms, and construct all other mass units from that.
 
 -/
@@ -128,16 +128,16 @@ lemma scale_scale (x : MassUnit) (r1 r2 : ℝ) (hr1 : 0 < r1) (hr2 : 0 < r2) :
 
 ## Specific choices of mass units
 
-To define a specific mass units, we must first axiomise the existence of a
-a given mass unit, and then construct all other mass units from it.
-We choose to axiomise the existence of the mass unit of kilograms.
-
-We need an axiom since this relates something to something in the physical world.
+To define a specific mass units.
+We first define the notion of a kilogram to correspond to the mass unit with underlying value
+equal to `1`. This is really down to a choice in the isomorphism between the set of metrics
+on the mass manifold and the positive reals.
+From this choice of kilograms, we can define other length units by scaling kilograms.
 
 -/
 
-/-- The axiom corresponding to the definition of a mass unit of kilograms. -/
-axiom kilograms : MassUnit
+/-- The definition of a mass unit of kilograms. -/
+def kilograms : MassUnit := ⟨1, by norm_num⟩
 
 /-- The mass unit of a microgram (10^(-9) of a kilogram). -/
 noncomputable def micrograms : MassUnit := scale ((1/10) ^ 9) kilograms

--- a/PhysLean/Electromagnetism/Charge/ChargeUnit.lean
+++ b/PhysLean/Electromagnetism/Charge/ChargeUnit.lean
@@ -23,9 +23,9 @@ electron being in the negative direction.
 On `ChargeUnit` there is an instance of division giving a real number, corresponding to the
 ratio of the two scales of temperature unit.
 
-To define specific charge units, we first axiomise the existence of a
+To define specific charge units, we first state the existence of a
 a given charge unit, and then construct all other charge units from it.
-We choose to axiomise the
+We choose to state the
 existence of the charge unit of the coulomb, and construct all other charge units from that.
 
 -/
@@ -135,16 +135,15 @@ lemma scale_scale (x : ChargeUnit) (r1 r2 : ℝ) (hr1 : 0 < r1) (hr2 : 0 < r2) :
 
 ## Specific choices of charge units
 
-To define a specific charge units, we must first axiomise the existence of a
-a given charge unit, and then construct all other charge units from it.
-We choose to axiomise the existence of the charge unit of coulomb.
-
-We need an axiom since this relates something to something in the physical world.
+We define specific choices of charge units.
+We first define the notion of a columb to correspond to the charge unit with underlying value
+equal to `1`. This is really down to a choice in the isomorphism between the set of metrics
+on the charge manifold and the positive reals.
 
 -/
 
-/-- The axiom corresponding to the definition of a charge unit of coulomb. -/
-axiom coulombs : ChargeUnit
+/-- The definition of a charge unit of coulomb. -/
+def coulombs : ChargeUnit := ⟨1, by norm_num⟩
 
 /-- The charge unit of a elementryCharge (1.602176634×10−19 coulomb). -/
 noncomputable def elementaryCharge : ChargeUnit := scale (1.602176634e-19) coulombs

--- a/PhysLean/SpaceAndTime/Space/LengthUnit.lean
+++ b/PhysLean/SpaceAndTime/Space/LengthUnit.lean
@@ -17,8 +17,8 @@ positive reals.
 On `LengthUnit` there is an instance of division giving a real number, corresponding to the
 ratio of the two scales of length unit.
 
-To define specific length units, we first axiomise the existence of a
-a given length unit, and then construct all other length units from it. We choose to axiomise the
+To define specific length units, we first state the existence of a
+a given length unit, and then construct all other length units from it. We choose to state the
 existence of the length unit of meters, and construct all other length units from that.
 
 -/
@@ -126,16 +126,16 @@ lemma scale_scale (x : LengthUnit) (r1 r2 : ℝ) (hr1 : 0 < r1) (hr2 : 0 < r2) :
 
 ## Specific choices of Length units
 
-To define a specific length units, we must first axiomise the existence of a
-a given length unit, and then construct all other length units from it.
-We choose to axiomise the existence of the length unit of meters.
-
-We need an axiom since this relates something to something in the physical world.
+To define a specific length units.
+We first define the notion of a meter to correspond to the length unit with underlying value
+equal to `1`. This is really down to a choice in the isomorphism between the set of metrics
+on the space manifold and the positive reals.
+From this choice of meters, we can define other length units by scaling meters.
 
 -/
 
-/-- The axiom corresponding to the definition of a length unit of meters. -/
-axiom meters : LengthUnit
+/-- The definition of a length unit of meters. -/
+def meters : LengthUnit := ⟨1, by norm_num⟩
 
 /-- The length unit of femtometers (10⁻¹⁵ of a meter). -/
 noncomputable def femtometers : LengthUnit := scale ((1/10) ^ (15)) meters

--- a/PhysLean/SpaceAndTime/Time/TimeUnit.lean
+++ b/PhysLean/SpaceAndTime/Time/TimeUnit.lean
@@ -20,8 +20,8 @@ ratio of the two scales of time unit.
 We define `HasTimeDimension` to be a property of a function from `TimeUnit` to a type `M`
 which is a function that scales with the time unit with respect to the rational power `d`.
 
-To define specific time units, we first axiomise the existence of a
-a given time unit, and then construct all other time units from it. We choose to axiomise the
+To define specific time units, we first state the existence of a
+a given time unit, and then construct all other time units from it. We choose to state the
 existence of the time unit of seconds, and construct all other time units from that.
 
 -/
@@ -129,16 +129,16 @@ lemma scale_scale (x : TimeUnit) (r1 r2 : ℝ) (hr1 : 0 < r1) (hr2 : 0 < r2) :
 
 ## Specific choices of time units
 
-To define a specific time units, we must first axiomise the existence of a
-a given time unit, and then construct all other time units from it.
-We choose to axiomise the existence of the time unit of seconds.
-
-We need an axiom since this relates something to something in the physical world.
+To define a specific time units.
+We first define the notion of a second to correspond to the length unit with underlying value
+equal to `1`. This is really down to a choice in the isomorphism between the set of metrics
+on the time manifold and the positive reals.
+From this choice of second, we can define other length units by scaling second.
 
 -/
 
-/-- The axiom corresponding to the definition of a time unit of seconds. -/
-axiom seconds : TimeUnit
+/-- The definition of a time unit of seconds. -/
+def seconds : TimeUnit := ⟨1, by norm_num⟩
 
 /-- The time unit of femtoseconds (10⁻¹⁵ of a second). -/
 noncomputable def femtoseconds : TimeUnit := scale ((1/10) ^ (15)) seconds

--- a/PhysLean/Thermodynamics/Temperature/TemperatureUnits.lean
+++ b/PhysLean/Thermodynamics/Temperature/TemperatureUnits.lean
@@ -18,9 +18,9 @@ positive reals.
 On `TemperatureUnit` there is an instance of division giving a real number, corresponding to the
 ratio of the two scales of temperature unit.
 
-To define specific temperature units, we first axiomise the existence of a
+To define specific temperature units, we first state the existence of a
 a given temperature unit, and then construct all other temperature units from it.
-We choose to axiomise the
+We choose to state the
 existence of the temperature unit of kelvin, and construct all other temperature units from that.
 
 -/
@@ -129,16 +129,17 @@ lemma scale_scale (x : TemperatureUnit) (r1 r2 : ℝ) (hr1 : 0 < r1) (hr2 : 0 < 
 
 ## Specific choices of temperature units
 
-To define a specific temperature units, we must first axiomise the existence of a
-a given temperature unit, and then construct all other temperature units from it.
-We choose to axiomise the existence of the temperature unit of kelvin.
+To define a specific temperature units.
+We first define the notion of a kelvin to correspond to the temperature unit with underlying value
+equal to `1`. This is really down to a choice in the isomorphism between the set of metrics
+on the temperature manifold and the positive reals.
 
-We need an axiom since this relates something to something in the physical world.
+Once we have defined kelvin, we can define other temperature units by scaling kelvin.
 
 -/
 
-/-- The axiom corresponding to the definition of a temperature unit of kelvin. -/
-axiom kelvin : TemperatureUnit
+/-- The definition of a temperature unit of kelvin. -/
+def kelvin : TemperatureUnit := ⟨1, by norm_num⟩
 
 /-- The temperature unit of degrees nanokelvin (10^(-9) kelvin). -/
 noncomputable def nanokelvin : TemperatureUnit := scale (1e-9) kelvin


### PR DESCRIPTION
In this PR we remove a number of axioms related to units, and replace them with explicit definitions. 
This reasoning behind this change is discussed here:

https://leanprover.zulipchat.com/#narrow/channel/479953-PhysLean/topic/physical.20units/near/534907020

In the end the idea is that we do not introduce any axioms other than those in Mathlib. After this PR there are two axioms left related to the existence of Planck's constant and Boltzmann's constant. These could very easily be removed.

The use of axioms here is also reported to result in errors when interacting with @Aristotle-Harmonic, which this PR should fix (@rlamy).