### PR TITLE
feat: Replacing PhysLean PairSwap() with MathLib Equiv.Swap()

### DIFF
--- a/PhysLean/QFT/QED/AnomalyCancellation/Even/BasisLinear.lean
+++ b/PhysLean/QFT/QED/AnomalyCancellation/Even/BasisLinear.lean
@@ -754,21 +754,19 @@ lemma smul_basis!AsCharges_in_span (S : (PureU1 (2 * n.succ)).LinSols) (j : Fin 
   adding a vector basis!AsCharges j. -/
 lemma swap!_as_add {S S' : (PureU1 (2 * n.succ)).LinSols} (j : Fin n)
     (hS : ((FamilyPermutations (2 * n.succ)).linSolRep
-    (pairSwap (evenShiftFst j) (evenShiftSnd j))) S = S') :
+    (Equiv.swap (evenShiftFst j) (evenShiftSnd j))) S = S') :
     S'.val = S.val + (S.val (evenShiftSnd j) - S.val (evenShiftFst j)) • basis!AsCharges j := by
   funext i
   rw [← hS, FamilyPermutations_anomalyFreeLinear_apply]
   by_cases hi : i = evenShiftFst j
   · subst hi
-    simp [HSMul.hSMul, basis!_on_evenShiftFst_self, pairSwap_inv_fst]
+    simp [HSMul.hSMul, basis!_on_evenShiftFst_self, Equiv.swap_apply_left]
   · by_cases hi2 : i = evenShiftSnd j
-    · simp [HSMul.hSMul, hi2, basis!_on_evenShiftSnd_self, pairSwap_inv_snd]
+    · simp [HSMul.hSMul, hi2, basis!_on_evenShiftSnd_self, Equiv.swap_apply_right]
     · simp only [succ_eq_add_one, Equiv.invFun_as_coe, HSMul.hSMul,
       ACCSystemCharges.chargesAddCommMonoid_add, ACCSystemCharges.chargesModule_smul]
       rw [basis!_on_other hi hi2]
-      change S.val ((pairSwap (evenShiftFst j) (evenShiftSnd j)).invFun i) =_
-      erw [pairSwap_inv_other (Ne.symm hi) (Ne.symm hi2)]
-      simp
+      aesop
 /-!
 
 ## D. Mixed cubic ACCs involing points from both planes
@@ -1024,7 +1022,7 @@ lemma span_basis (S : (PureU1 (2 * n.succ)).LinSols) :
 -/
 lemma span_basis_swap! {S : (PureU1 (2 * n.succ)).LinSols} (j : Fin n)
     (hS : ((FamilyPermutations (2 * n.succ)).linSolRep
-    (pairSwap (evenShiftFst j) (evenShiftSnd j))) S = S') (g : Fin n.succ → ℚ) (f : Fin n → ℚ)
+    (Equiv.swap (evenShiftFst j) (evenShiftSnd j))) S = S') (g : Fin n.succ → ℚ) (f : Fin n → ℚ)
     (h : S.val = P g + P! f) : ∃ (g' : Fin n.succ → ℚ) (f' : Fin n → ℚ),
       S'.val = P g' + P! f' ∧ P! f' = P! f +
       (S.val (evenShiftSnd j) - S.val (evenShiftFst j)) • basis!AsCharges j ∧ g' = g := by

--- a/PhysLean/QFT/QED/AnomalyCancellation/Even/LineInCubic.lean
+++ b/PhysLean/QFT/QED/AnomalyCancellation/Even/LineInCubic.lean
@@ -97,14 +97,14 @@ lemma lineInCubicPerm_swap {S : (PureU1 (2 * n.succ)).LinSols}
       * accCubeTriLinSymm (P g) (P g) (basis!AsCharges j) = 0 := by
   intro j g f h
   let S' := (FamilyPermutations (2 * n.succ)).linSolRep
-    (pairSwap (evenShiftFst j) (evenShiftSnd j)) S
+    (Equiv.swap (evenShiftFst j) (evenShiftSnd j)) S
   have hSS' : ((FamilyPermutations (2 * n.succ)).linSolRep
-    (pairSwap (evenShiftFst j) (evenShiftSnd j))) S = S' := rfl
+    (Equiv.swap (evenShiftFst j) (evenShiftSnd j))) S = S' := rfl
   obtain ⟨g', f', hall⟩ := span_basis_swap! j hSS' g f h
   have h1 := line_in_cubic_P_P_P! (lineInCubicPerm_self LIC) g f h
   have h2 := line_in_cubic_P_P_P!
     (lineInCubicPerm_self (lineInCubicPerm_permute LIC
-    (pairSwap (evenShiftFst j) (evenShiftSnd j)))) g' f' hall.1
+    (Equiv.swap (evenShiftFst j) (evenShiftSnd j)))) g' f' hall.1
   rw [hall.2.1, hall.2.2] at h2
   rw [accCubeTriLinSymm.map_add₃, h1, accCubeTriLinSymm.map_smul₃] at h2
   simpa using h2

