### PR TITLE
feat: Extrema condition is invariant for distribution EM potential

### DIFF
--- a/PhysLean/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/PhysLean/Electromagnetism/Dynamics/IsExtrema.lean
@@ -681,15 +681,74 @@ lemma isExtrema_iff_vectorPotential {𝓕 : FreeSpace}
 
 /-!
 
-### E.3. Equivariance of the extrema condition
+### E.3. The exterma condition in terms of tensors
+
+-/
+open SpaceTime minkowskiMatrix
+lemma isExterma_iff_tensor {𝓕 : FreeSpace}
+    (A : DistElectromagneticPotential d)
+    (J : DistLorentzCurrentDensity d) :
+    IsExtrema 𝓕 A J ↔ ∀ ε,
+    {((1/ 𝓕.μ₀ : ℝ) • distTensorDeriv A.fieldStrength ε | κ κ ν') + - (J ε | ν')}ᵀ = 0 := by
+  apply Iff.intro
+  · intro h
+    simp only [IsExtrema] at h
+    intro x
+    have h1 : ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
+        (permT id (PermCond.auto) {((1/ 𝓕.μ₀ : ℝ) • distTensorDeriv A.fieldStrength x | κ κ ν') +
+        - (J x | ν')}ᵀ)) = 0 := by
+      funext ν
+      have h2 : gradLagrangian 𝓕 A J x ν = 0 := by simp [h]
+      rw [gradLagrangian_eq_tensor A J] at h2
+      simp at h2
+      have hn : minkowskiMatrix  ν ν ≠ 0 := minkowskiMatrix.η_diag_ne_zero
+      simp_all
+    rw [EmbeddingLike.map_eq_zero_iff, permT_eq_zero_iff] at h1
+    exact h1
+  · intro h
+    simp only [IsExtrema]
+    ext x
+    funext ν
+    rw [gradLagrangian_eq_tensor A J, h]
+    simp
+
+
+/-!
+
+### E.4. The invariance of the exterma condition under Lorentz transformations
 
 -/
 
-lemma isExterma_invariant {𝓕 : FreeSpace}
+lemma isExterma_equivariant {𝓕 : FreeSpace}
     (A : DistElectromagneticPotential d)
-    (J : DistLorentzCurrentDensity d)
-    (Λ : LorentzGroup d) :
+    (J : DistLorentzCurrentDensity d) (Λ : LorentzGroup d) :
     IsExtrema 𝓕 (Λ • A) (Λ • J) ↔ IsExtrema 𝓕 A J := by
-  sorry
+  rw [isExterma_iff_tensor]
+  conv_lhs =>
+    enter [x, 1, 1, 2, 2, 2]
+    rw [fieldStrength_equivariant, distTensorDeriv_equivariant]
+    rw [lorentzGroup_smul_dist_apply]
+  conv_lhs =>
+    enter [x]
+    rw [smul_comm]
+    rw [Tensorial.toTensor_smul, lorentzGroup_smul_dist_apply, Tensorial.toTensor_smul]
+    simp only [Nat.reduceAdd, Nat.reduceSucc, Fin.isValue, one_div, map_smul, actionT_smul,
+      contrT_equivariant, map_neg, permT_equivariant]
+    rw [smul_comm, ← Tensor.actionT_neg, ← Tensor.actionT_add]
+  apply Iff.intro
+  · intro h
+    rw [isExterma_iff_tensor A J ]
+    intro x
+    apply MulAction.injective Λ
+    simp only [Nat.reduceAdd, Nat.reduceSucc, Fin.isValue, one_div, map_smul, map_neg,
+      _root_.smul_add, actionT_smul, _root_.smul_neg, _root_.smul_zero]
+    simpa [schwartzAction_mul_apply] using h (schwartzAction Λ x)
+  · intro h x
+    rw [isExterma_iff_tensor A  J ] at h
+    specialize h (schwartzAction Λ⁻¹ x)
+    simp  at h
+    rw [h]
+    simp
+
 end DistElectromagneticPotential
 end Electromagnetism

--- a/PhysLean/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/PhysLean/Electromagnetism/Dynamics/IsExtrema.lean
@@ -679,5 +679,17 @@ lemma isExtrema_iff_vectorPotential {𝓕 : FreeSpace}
   rw [magneticFieldMatrix_distSpaceDeriv_basis_repr_eq_vector_potential]
   ring
 
+/-!
+
+### E.3. Equivariance of the extrema condition
+
+-/
+
+lemma isExterma_invariant {𝓕 : FreeSpace}
+    (A : DistElectromagneticPotential d)
+    (J : DistLorentzCurrentDensity d)
+    (Λ : LorentzGroup d) :
+    IsExtrema 𝓕 (Λ • A) (Λ • J) ↔ IsExtrema 𝓕 A J := by
+  sorry
 end DistElectromagneticPotential
 end Electromagnetism

--- a/PhysLean/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/PhysLean/Electromagnetism/Dynamics/IsExtrema.lean
@@ -41,6 +41,8 @@ Maxwell's equations with sources, i.e. Gauss's law and Ampère's law.
 - E. Is Extema condition in the distributional case
   - E.1. IsExtrema and Gauss's law and Ampère's law
   - E.2. IsExtrema in terms of Vector Potentials
+  - E.3. The exterma condition in terms of tensors
+  - E.4. The invariance of the exterma condition under Lorentz transformations
 
 ## iv. References
 
@@ -294,7 +296,6 @@ lemma time_deriv_electricField_of_isExtrema {A : ElectromagneticPotential d}
 ### D.1. Second time derivatives of the magnetic field from the extrema condition
 
 We show that the magnetic field matrix $B_{ij}$ satisfies the following wave-like equation
-
 
 -/
 
@@ -708,7 +709,7 @@ lemma isExterma_iff_tensor {𝓕 : FreeSpace}
       have h2 : gradLagrangian 𝓕 A J x ν = 0 := by simp [h]
       rw [gradLagrangian_eq_tensor A J] at h2
       simp at h2
-      have hn : minkowskiMatrix  ν ν ≠ 0 := minkowskiMatrix.η_diag_ne_zero
+      have hn : minkowskiMatrix ν ν ≠ 0 := minkowskiMatrix.η_diag_ne_zero
       simp_all
     rw [EmbeddingLike.map_eq_zero_iff, permT_eq_zero_iff] at h1
     exact h1
@@ -718,7 +719,6 @@ lemma isExterma_iff_tensor {𝓕 : FreeSpace}
     funext ν
     rw [gradLagrangian_eq_tensor A J, h]
     simp
-
 
 /-!
 
@@ -750,16 +750,16 @@ lemma isExterma_equivariant {𝓕 : FreeSpace}
     rw [smul_comm, ← Tensor.actionT_neg, ← Tensor.actionT_add]
   apply Iff.intro
   · intro h
-    rw [isExterma_iff_tensor A J ]
+    rw [isExterma_iff_tensor A J]
     intro x
     apply MulAction.injective Λ
     simp only [Nat.reduceAdd, Nat.reduceSucc, Fin.isValue, one_div, map_smul, map_neg,
       _root_.smul_add, actionT_smul, _root_.smul_neg, _root_.smul_zero]
     simpa [schwartzAction_mul_apply] using h (schwartzAction Λ x)
   · intro h x
-    rw [isExterma_iff_tensor A  J ] at h
+    rw [isExterma_iff_tensor A J] at h
     specialize h (schwartzAction Λ⁻¹ x)
-    simp  at h
+    simp at h
     rw [h]
     simp
 

--- a/PhysLean/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/PhysLean/Electromagnetism/Dynamics/IsExtrema.lean
@@ -293,11 +293,14 @@ lemma time_deriv_electricField_of_isExtrema {A : ElectromagneticPotential d}
 
 ### D.1. Second time derivatives of the magnetic field from the extrema condition
 
+We show that the magnetic field matrix $B_{ij}$ satisfies the following wave-like equation
+
+
 -/
 
 lemma time_deriv_time_deriv_magneticFieldMatrix_of_isExtrema {A : ElectromagneticPotential d}
     {𝓕 : FreeSpace}
-    (hA : ContDiff ℝ ∞ A) (J : LorentzCurrentDensity d) (hJd : Differentiable ℝ J)
+    (hA : ContDiff ℝ ∞ A) (J : LorentzCurrentDensity d)
     (hJ : ContDiff ℝ ∞ J) (h : IsExtrema 𝓕 A J)
     (t : Time) (x : Space d) (i j : Fin d) :
     ∂ₜ (∂ₜ (A.magneticFieldMatrix 𝓕.c · x (i, j))) t =
@@ -318,7 +321,7 @@ lemma time_deriv_time_deriv_magneticFieldMatrix_of_isExtrema {A : Electromagneti
         apply Space.deriv_differentiable
         apply magneticFieldMatrix_space_contDiff _ (hA.of_le (right_eq_inf.mp rfl)))
           ((LorentzCurrentDensity.currentDensity_apply_differentiable_space
-          hJd _ _).const_mul _).differentiableAt,
+          (hJ.differentiable (ENat.LEInfty.out)) _ _).const_mul _).differentiableAt,
     fderiv_const_mul (by
         apply Differentiable.fun_sum
         intro i _
@@ -326,7 +329,7 @@ lemma time_deriv_time_deriv_magneticFieldMatrix_of_isExtrema {A : Electromagneti
         apply magneticFieldMatrix_space_contDiff _ (hA.of_le (right_eq_inf.mp rfl))),
     fderiv_const_mul (by
         apply (LorentzCurrentDensity.currentDensity_apply_differentiable_space
-        hJd _ _).differentiableAt),
+        (hJ.differentiable (ENat.LEInfty.out)) _ _).differentiableAt),
     fderiv_fun_sum fun i _ => by
         apply Differentiable.differentiableAt
         apply Space.deriv_differentiable
@@ -341,7 +344,7 @@ lemma time_deriv_time_deriv_magneticFieldMatrix_of_isExtrema {A : Electromagneti
         apply Space.deriv_differentiable
         apply magneticFieldMatrix_space_contDiff _ (hA.of_le (right_eq_inf.mp rfl)))
           ((LorentzCurrentDensity.currentDensity_apply_differentiable_space
-          hJd _ _).const_mul _).differentiableAt,
+          (hJ.differentiable (ENat.LEInfty.out)) _ _).const_mul _).differentiableAt,
     fderiv_const_mul (by
         apply Differentiable.fun_sum
         intro i _
@@ -349,7 +352,7 @@ lemma time_deriv_time_deriv_magneticFieldMatrix_of_isExtrema {A : Electromagneti
         apply magneticFieldMatrix_space_contDiff _ (hA.of_le (right_eq_inf.mp rfl))),
     fderiv_const_mul (by
         apply (LorentzCurrentDensity.currentDensity_apply_differentiable_space
-        hJd _ _).differentiableAt),
+        (hJ.differentiable (ENat.LEInfty.out)) _ _).differentiableAt),
     fderiv_fun_sum fun i _ => by
         apply Differentiable.differentiableAt
         apply Space.deriv_differentiable
