### PR TITLE
docs: Add reference for Hamilton's equations from SICM

### DIFF
--- a/PhysLean/ClassicalMechanics/HamiltonsEquations.lean
+++ b/PhysLean/ClassicalMechanics/HamiltonsEquations.lean
@@ -16,6 +16,11 @@ We show that the variational derivative of the action functional
 `∫ ⟪p, dq/dt⟫ - H(t, p, q) dt` is equal to the `hamiltonEqOp`
 applied to `(p, q)`.
 
+## References
+
+- G. J. Sussman and J. Wisdom, "Structure and Interpretation of Classical Mechanics", Section 3.1.2.
+<https://groups.csail.mit.edu/mac/users/gjs/6946/sicm-html/book-Z-H-36.html#%_sec_3.1.2>
+
 -/
 
 open MeasureTheory ContDiff InnerProductSpace Time


### PR DESCRIPTION
I did it in the style of https://github.com/HEPLean/PhysLean/blob/f0b5bb0695aaf737c4f30ae68dd29e3c5a3d1009/PhysLean/Relativity/LorentzGroup/Basic.lean#L17, but put the authors name first before the book title because that's how the citation in BibTeX is done.