--- a/PhysLean/QFT/QED/AnomalyCancellation/Odd/BasisLinear.lean
+++ b/PhysLean/QFT/QED/AnomalyCancellation/Odd/BasisLinear.lean
@@ -599,22 +599,20 @@ def basis! (j : Fin n) : (PureU1 (2 * n + 1)).LinSols :=
   basis!AsCharges j. -/
 lemma swap!_as_add {S S' : (PureU1 (2 * n + 1)).LinSols} (j : Fin n)
     (hS : ((FamilyPermutations (2 * n + 1)).linSolRep
-    (pairSwap (oddShiftFst j) (oddShiftSnd j))) S = S') :
+    (Equiv.swap (oddShiftFst j) (oddShiftSnd j))) S = S') :
     S'.val = S.val + (S.val (oddShiftSnd j) - S.val (oddShiftFst j)) • basis!AsCharges j := by
   funext i
   rw [← hS, FamilyPermutations_anomalyFreeLinear_apply]
   by_cases hi : i = oddShiftFst j
   · subst hi
-    simp [HSMul.hSMul, basis!_on_oddShiftFst_self, pairSwap_inv_fst]
+    simp [HSMul.hSMul, basis!_on_oddShiftFst_self, Equiv.swap_apply_left]
   · by_cases hi2 : i = oddShiftSnd j
     · subst hi2
-      simp [HSMul.hSMul,basis!_on_oddShiftSnd_self, pairSwap_inv_snd]
+      simp [HSMul.hSMul,basis!_on_oddShiftSnd_self, Equiv.swap_apply_right]
     · simp only [Equiv.invFun_as_coe, HSMul.hSMul, ACCSystemCharges.chargesAddCommMonoid_add,
       ACCSystemCharges.chargesModule_smul]
       rw [basis!_on_other hi hi2]
-      change S.val ((pairSwap (oddShiftFst j) (oddShiftSnd j)).invFun i) =_
-      erw [pairSwap_inv_other (Ne.symm hi) (Ne.symm hi2)]
-      simp
+      aesop
 
 /-!
 
@@ -970,7 +968,7 @@ lemma span_basis (S : (PureU1 (2 * n.succ + 1)).LinSols) :
 
 lemma span_basis_swap! {S : (PureU1 (2 * n.succ + 1)).LinSols} (j : Fin n.succ)
     (hS : ((FamilyPermutations (2 * n.succ + 1)).linSolRep
-    (pairSwap (oddShiftFst j) (oddShiftSnd j))) S = S') (g f : Fin n.succ → ℚ)
+    (Equiv.swap (oddShiftFst j) (oddShiftSnd j))) S = S') (g f : Fin n.succ → ℚ)
     (hS1 : S.val = P g + P! f) : ∃ (g' f' : Fin n.succ → ℚ),
     S'.val = P g' + P! f' ∧ P! f' = P! f +
     (S.val (oddShiftSnd j) - S.val (oddShiftFst j)) • basis!AsCharges j ∧ g' = g := by

--- a/PhysLean/QFT/QED/AnomalyCancellation/Odd/LineInCubic.lean
+++ b/PhysLean/QFT/QED/AnomalyCancellation/Odd/LineInCubic.lean
@@ -80,13 +80,13 @@ lemma lineInCubicPerm_swap {S : (PureU1 (2 * n.succ + 1)).LinSols}
       * accCubeTriLinSymm (P g) (P g) (basis!AsCharges j) = 0 := by
   intro j g f h
   let S' := (FamilyPermutations (2 * n.succ + 1)).linSolRep
-    (pairSwap (oddShiftFst j) (oddShiftSnd j)) S
+    (Equiv.swap (oddShiftFst j) (oddShiftSnd j)) S
   have hSS' : ((FamilyPermutations (2 * n.succ + 1)).linSolRep
-    (pairSwap (oddShiftFst j) (oddShiftSnd j))) S = S' := rfl
+    (Equiv.swap (oddShiftFst j) (oddShiftSnd j))) S = S' := rfl
   obtain ⟨g', f', hall⟩ := span_basis_swap! j hSS' g f h
   have h1 := line_in_cubic_P_P_P! (lineInCubicPerm_self LIC) g f h
   have h2 := line_in_cubic_P_P_P! (lineInCubicPerm_self (lineInCubicPerm_permute LIC
-    (pairSwap (oddShiftFst j) (oddShiftSnd j)))) g' f' hall.1
+    (Equiv.swap (oddShiftFst j) (oddShiftSnd j)))) g' f' hall.1
   rw [hall.2.1, hall.2.2] at h2
   rw [accCubeTriLinSymm.map_add₃, h1, accCubeTriLinSymm.map_smul₃] at h2
   simpa using h2