@@ -683,6 +686,10 @@ lemma isExtrema_iff_vectorPotential {𝓕 : FreeSpace}
 
 ### E.3. The exterma condition in terms of tensors
 
+We show that `A` is an extrema of the lagrangian if and only if the equation
+$$(\frac{1}{\mu_0} \partial_\kappa F^{\kappa \nu'} - J^{\nu'}) = 0,$$
+holds.
+
 -/
 open SpaceTime minkowskiMatrix
 lemma isExterma_iff_tensor {𝓕 : FreeSpace}
@@ -716,6 +723,12 @@ lemma isExterma_iff_tensor {𝓕 : FreeSpace}
 /-!
 
 ### E.4. The invariance of the exterma condition under Lorentz transformations
+
+We show that the Exterma condition is invariant under Lorentz transformations.
+This implies that if an electromagnetic potential is an extrema in one inertial frame,
+it is also an extrema in any other inertial frame.
+In otherwords that the Maxwell's equations are Lorentz invariant.
+A natural consequence of this is that the speed of light is the same in all inertial frames.
 
 -/
 

--- a/PhysLean/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/PhysLean/Electromagnetism/Dynamics/KineticTerm.lean
@@ -1205,5 +1205,92 @@ lemma gradKineticTerm_sum_inr_eq {d} {𝓕 : FreeSpace}
         ← distTimeSlice_symm_apply]
     simp [← distTimeSlice_distDeriv_inr]
 
