### PR TITLE
feat: Position & momentum unbounded operators

### DIFF
--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -126,8 +126,10 @@ lemma position_commutation_momentum {d : ℕ} (i j : Fin d) : ⁅𝐱[i], 𝐩[j
   rw [positionOperator_apply, momentumOperator_apply_fun]
   rw [momentumOperator_apply, positionOperator_apply_fun]
   simp only [neg_mul, Pi.smul_apply, smul_eq_mul, mul_neg, sub_neg_eq_add]
-
-  have h : (fun x ↦ ↑(x i) * ψ x) = (fun (x : Space d) ↦ x i) • ψ := rfl
+  have h : ⇑(smulLeftCLM ℂ ⇑(Space.coordCLM i) • ψ) = (fun (x : Space d) ↦ x i) • ψ := by
+    ext x
+    rw [ContinuousLinearMap.smul_def, smulLeftCLM_apply_apply (by fun_prop), Space.coordCLM_apply]
+    simp only [Space.coord_apply, Complex.real_smul, Pi.smul_apply']
   rw [h]
   rw [Space.deriv_smul (by fun_prop) (SchwartzMap.differentiableAt ψ)]
   rw [Space.deriv_component, ite_cond_symm j i]

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -12,11 +12,6 @@ import PhysLean.SpaceAndTime.Space.Derivatives.Basic
 # Momentum vector operator
 
 In this module we define:
-- The momentum operator on Schwartz maps, component-wise.
-- The momentum squared operator on Schwartz maps.
-
-
-In this module we define:
 - `momentumOperator i` acting on Schwartz maps `𝓢(Space d, ℂ)` as `-Iℏ∂ᵢ`.
 - `momentumOperatorSqr` acting on Schwartz maps `𝓢(Space d, ℂ)` as `∑ᵢ 𝐩[i]∘𝐩[i]`.
 - `momentumUnboundedOperator i`, a symmetric unbounded operator acting on the Schwartz submodule
@@ -25,7 +20,6 @@ In this module we define:
 We also introduce the following notation:
 - `𝐩[i]` for `momentumOperator i`
 - `𝐩²` for `momentumOperatorSqr`
-
 
 -/
 

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 Gregory J. Loges. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gregory J. Loges
 -/
-import PhysLean.SpaceAndTime.Space.Derivatives.Basic
+import PhysLean.QuantumMechanics.DDimensions.Operators.Unbounded
+import PhysLean.QuantumMechanics.DDimensions.SpaceDHilbertSpace.SchwartzSubmodule
 import PhysLean.QuantumMechanics.PlanckConstant
+import PhysLean.SpaceAndTime.Space.Derivatives.Basic
 /-!
 
 # Momentum vector operator
@@ -21,33 +23,67 @@ open Constants
 open Space
 open ContDiff SchwartzMap
 
+variable {d : ℕ} (i : Fin d)
+
 /-- Component `i` of the momentum operator is the continuous linear map
 from `𝓢(Space d, ℂ)` to itself which maps `ψ` to `-iℏ ∂ᵢψ`. -/
-def momentumOperator {d : ℕ} (i : Fin d) : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
+def momentumOperator : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
   (- Complex.I * ℏ) • (SchwartzMap.evalCLM ℂ (Space d) ℂ (basis i)) ∘L
     (SchwartzMap.fderivCLM ℂ (Space d) ℂ)
 
 @[inherit_doc momentumOperator]
 macro "𝐩[" i:term "]" : term => `(momentumOperator $i)
 
-lemma momentumOperator_apply_fun {d : ℕ} (i : Fin d) (ψ : 𝓢(Space d, ℂ)) :
+lemma momentumOperator_apply_fun (ψ : 𝓢(Space d, ℂ)) :
     𝐩[i] ψ = (- Complex.I * ℏ) • ∂[i] ψ := rfl
 
-lemma momentumOperator_apply {d : ℕ} (i : Fin d) (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
+@[simp]
+lemma momentumOperator_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
     𝐩[i] ψ x = - Complex.I * ℏ * ∂[i] ψ x := rfl
 
 /-- The square of the momentum operator, `𝐩² ≔ ∑ᵢ 𝐩ᵢ∘𝐩ᵢ`. -/
-def momentumOperatorSqr {d : ℕ} : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) := ∑ i, 𝐩[i] ∘L 𝐩[i]
+def momentumOperatorSqr : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) := ∑ i, 𝐩[i] ∘L 𝐩[i]
 
 @[inherit_doc momentumOperatorSqr]
 notation "𝐩²" => momentumOperatorSqr
 
-lemma momentumOperatorSqr_apply {d : ℕ} (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
+lemma momentumOperatorSqr_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
     𝐩² ψ x = ∑ i, 𝐩[i] (𝐩[i] ψ) x := by
   dsimp only [momentumOperatorSqr]
   rw [← SchwartzMap.coe_coeHom]
   simp only [ContinuousLinearMap.coe_sum', ContinuousLinearMap.coe_comp', Finset.sum_apply,
     Function.comp_apply, map_sum]
+
+/-!
+## Unbounded momentum operators
+-/
+
+open SpaceDHilbertSpace
+
+/-- The momentum operators defined on the Schwartz submodule. -/
+def momentumOperatorSchwartz : schwartzSubmodule d →ₗ[ℂ] schwartzSubmodule d :=
+  (schwartzEquiv (d := d)) ∘ₗ 𝐩[i].toLinearMap ∘ₗ (schwartzEquiv (d := d)).symm
+
+@[sorryful]
+lemma momentumOperatorSchwartz_isSymmetric : (momentumOperatorSchwartz i).IsSymmetric := by
+  intro ψ ψ'
+  obtain ⟨f, rfl⟩ := schwartzEquiv_exists ψ
+  obtain ⟨f', rfl⟩ := schwartzEquiv_exists ψ'
+  unfold momentumOperatorSchwartz
+  simp only [LinearMap.coe_comp, LinearEquiv.coe_coe, ContinuousLinearMap.coe_coe,
+    Function.comp_apply, LinearEquiv.symm_apply_apply, schwartzEquiv_inner, momentumOperator_apply,
+    neg_mul, map_neg, map_mul, Complex.conj_I, Complex.conj_ofReal, neg_neg, mul_neg]
+  -- Need integration by parts and `starRingEnd ∂[i] = ∂[i] starRingEnd`:
+  -- ⊢ ∫ (x : Space d), Complex.I * ↑↑ℏ * (starRingEnd ℂ) (Space.deriv i (⇑f) x) * f' x =
+  -- ∫ (x : Space d), -((starRingEnd ℂ) (f x) * (Complex.I * ↑↑ℏ * Space.deriv i (⇑f') x))
+  sorry
+
+/-- The symmetric momentum unbounded operators with domain the Schwartz submodule
+  of the Hilbert space. -/
+@[sorryful]
+def momentumUnboundedOperator : UnboundedOperator (SpaceDHilbertSpace d) :=
+  UnboundedOperator.ofSymmetric (hE := schwartzSubmodule_dense) (momentumOperatorSchwartz i)
+    (momentumOperatorSchwartz_isSymmetric i)
 
 end
 end QuantumMechanics

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -15,6 +15,18 @@ In this module we define:
 - The momentum operator on Schwartz maps, component-wise.
 - The momentum squared operator on Schwartz maps.
 
+
+In this module we define:
+- `momentumOperator i` acting on Schwartz maps `𝓢(Space d, ℂ)` as `-Iℏ∂ᵢ`.
+- `momentumOperatorSqr` acting on Schwartz maps `𝓢(Space d, ℂ)` as `∑ᵢ 𝐩[i]∘𝐩[i]`.
+- `momentumUnboundedOperator i`, a symmetric unbounded operator acting on the Schwartz submodule
+  of the Hilbert space `SpaceDHilbertSpace d`.
+
+We also introduce the following notation:
+- `𝐩[i]` for `momentumOperator i`
+- `𝐩²` for `momentumOperatorSqr`
+
+
 -/
 
 namespace QuantumMechanics

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -68,7 +68,7 @@ open SpaceDHilbertSpace
 
 /-- The momentum operators defined on the Schwartz submodule. -/
 def momentumOperatorSchwartz : schwartzSubmodule d →ₗ[ℂ] schwartzSubmodule d :=
-  (schwartzEquiv (d := d)) ∘ₗ 𝐩[i].toLinearMap ∘ₗ (schwartzEquiv (d := d)).symm
+  schwartzEquiv.toLinearMap ∘ₗ 𝐩[i].toLinearMap ∘ₗ schwartzEquiv.symm.toLinearMap
 
 @[sorryful]
 lemma momentumOperatorSchwartz_isSymmetric : (momentumOperatorSchwartz i).IsSymmetric := by
@@ -88,7 +88,7 @@ lemma momentumOperatorSchwartz_isSymmetric : (momentumOperatorSchwartz i).IsSymm
   of the Hilbert space. -/
 @[sorryful]
 def momentumUnboundedOperator : UnboundedOperator (SpaceDHilbertSpace d) :=
-  UnboundedOperator.ofSymmetric (hE := schwartzSubmodule_dense) (momentumOperatorSchwartz i)
+  UnboundedOperator.ofSymmetric (hE := schwartzSubmodule_dense d) (momentumOperatorSchwartz i)
     (momentumOperatorSchwartz_isSymmetric i)
 
 end

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -73,8 +73,8 @@ def momentumOperatorSchwartz : schwartzSubmodule d →ₗ[ℂ] schwartzSubmodule
 @[sorryful]
 lemma momentumOperatorSchwartz_isSymmetric : (momentumOperatorSchwartz i).IsSymmetric := by
   intro ψ ψ'
-  obtain ⟨f, rfl⟩ := schwartzEquiv_exists ψ
-  obtain ⟨f', rfl⟩ := schwartzEquiv_exists ψ'
+  obtain ⟨f, rfl⟩ := schwartzEquiv.surjective ψ
+  obtain ⟨f', rfl⟩ := schwartzEquiv.surjective ψ'
   unfold momentumOperatorSchwartz
   simp only [LinearMap.coe_comp, LinearEquiv.coe_coe, ContinuousLinearMap.coe_coe,
     Function.comp_apply, LinearEquiv.symm_apply_apply, schwartzEquiv_inner, momentumOperator_apply,

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -145,8 +145,7 @@ lemma positionOperatorSqr_eq {ε : ℝ} (hε : 0 < ε) : ∑ i, 𝐱[i] ∘L �
 ## Unbounded position operators
 -/
 
-open SpaceDHilbertSpace UnboundedOperator
-open MeasureTheory
+open SpaceDHilbertSpace
 
 /-- The position operators defined on the Schwartz submodule. -/
 def positionOperatorSchwartz : schwartzSubmodule d →ₗ[ℂ] schwartzSubmodule d :=

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -11,8 +11,19 @@ import PhysLean.SpaceAndTime.Space.Derivatives.Basic
 # Position operators
 
 In this module we define:
-- The position vector operator on Schwartz maps, component-wise.
-- The (regularized) real powers of the radius operator on Schwartz maps.
+- `positionOperator i` acting on Schwartz maps `𝓢(Space d, ℂ)` by multiplication by `xᵢ`.
+- `radiusRegPowOperator ε s` acting on Schwartz maps `𝓢(Space d, ℂ)` by multiplication
+  by `(‖x‖² + ε²)^(s/2)`, a smooth regularization of `‖x‖ˢ`.
+- `positionUnboundedOperator i`, a symmetric unbounded operator acting on the Schwartz submodule
+  of the Hilbert space `SpaceDHilbertSpace d`.
+- `radiusRegPowUnboundedOperator ε s`, a symmetric unbounded operator acting on the Schwartz
+  submodule of the Hilbert space `SpaceDHilbertSpace d`. For `s ≤ 0` this operator is bounded
+  (by `ε⁻ˢ`) and has natural domain the entire Hilbert space, but for uniformity we use the same
+  domain for all `s`.
+
+We also introduce the following notation:
+- `𝐱[i]` for `positionOperator i`
+- `𝐫[ε,s]` for `radiusRegPowOperator ε s`
 
 -/
 

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -153,8 +153,8 @@ def positionOperatorSchwartz : schwartzSubmodule d →ₗ[ℂ] schwartzSubmodule
 
 lemma positionOperatorSchwartz_isSymmetric : (positionOperatorSchwartz i).IsSymmetric := by
   intro ψ ψ'
-  obtain ⟨_, rfl⟩ := schwartzEquiv_exists ψ
-  obtain ⟨_, rfl⟩ := schwartzEquiv_exists ψ'
+  obtain ⟨_, rfl⟩ := schwartzEquiv.surjective ψ
+  obtain ⟨_, rfl⟩ := schwartzEquiv.surjective ψ'
   unfold positionOperatorSchwartz
   simp only [LinearMap.coe_comp, LinearEquiv.coe_coe, comp_apply, schwartzEquiv_inner]
   congr with x
@@ -176,8 +176,8 @@ def radiusRegPowOperatorSchwartz (ε s : ℝ) : schwartzSubmodule d →ₗ[ℂ] 
 lemma radiusRegPowOperatorSchwartz_isSymmetric (ε s : ℝ) (hε : 0 < ε) :
     (radiusRegPowOperatorSchwartz (d := d) ε s).IsSymmetric := by
   intro ψ ψ'
-  obtain ⟨_, rfl⟩ := schwartzEquiv_exists ψ
-  obtain ⟨_, rfl⟩ := schwartzEquiv_exists ψ'
+  obtain ⟨_, rfl⟩ := schwartzEquiv.surjective ψ
+  obtain ⟨_, rfl⟩ := schwartzEquiv.surjective ψ'
   unfold radiusRegPowOperatorSchwartz
   simp only [LinearMap.coe_comp, LinearEquiv.coe_coe, comp_apply, schwartzEquiv_inner]
   congr with x

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -149,7 +149,7 @@ open SpaceDHilbertSpace
 
 /-- The position operators defined on the Schwartz submodule. -/
 def positionOperatorSchwartz : schwartzSubmodule d →ₗ[ℂ] schwartzSubmodule d :=
-  (schwartzEquiv (d := d)) ∘ₗ 𝐱[i].toLinearMap ∘ₗ (schwartzEquiv (d := d)).symm
+  schwartzEquiv.toLinearMap ∘ₗ 𝐱[i].toLinearMap ∘ₗ schwartzEquiv.symm.toLinearMap
 
 lemma positionOperatorSchwartz_isSymmetric : (positionOperatorSchwartz i).IsSymmetric := by
   intro ψ ψ'
@@ -165,13 +165,12 @@ lemma positionOperatorSchwartz_isSymmetric : (positionOperatorSchwartz i).IsSymm
 /-- The symmetric position unbounded operators with domain the Schwartz submodule
   of the Hilbert space. -/
 def positionUnboundedOperator : UnboundedOperator (SpaceDHilbertSpace d) :=
-  UnboundedOperator.ofSymmetric (hE := schwartzSubmodule_dense) (positionOperatorSchwartz i)
+  UnboundedOperator.ofSymmetric (hE := schwartzSubmodule_dense d) (positionOperatorSchwartz i)
     (positionOperatorSchwartz_isSymmetric i)
 
 /-- The (regularized) radius operators defined on the Schwartz submodule. -/
 def radiusRegPowOperatorSchwartz (ε s : ℝ) : schwartzSubmodule d →ₗ[ℂ] schwartzSubmodule d :=
-  (schwartzEquiv (d := d)) ∘ₗ (radiusRegPowOperator (d := d) ε s).toLinearMap ∘ₗ
-  (schwartzEquiv (d := d)).symm
+  schwartzEquiv.toLinearMap ∘ₗ 𝐫[ε,s].toLinearMap ∘ₗ schwartzEquiv.symm.toLinearMap
 
 lemma radiusRegPowOperatorSchwartz_isSymmetric (ε s : ℝ) (hε : 0 < ε) :
     (radiusRegPowOperatorSchwartz (d := d) ε s).IsSymmetric := by
@@ -189,7 +188,7 @@ lemma radiusRegPowOperatorSchwartz_isSymmetric (ε s : ℝ) (hε : 0 < ε) :
   of the Hilbert space. -/
 def radiusRegPowUnboundedOperator (ε s : ℝ) (hε : 0 < ε) :
     UnboundedOperator (SpaceDHilbertSpace d) :=
-  UnboundedOperator.ofSymmetric (hE := schwartzSubmodule_dense) (radiusRegPowOperatorSchwartz ε s)
+  UnboundedOperator.ofSymmetric (hE := schwartzSubmodule_dense d) (radiusRegPowOperatorSchwartz ε s)
     (radiusRegPowOperatorSchwartz_isSymmetric ε s hε)
 
 end

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gregory J. Loges
 -/
 import PhysLean.Mathematics.InnerProductSpace.Submodule
-import PhysLean.QuantumMechanics.DDimensions.SpaceDHilbertSpace.SchwartzSubmodule
 /-!
 
 # Unbounded operators

--- a/PhysLean/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -20,28 +20,44 @@ open MeasureTheory
 open InnerProductSpace
 open SchwartzMap
 
+variable {d : ℕ}
+
 /-- The continuous linear map including Schwartz functions into `SpaceDHilbertSpace d`. -/
-def schwartzIncl {d : ℕ} : 𝓢(Space d, ℂ) →L[ℂ] SpaceDHilbertSpace d := toLpCLM ℂ (E := Space d) ℂ 2
-
-lemma schwartzIncl_injective {d : ℕ} : Function.Injective (schwartzIncl (d := d)) :=
-  injective_toLp (E := Space d) 2
-
-lemma schwartzIncl_coe_ae {d : ℕ} (f : 𝓢(Space d, ℂ)) : f.1 =ᵐ[volume] (schwartzIncl f) :=
-  (coeFn_toLp f 2).symm
-
-lemma schwartzIncl_inner {d : ℕ} (f g : 𝓢(Space d, ℂ)) :
-    ⟪schwartzIncl f, schwartzIncl g⟫_ℂ = ∫ x : Space d, starRingEnd ℂ (f x) * g x := by
-  apply integral_congr_ae
-  filter_upwards [schwartzIncl_coe_ae f, schwartzIncl_coe_ae g] with _ hf hg
-  rw [← hf, ← hg, RCLike.inner_apply, mul_comm]
-  rfl
+def schwartzIncl : 𝓢(Space d, ℂ) →L[ℂ] SpaceDHilbertSpace d := toLpCLM ℂ (E := Space d) ℂ 2
 
 /-- The submodule of `SpaceDHilbertSpace d` consisting of Schwartz functions. -/
 abbrev schwartzSubmodule (d : ℕ) := (schwartzIncl (d := d)).range
 
-lemma schwartzSubmodule_dense {d : ℕ} :
+instance : CoeFun (schwartzSubmodule d) fun _ ↦ Space d → ℂ := ⟨fun ψ ↦ ψ.val⟩
+
+@[simp]
+lemma val_eq_coe (ψ : schwartzSubmodule d) (x : Space d) : ψ.val x = ψ x := rfl
+
+lemma schwartzSubmodule_dense :
     Dense (schwartzSubmodule d : Set (SpaceDHilbertSpace d)) :=
   denseRange_toLpCLM ENNReal.top_ne_ofNat.symm
+
+/-- The linear equivalence between the Schwartz functions `𝓢(Space d, ℂ)`
+  and the Schwartz submodule of `SpaceDHilbertSpace d`. -/
+def schwartzEquiv : 𝓢(Space d, ℂ) ≃ₗ[ℂ] schwartzSubmodule d :=
+  LinearEquiv.ofInjective schwartzIncl.toLinearMap (injective_toLp (E := Space d) 2)
+
+variable (f g : 𝓢(Space d, ℂ))
+
+lemma schwartzEquiv_coe_ae : (schwartzEquiv f) =ᵐ[volume] f := coeFn_toLp f 2 volume
+
+lemma schwartzEquiv_inner :
+    ⟪schwartzEquiv f, schwartzEquiv g⟫_ℂ = ∫ x : Space d, starRingEnd ℂ (f x) * g x := by
+  apply integral_congr_ae
+  filter_upwards [schwartzEquiv_coe_ae f, schwartzEquiv_coe_ae g] with _ hf hg
+  simp [hf, hg, mul_comm]
+
+lemma schwartzEquiv_ae_eq (h : schwartzEquiv f =ᵐ[volume] schwartzEquiv g) : f = g :=
+  (EmbeddingLike.apply_eq_iff_eq _).mp (SetLike.coe_eq_coe.mp (ext_iff.mpr h))
+
+lemma schwartzEquiv_exists (ψ : schwartzSubmodule d) : ∃ f, ψ = schwartzEquiv f := by
+  use schwartzEquiv.symm ψ
+  exact (LinearEquiv.apply_symm_apply _ _).symm
 
 end
 end SpaceDHilbertSpace

--- a/PhysLean/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -33,7 +33,7 @@ instance : CoeFun (schwartzSubmodule d) fun _ ↦ Space d → ℂ := ⟨fun ψ �
 @[simp]
 lemma val_eq_coe (ψ : schwartzSubmodule d) (x : Space d) : ψ.val x = ψ x := rfl
 
-lemma schwartzSubmodule_dense :
+lemma schwartzSubmodule_dense (d : ℕ) :
     Dense (schwartzSubmodule d : Set (SpaceDHilbertSpace d)) :=
   denseRange_toLpCLM ENNReal.top_ne_ofNat.symm
 

--- a/PhysLean/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -55,10 +55,6 @@ lemma schwartzEquiv_inner :
 lemma schwartzEquiv_ae_eq (h : schwartzEquiv f =ᵐ[volume] schwartzEquiv g) : f = g :=
   (EmbeddingLike.apply_eq_iff_eq _).mp (SetLike.coe_eq_coe.mp (ext_iff.mpr h))
 
-lemma schwartzEquiv_exists (ψ : schwartzSubmodule d) : ∃ f, ψ = schwartzEquiv f := by
-  use schwartzEquiv.symm ψ
-  exact (LinearEquiv.apply_symm_apply _ _).symm
-
 end
 end SpaceDHilbertSpace
 end QuantumMechanics


### PR DESCRIPTION
Continues on from #957 and makes progress on #851.

Introduces `schwartzEquiv`, the `LinearEquiv` between Schwartz functions and their image in the Hilbert space, along with some basic properties. This bijection is then used to define three symmetric unbounded operators with Schwartz submodule for domain, using the previously-defined continuous linear maps on Schwartz functions. These are the position and momentum unbounded operators, defined component-wise, and the (regularized) radius operator to any real power.

There remains one sorry which will have to be revisited. Showing that the momentum operator on Schwartz functions is symmetric requires two results for `Space.deriv`: integration-by-parts over all of `Space d` and commutation through complex conjugation.