--- a/PhysLean/QFT/QED/AnomalyCancellation/Permutations.lean
+++ b/PhysLean/QFT/QED/AnomalyCancellation/Permutations.lean
@@ -86,67 +86,6 @@ lemma FamilyPermutations_anomalyFreeLinear_apply (S : (PureU1 n).LinSols)
     ((FamilyPermutations n).linSolRep f S).val i = S.val (f.invFun i) := by
   rfl
 
-TODO "6VZPL" "Remove `pairSwap`, and use the Mathlib defined function `Equiv.swap` instead."
-/-- The permutation which swaps i and j. -/
-def pairSwap {n : ℕ} (i j : Fin n) : (FamilyPermutations n).group where
-  toFun s :=
-    if s = i then
-        j
-    else
-      if s = j then
-        i
-      else
-        s
-  invFun s :=
-    if s = i then
-        j
-    else
-      if s = j then
-        i
-      else
-        s
-  left_inv s := by
-    aesop
-  right_inv s := by
-    aesop
-
-lemma pairSwap_self_inv {n : ℕ} (i j : Fin n) : (pairSwap i j)⁻¹ = (pairSwap i j) := by
-  rfl
-
-lemma pairSwap_fst {n : ℕ} (i j : Fin n) : (pairSwap i j).toFun i = j := by
-  simp [pairSwap]
-
-lemma pairSwap_snd {n : ℕ} (i j : Fin n) : (pairSwap i j).toFun j = i := by
-  simp [pairSwap]
-
-lemma pairSwap_inv_fst {n : ℕ} (i j : Fin n) : (pairSwap i j).invFun i = j := by
-  simp [pairSwap]
-
-lemma pairSwap_inv_snd {n : ℕ} (i j : Fin n) : (pairSwap i j).invFun j = i := by
-  simp [pairSwap]
-
-lemma pairSwap_other {n : ℕ} (i j k : Fin n) (hik : i ≠ k) (hjk : j ≠ k) :
-    (pairSwap i j).toFun k = k := by
-  simp only [pairSwap, Equiv.toFun_as_coe, Equiv.coe_fn_mk]
-  split
-  · rename_i h
-    exact False.elim (hik (id (Eq.symm h)))
-  · split
-    · rename_i h
-      exact False.elim (hjk (id (Eq.symm h)))
-    · rfl
-
-lemma pairSwap_inv_other {n : ℕ} {i j k : Fin n} (hik : i ≠ k) (hjk : j ≠ k) :
-    (pairSwap i j).invFun k = k := by
-  simp only [pairSwap, Equiv.invFun_as_coe, Equiv.coe_fn_symm_mk]
-  split
-  · rename_i h
-    exact False.elim (hik (id (Eq.symm h)))
-  · split
-    · rename_i h
-      exact False.elim (hjk (id (Eq.symm h)))
-    · rfl
-
 /-- A permutation of fermions which takes one ordered subset into another. -/
 noncomputable def permOfInjection (f g : Fin m ↪ Fin n) : (FamilyPermutations n).group :=
   Equiv.extendSubtype (g.toEquivRange.symm.trans f.toEquivRange)


### PR DESCRIPTION
Replacing PhysLean PairSwap() with MathLib Equiv.Swap()