+/-!
+
+### C.1. The gradient of the kinetic term as a tensor
+
+-/
+
+lemma gradKineticTerm_eq_distTensorDeriv {d} {𝓕 : FreeSpace}
+    (A : DistElectromagneticPotential d) (ε : 𝓢(SpaceTime d, ℝ)) (ν : Fin 1 ⊕ Fin d) :
+    A.gradKineticTerm 𝓕 ε ν = η ν ν * ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
+    (permT id (PermCond.auto) {(1/ 𝓕.μ₀ : ℝ) • distTensorDeriv A.fieldStrength ε | κ κ ν'}ᵀ)) ν := by
+  trans η ν ν * (Lorentz.Vector.basis.repr
+    ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
+    (permT id (PermCond.auto) {(1/ 𝓕.μ₀ : ℝ) • distTensorDeriv A.fieldStrength ε  | κ κ ν'}ᵀ))) ν
+  swap
+  · rfl
+  simp [Lorentz.Vector.basis_eq_map_tensor_basis]
+  rw [permT_basis_repr_symm_apply, contrT_basis_repr_apply_eq_fin]
+  conv_lhs =>
+    rw [gradKineticTerm_eq_fieldStrength A ε]
+    simp [Lorentz.Vector.apply_sum]
+  ring_nf
+  congr 1
+  rw [← finSumFinEquiv.sum_comp]
+  congr
+  funext μ
+  rw [distTensorDeriv_toTensor_basis_repr]
+  conv_rhs =>
+    enter [1, 2, 2]
+  trans (Tensor.basis _).repr (Tensorial.toTensor ( distDeriv μ (A.fieldStrength) ε))
+      (fun | 0 => finSumFinEquiv μ | 1 => finSumFinEquiv ν)
+  · generalize ( distDeriv μ (A.fieldStrength) ε) = t at *
+    rw [Tensorial.basis_toTensor_apply]
+    rw [Tensorial.basis_map_prod]
+    simp only [Nat.reduceSucc, Nat.reduceAdd, Basis.repr_reindex, Finsupp.mapDomain_equiv_apply,
+      Equiv.symm_symm]
+    rw [Lorentz.Vector.tensor_basis_map_eq_basis_reindex]
+    have hb : (((Lorentz.Vector.basis (d := d)).reindex Lorentz.Vector.indexEquiv.symm).tensorProduct
+            (Lorentz.Vector.basis.reindex Lorentz.Vector.indexEquiv.symm)) =
+            ((Lorentz.Vector.basis (d := d)).tensorProduct (Lorentz.Vector.basis (d := d))).reindex
+            (Lorentz.Vector.indexEquiv.symm.prodCongr Lorentz.Vector.indexEquiv.symm) := by
+          ext b
+          match b with
+          | ⟨i, j⟩ =>
+          simp
+    rw [hb]
+    rw [Module.Basis.repr_reindex_apply]
+    congr 1
+    simp [ComponentIdx.prodEquiv,ComponentIdx.prodIndexEquiv, Vector.indexEquiv]
+    apply And.intro
+    · rw [@Equiv.eq_symm_apply]
+      rfl
+    · rw [@Equiv.eq_symm_apply]
+      rfl
+  apply congr
+  · simp
+    congr
+    apply Lorentz.CoVector.indexEquiv.symm.injective
+    simp only [Nat.reduceSucc, Fin.isValue, Equiv.symm_apply_apply]
+    simp [Lorentz.CoVector.indexEquiv]
+    funext j
+    fin_cases j
+    simp [ComponentIdx.prodEquiv, ComponentIdx.prodIndexEquiv]
+    simp [ComponentIdx.DropPairSection.ofFinEquiv, ComponentIdx.DropPairSection.ofFin]
+    intro h
+    change ¬ 0 = 0 at h
+    simp at h
+  funext x
+  fin_cases x
+  · simp only [Nat.reduceSucc, Nat.reduceAdd, Fin.isValue, Function.comp_apply, Fin.cast_eq_self]
+    simp [ComponentIdx.prodEquiv, ComponentIdx.prodIndexEquiv]
+    simp [ComponentIdx.DropPairSection.ofFinEquiv, ComponentIdx.DropPairSection.ofFin]
+    intro _ h
+    apply False.elim
+    apply h
+    decide
+  · simp only [Nat.reduceSucc, Nat.reduceAdd, Fin.isValue, Function.comp_apply, Fin.cast_eq_self]
+    simp [ComponentIdx.prodEquiv, ComponentIdx.prodIndexEquiv]
+    simp [ComponentIdx.DropPairSection.ofFinEquiv, ComponentIdx.DropPairSection.ofFin]
+    split_ifs
+    · rename_i h
+      suffices ¬ (finSumFinEquiv (Sum.inr 1) = (0 : Fin (1 + 1 + 1))) from False.elim (this h)
+      decide
+    · rename_i h h2
+      suffices ¬ (finSumFinEquiv (Sum.inr 1) = (1 : Fin (1 + 1 + 1))) from False.elim (this h2)
+      decide
+    · rfl
+
 end DistElectromagneticPotential
 end Electromagnetism

--- a/PhysLean/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/PhysLean/Electromagnetism/Dynamics/KineticTerm.lean
@@ -50,6 +50,7 @@ In this implementation we have set `μ₀ = 1`. It is a TODO to introduce this c
   - B.6. HasVarGradientAt for the variational gradient
   - B.7. Gradient of the kinetic term in terms of the tensor derivative
 - C. The gradient of the kinetic term for distributions
+  - C.1. The gradient of the kinetic term as a tensor
 
 ## iv. References
 
@@ -1214,10 +1215,11 @@ lemma gradKineticTerm_sum_inr_eq {d} {𝓕 : FreeSpace}
 lemma gradKineticTerm_eq_distTensorDeriv {d} {𝓕 : FreeSpace}
     (A : DistElectromagneticPotential d) (ε : 𝓢(SpaceTime d, ℝ)) (ν : Fin 1 ⊕ Fin d) :
     A.gradKineticTerm 𝓕 ε ν = η ν ν * ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
-    (permT id (PermCond.auto) {(1/ 𝓕.μ₀ : ℝ) • distTensorDeriv A.fieldStrength ε | κ κ ν'}ᵀ)) ν := by
+    (permT id (PermCond.auto) {(1/ 𝓕.μ₀ : ℝ) •
+    distTensorDeriv A.fieldStrength ε | κ κ ν'}ᵀ)) ν := by
   trans η ν ν * (Lorentz.Vector.basis.repr
     ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
-    (permT id (PermCond.auto) {(1/ 𝓕.μ₀ : ℝ) • distTensorDeriv A.fieldStrength ε  | κ κ ν'}ᵀ))) ν
+    (permT id (PermCond.auto) {(1/ 𝓕.μ₀ : ℝ) • distTensorDeriv A.fieldStrength ε | κ κ ν'}ᵀ))) ν
   swap
   · rfl
   simp [Lorentz.Vector.basis_eq_map_tensor_basis]
@@ -1233,22 +1235,23 @@ lemma gradKineticTerm_eq_distTensorDeriv {d} {𝓕 : FreeSpace}
   rw [distTensorDeriv_toTensor_basis_repr]
   conv_rhs =>
     enter [1, 2, 2]
-  trans (Tensor.basis _).repr (Tensorial.toTensor ( distDeriv μ (A.fieldStrength) ε))
+  trans (Tensor.basis _).repr (Tensorial.toTensor (distDeriv μ (A.fieldStrength) ε))
       (fun | 0 => finSumFinEquiv μ | 1 => finSumFinEquiv ν)
-  · generalize ( distDeriv μ (A.fieldStrength) ε) = t at *
+  · generalize (distDeriv μ (A.fieldStrength) ε) = t at *
     rw [Tensorial.basis_toTensor_apply]
     rw [Tensorial.basis_map_prod]
     simp only [Nat.reduceSucc, Nat.reduceAdd, Basis.repr_reindex, Finsupp.mapDomain_equiv_apply,
       Equiv.symm_symm]
     rw [Lorentz.Vector.tensor_basis_map_eq_basis_reindex]
-    have hb : (((Lorentz.Vector.basis (d := d)).reindex Lorentz.Vector.indexEquiv.symm).tensorProduct
-            (Lorentz.Vector.basis.reindex Lorentz.Vector.indexEquiv.symm)) =
-            ((Lorentz.Vector.basis (d := d)).tensorProduct (Lorentz.Vector.basis (d := d))).reindex
-            (Lorentz.Vector.indexEquiv.symm.prodCongr Lorentz.Vector.indexEquiv.symm) := by
-          ext b
-          match b with
-          | ⟨i, j⟩ =>
-          simp
+    have hb : (((Lorentz.Vector.basis (d := d)).reindex
+        Lorentz.Vector.indexEquiv.symm).tensorProduct
+        (Lorentz.Vector.basis.reindex Lorentz.Vector.indexEquiv.symm)) =
+        ((Lorentz.Vector.basis (d := d)).tensorProduct (Lorentz.Vector.basis (d := d))).reindex
+        (Lorentz.Vector.indexEquiv.symm.prodCongr Lorentz.Vector.indexEquiv.symm) := by
+      ext b
+      match b with
+      | ⟨i, j⟩ =>
+      simp
     rw [hb]
     rw [Module.Basis.repr_reindex_apply]
     congr 1

--- a/PhysLean/Electromagnetism/Dynamics/Lagrangian.lean
+++ b/PhysLean/Electromagnetism/Dynamics/Lagrangian.lean
@@ -447,6 +447,11 @@ noncomputable def gradFreeCurrentPotential {d} :
     funext i
     ring_nf
 
+lemma gradFreeCurrentPotential_eq_sum_basis {d}
+    (J : DistLorentzCurrentDensity d) (ε : 𝓢(SpaceTime d, ℝ)) :
+    (gradFreeCurrentPotential J) ε =
+    (∑ μ, (η μ μ • (J ε μ) • Lorentz.Vector.basis μ)) := rfl
+
 lemma gradFreeCurrentPotential_sum_inl_0 (𝓕 : FreeSpace) {d}
     (J : DistLorentzCurrentDensity d) (ε : 𝓢(SpaceTime d, ℝ)) :
     (gradFreeCurrentPotential J) ε (Sum.inl 0) =
@@ -472,6 +477,26 @@ lemma gradFreeCurrentPotential_sum_inr_i (𝓕 : FreeSpace) {d}
     ContinuousLinearMap.coe_comp', Function.comp_apply]
   rw [← distTimeSlice_symm_apply]
   simp
+
+/-!
+
+#### D.1.1 Free current potential as a tensor
+
+-/
+
+lemma gradFreeCurrentPotential_eq_tensor {d}
+    (J : DistLorentzCurrentDensity d) (ε : 𝓢(SpaceTime d, ℝ))
+    (ν : Fin 1 ⊕ Fin d) :
+    gradFreeCurrentPotential J ε ν  = η ν ν * ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
+    (permT id (PermCond.auto) {J ε | ν'}ᵀ)) ν:= by
+  trans η ν ν * (Lorentz.Vector.basis.repr ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
+    (permT id (PermCond.auto) {J ε | ν'}ᵀ))) ν
+  swap
+  · simp [Lorentz.Vector.basis_repr_apply]
+  simp [Lorentz.Vector.basis_repr_apply]
+  rw [gradFreeCurrentPotential_eq_sum_basis]
+  simp [Lorentz.Vector.apply_sum]
+
 /-!
 
 ### D.2. The gradient of the lagrangian density
@@ -504,6 +529,32 @@ lemma gradLagrangian_sum_inr_i {𝓕 : FreeSpace}
         ((distTimeSlice 𝓕.c).symm (Space.distSpaceDeriv j (A.magneticFieldMatrix 𝓕.c)) ε) (j, i)) +
     (distTimeSlice 𝓕.c).symm (J.currentDensity 𝓕.c) ε i := by
   simp [gradLagrangian, gradKineticTerm_sum_inr_eq, gradFreeCurrentPotential_sum_inr_i 𝓕]
+
+/-!
+
+#### D.2.1 The lagrangian gradient as a tensor
+
+-/
+
+lemma gradLagrangian_eq_tensor {𝓕 : FreeSpace}
+    (A : DistElectromagneticPotential d) (J : DistLorentzCurrentDensity d)
+    (ε : 𝓢(SpaceTime d, ℝ)) (ν : Fin 1 ⊕ Fin d) :
+    A.gradLagrangian 𝓕 J ε ν =
+    η ν ν * ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
+    (permT id (PermCond.auto) {((1/ 𝓕.μ₀ : ℝ) • distTensorDeriv A.fieldStrength ε | κ κ ν') +
+    - (J ε | ν')}ᵀ)) ν := by
+  rw [gradLagrangian]
+  simp
+  rw [gradKineticTerm_eq_distTensorDeriv, gradFreeCurrentPotential_eq_tensor J ε ν]
+  simp only [Nat.reduceSucc, Nat.reduceAdd, Fin.isValue, one_div, map_smul, apply_smul,
+    permT_id_self, LinearEquiv.symm_apply_apply]
+  ring_nf
+  congr
+  rw [permT_congr_eq_id]
+  simp only [LinearEquiv.symm_apply_apply]
+  funext i
+  fin_cases i
+  simp
 
 end DistElectromagneticPotential
 end Electromagnetism

--- a/PhysLean/Electromagnetism/Dynamics/Lagrangian.lean
+++ b/PhysLean/Electromagnetism/Dynamics/Lagrangian.lean
@@ -51,7 +51,9 @@ In this implementation we set `μ₀ = 1`. It is a TODO to introduce this consta
   - C.7. The lagrangian gradient in tensor notation
 - D. The gradient of the lagrangian density for distributions
   - D.1. The gradient of the free current potential
+    - D.1.1. Free current potential as a tensor
   - D.2. The gradient of the lagrangian density
+    - D.2.1. The lagrangian gradient as a tensor
 
 ## iv. References
 
@@ -480,14 +482,14 @@ lemma gradFreeCurrentPotential_sum_inr_i (𝓕 : FreeSpace) {d}
 
 /-!
 
-#### D.1.1 Free current potential as a tensor
+#### D.1.1. Free current potential as a tensor
 
 -/
 
 lemma gradFreeCurrentPotential_eq_tensor {d}
     (J : DistLorentzCurrentDensity d) (ε : 𝓢(SpaceTime d, ℝ))
     (ν : Fin 1 ⊕ Fin d) :
-    gradFreeCurrentPotential J ε ν  = η ν ν * ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
+    gradFreeCurrentPotential J ε ν = η ν ν * ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
     (permT id (PermCond.auto) {J ε | ν'}ᵀ)) ν:= by
   trans η ν ν * (Lorentz.Vector.basis.repr ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
     (permT id (PermCond.auto) {J ε | ν'}ᵀ))) ν
@@ -532,7 +534,7 @@ lemma gradLagrangian_sum_inr_i {𝓕 : FreeSpace}
 
 /-!
 
-#### D.2.1 The lagrangian gradient as a tensor
+#### D.2.1. The lagrangian gradient as a tensor
 
 -/
 
@@ -544,7 +546,9 @@ lemma gradLagrangian_eq_tensor {𝓕 : FreeSpace}
     (permT id (PermCond.auto) {((1/ 𝓕.μ₀ : ℝ) • distTensorDeriv A.fieldStrength ε | κ κ ν') +
     - (J ε | ν')}ᵀ)) ν := by
   rw [gradLagrangian]
-  simp
+  simp only [ContinuousLinearMap.coe_sub', Pi.sub_apply, apply_sub, Nat.reduceSucc, Nat.reduceAdd,
+    Fin.isValue, one_div, map_smul, map_neg, map_add, permT_permT, CompTriple.comp_eq, apply_add,
+    apply_smul, Lorentz.Vector.neg_apply]
   rw [gradKineticTerm_eq_distTensorDeriv, gradFreeCurrentPotential_eq_tensor J ε ν]
   simp only [Nat.reduceSucc, Nat.reduceAdd, Fin.isValue, one_div, map_smul, apply_smul,
     permT_id_self, LinearEquiv.symm_apply_apply]

--- a/PhysLean/SpaceAndTime/SpaceTime/Derivatives.lean
+++ b/PhysLean/SpaceAndTime/SpaceTime/Derivatives.lean
@@ -540,6 +540,28 @@ lemma distTensorDeriv_equivariant {M : Type} [NormedAddCommGroup M]
   simp only [map_sum]
   simp [TensorSpecies.Tensorial.smulLinearMap_apply]
 
+lemma distTensorDeriv_toTensor_basis_repr {M : Type} [NormedAddCommGroup M]
+    [InnerProductSpace ℝ M] [FiniteDimensional ℝ M] [(realLorentzTensor d).Tensorial c M]
+    {f : (SpaceTime d) →d[ℝ] M}
+    (ε : 𝓢(SpaceTime d, ℝ))
+    (b : Tensor.ComponentIdx (Fin.append ![realLorentzTensor.Color.down] c)) :
+    (Tensor.basis _).repr (Tensorial.toTensor (distTensorDeriv f ε)) b =
+    (Tensor.basis _).repr (Tensorial.toTensor
+    (distDeriv (Lorentz.CoVector.indexEquiv (Tensor.ComponentIdx.prodEquiv b).1) f ε))
+    (Tensor.ComponentIdx.prodEquiv b).2 := by
+  simp [distTensorDeriv]
+  conv_lhs =>
+    enter [2, μ]
+    rw [Tensorial.toTensor_tprod, Tensor.prodT_basis_repr_apply]
+    simp [Lorentz.CoVector.toTensor_basis_eq_tensor_basis, Finsupp.single_apply]
+  rw [Finset.sum_eq_single (Lorentz.CoVector.indexEquiv (Tensor.ComponentIdx.prodEquiv b).1)]
+  · simp
+  · intro b' _ hb
+    simp only [ite_eq_right_iff]
+    intro hx
+    grind
+  · simp
+
 end SpaceTime
 
 end


### PR DESCRIPTION
In this PR we prove that the exterma condition for distribution EM potentials is invariant. In other words, for electromagnetic potentials based on distributions, Maxwell's equations are invariant under the Lorentz group.