### PR TITLE
golf: QM commutators

### DIFF
--- a/PhysLean/Mathematics/KroneckerDelta.lean
+++ b/PhysLean/Mathematics/KroneckerDelta.lean
@@ -49,11 +49,6 @@ lemma sum_kroneckerDelta' [AddCommGroup M] [Module ℂ M]
 
 lemma sum_kroneckerDelta_self [AddCommGroup M] [Module ℂ M] (c : ℂ) (f : M) :
     ∑ (i : Fin d), (c * δ[i,i]) • f = (d * c) • f := by
-  simp only [kroneckerDelta_self, Complex.ofReal_one, mul_one, Finset.sum_const, Finset.card_univ,
-    Fintype.card_fin]
-  induction d with
-  | zero => simp
-  | succ n hn =>
-    rw [succ_nsmul, hn, ← add_smul, Nat.cast_add_one, add_mul, one_mul]
+  simp [kroneckerDelta_self, ← Nat.cast_smul_eq_nsmul ℂ, smul_smul]
 
 end KroneckerDelta

--- a/PhysLean/Mathematics/KroneckerDelta.lean
+++ b/PhysLean/Mathematics/KroneckerDelta.lean
@@ -41,4 +41,8 @@ lemma sum_kroneckerDelta [AddCommGroup M] [Module ℂ M]
     · simp [if_neg hne]
   simp [this]
 
+lemma sum_kroneckerDelta' [AddCommGroup M] [Module ℂ M]
+    (c : ℂ) (i : Fin d) (f : Fin d → M) : ∑ j, (c * δ[j,i]) • f j = c • f i := by
+  simp [kroneckerDelta_symm, sum_kroneckerDelta]
+
 end KroneckerDelta

--- a/PhysLean/Mathematics/KroneckerDelta.lean
+++ b/PhysLean/Mathematics/KroneckerDelta.lean
@@ -6,7 +6,7 @@ Authors: Gregory J. Loges
 import Mathlib.Algebra.BigOperators.Group.Finset.Piecewise
 import Mathlib.Algebra.Module.Basic
 import Mathlib.Data.Complex.Basic
-import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Card
 import PhysLean.Meta.TODO.Basic
 /-!
 
@@ -46,5 +46,14 @@ lemma sum_kroneckerDelta [AddCommGroup M] [Module ℂ M]
 lemma sum_kroneckerDelta' [AddCommGroup M] [Module ℂ M]
     (c : ℂ) (i : Fin d) (f : Fin d → M) : ∑ j, (c * δ[j,i]) • f j = c • f i := by
   simp [kroneckerDelta_symm, sum_kroneckerDelta]
+
+lemma sum_kroneckerDelta_self [AddCommGroup M] [Module ℂ M] (c : ℂ) (f : M) :
+    ∑ (i : Fin d), (c * δ[i,i]) • f = (d * c) • f := by
+  simp only [kroneckerDelta_self, Complex.ofReal_one, mul_one, Finset.sum_const, Finset.card_univ,
+    Fintype.card_fin]
+  induction d with
+  | zero => simp
+  | succ n hn =>
+    rw [succ_nsmul, hn, ← add_smul, Nat.cast_add_one, add_mul, one_mul]
 
 end KroneckerDelta

--- a/PhysLean/Mathematics/KroneckerDelta.lean
+++ b/PhysLean/Mathematics/KroneckerDelta.lean
@@ -25,6 +25,8 @@ def kroneckerDelta (i j : Fin d) : ℝ := if (i = j) then 1 else 0
 @[inherit_doc kroneckerDelta]
 notation "δ[" i "," j "]" => kroneckerDelta i j
 
+lemma kroneckerDelta_eq (i j : Fin d) : δ[i,j] = if (i = j) then 1 else 0 := rfl
+
 lemma kroneckerDelta_symm (i j : Fin d) : δ[i,j] = δ[j,i] :=
   ite_cond_congr (Eq.propIntro Eq.symm Eq.symm)
 

--- a/PhysLean/Mathematics/KroneckerDelta.lean
+++ b/PhysLean/Mathematics/KroneckerDelta.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 Gregory J. Loges. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gregory J. Loges
 -/
-import Mathlib.Algebra.Ring.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset.Piecewise
+import Mathlib.Algebra.Module.Basic
+import Mathlib.Data.Complex.Basic
+import Mathlib.Data.Fintype.Basic
 import PhysLean.Meta.TODO.Basic
 /-!
 
@@ -12,22 +15,30 @@ import PhysLean.Meta.TODO.Basic
 This file defines the Kronecker delta, `δ[i,j] ≔ if (i = j) then 1 else 0`.
 
 -/
-TODO "YVABB" "Build functionality for working with sums involving Kronecker deltas."
+TODO "YVABB" "Build full API for working with sums involving Kronecker deltas."
 
 namespace KroneckerDelta
 
 /-- The Kronecker delta function, `ite (i = j) 1 0`. -/
-def kroneckerDelta [Ring R] (i j : Fin d) : R := if (i = j) then 1 else 0
+def kroneckerDelta (i j : Fin d) : ℝ := if (i = j) then 1 else 0
 
 @[inherit_doc kroneckerDelta]
-macro "δ[" i:term "," j:term "]" : term => `(kroneckerDelta $i $j)
+notation "δ[" i "," j "]" => kroneckerDelta i j
 
-lemma kroneckerDelta_symm [Ring R] (i j : Fin d) :
-    kroneckerDelta (R := R) i j = kroneckerDelta j i :=
+lemma kroneckerDelta_symm (i j : Fin d) : δ[i,j] = δ[j,i] :=
   ite_cond_congr (Eq.propIntro Eq.symm Eq.symm)
 
-lemma kroneckerDelta_self [Ring R] : ∀ i : Fin d, kroneckerDelta (R := R) i i = 1 := by
-  intro i
-  exact if_pos rfl
+lemma kroneckerDelta_self {i : Fin d} : δ[i,i] = 1 := if_pos rfl
+
+lemma kroneckerDelta_diff {i j : Fin d} (h : i ≠ j) : δ[i,j] = 0 := if_neg h
+
+lemma sum_kroneckerDelta [AddCommGroup M] [Module ℂ M]
+    (c : ℂ) (i : Fin d) (f : Fin d → M) : ∑ j, (c * δ[i,j]) • f j = c • f i := by
+  dsimp [kroneckerDelta]
+  have (j : Fin d) : c * Complex.ofReal (ite (i = j) 1 0) = ite (i = j) c 0 := by
+    rcases eq_or_ne i j with (rfl | hne)
+    · simp
+    · simp [if_neg hne]
+  simp [this]
 
 end KroneckerDelta

--- a/PhysLean/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -57,14 +57,20 @@ lemma lrlOperator_eq (i : Fin H.d) :
   rw [← ContinuousLinearMap.comp_finset_sum]
   simp only [← comp_assoc, ← ContinuousLinearMap.finset_sum_comp]
   rw [← momentumOperatorSqr]
-  unfold kroneckerDelta
-  simp only [mul_ite_zero, ite_zero_smul, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte,
-    Finset.sum_const, Finset.card_univ, Fintype.card_fin, ← smul_assoc]
-  ext ψ x
-  simp only [mul_one, nsmul_eq_mul, smul_add, ContinuousLinearMap.add_apply, coe_smul', coe_sub',
-    coe_comp', Pi.smul_apply, Pi.sub_apply, Function.comp_apply, SchwartzMap.add_apply,
-    SchwartzMap.smul_apply, SchwartzMap.sub_apply, smul_eq_mul, Complex.real_smul,
-    Complex.ofReal_inv, Complex.ofReal_ofNat]
+  simp only [sum_kroneckerDelta]
+  have : (∑ j : Fin H.d, (Complex.I * ℏ * δ[j,j]) • 𝐩[i]) = (H.d * Complex.I * ℏ) • 𝐩[i] := by
+    ext ψ x
+    simp only [kroneckerDelta_self, ContinuousLinearMap.sum_apply, SchwartzMap.sum_apply,
+      ContinuousLinearMap.smul_apply, SchwartzMap.smul_apply, smul_eq_mul]
+    simp only [Complex.ofReal_one, mul_one, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+      nsmul_eq_mul]
+    ring
+  rw [this]
+  ext
+  simp only [smul_add, ContinuousLinearMap.add_apply, coe_smul', coe_sub', coe_comp', coe_sum',
+    Pi.smul_apply, Pi.sub_apply, Function.comp_apply, Finset.sum_apply, SchwartzMap.add_apply,
+    SchwartzMap.smul_apply, SchwartzMap.sub_apply, smul_eq_mul, SchwartzMap.sum_apply,
+    Complex.real_smul, Complex.ofReal_inv, Complex.ofReal_ofNat]
   ring
 
 /-- `𝐀(ε)ᵢ = 𝐋ᵢⱼ𝐩ⱼ + ½iℏ(d-1)𝐩ᵢ - mk·𝐫(ε)⁻¹𝐱ᵢ` -/
@@ -76,14 +82,20 @@ lemma lrlOperator_eq' (i : Fin H.d) : H.lrlOperator ε i = ∑ j, 𝐋[i,j] ∘L
     enter [2, 2, j]
     rw [comp_eq_comp_sub_commute 𝐩[j] 𝐋[i,j], angularMomentum_commutation_momentum]
   repeat rw [Finset.sum_add_distrib, Finset.sum_sub_distrib, Finset.sum_sub_distrib]
-  unfold kroneckerDelta
-  ext ψ x
-  simp only [ContinuousLinearMap.add_apply, coe_smul', coe_sum', coe_comp', Pi.smul_apply,
-    Finset.sum_apply, Function.comp_apply, coe_sub', Pi.sub_apply, SchwartzMap.add_apply,
-    SchwartzMap.smul_apply, SchwartzMap.sum_apply, SchwartzMap.sub_apply]
-  simp only [mul_ite, mul_one, mul_zero, smul_eq_mul, ite_mul, zero_mul, Finset.sum_ite_eq,
-    Finset.mem_univ, ↓reduceIte, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
-    nsmul_eq_mul, smul_add, Complex.real_smul, Complex.ofReal_inv, Complex.ofReal_ofNat]
+  simp only [sum_kroneckerDelta]
+  have : (∑ j : Fin H.d, (Complex.I * ℏ * δ[j,j]) • 𝐩[i]) = (H.d * Complex.I * ℏ) • 𝐩[i] := by
+    ext ψ x
+    simp only [kroneckerDelta_self, ContinuousLinearMap.sum_apply, SchwartzMap.sum_apply,
+      ContinuousLinearMap.smul_apply, SchwartzMap.smul_apply, smul_eq_mul]
+    simp only [Complex.ofReal_one, mul_one, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+      nsmul_eq_mul]
+    ring
+  rw [this]
+  ext
+  simp only [smul_add, ContinuousLinearMap.add_apply, coe_smul', coe_sub', coe_sum', coe_comp',
+    Pi.smul_apply, Pi.sub_apply, Finset.sum_apply, Function.comp_apply, SchwartzMap.add_apply,
+    SchwartzMap.smul_apply, SchwartzMap.sub_apply, SchwartzMap.sum_apply, smul_eq_mul,
+    Complex.real_smul, Complex.ofReal_inv, Complex.ofReal_ofNat]
   ring
 
 /-- `𝐀(ε)ᵢ = 𝐩ⱼ𝐋ᵢⱼ - ½iℏ(d-1)𝐩ᵢ - mk·𝐫(ε)⁻¹𝐱ᵢ` -/
@@ -95,15 +107,20 @@ lemma lrlOperator_eq'' (i : Fin H.d) : H.lrlOperator ε i = ∑ j, 𝐩[j] ∘L 
     enter [2, 2, j]
     rw [comp_eq_comp_add_commute 𝐋[i,j] 𝐩[j], angularMomentum_commutation_momentum]
   rw [Finset.sum_add_distrib, Finset.sum_add_distrib, Finset.sum_sub_distrib]
+  simp only [sum_kroneckerDelta]
+  have : (∑ j : Fin H.d, (Complex.I * ℏ * δ[j,j]) • 𝐩[i]) = (H.d * Complex.I * ℏ) • 𝐩[i] := by
+    ext ψ x
+    simp only [kroneckerDelta_self, ContinuousLinearMap.sum_apply, SchwartzMap.sum_apply,
+      ContinuousLinearMap.smul_apply, SchwartzMap.smul_apply, smul_eq_mul]
+    simp only [Complex.ofReal_one, mul_one, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+      nsmul_eq_mul]
+    ring
+  rw [this]
   ext ψ x
-  unfold kroneckerDelta
-  simp only [ContinuousLinearMap.add_apply, coe_smul', coe_sum', coe_comp',
-    Pi.smul_apply, Finset.sum_apply, Function.comp_apply, coe_sub', Pi.sub_apply,
-    SchwartzMap.add_apply, SchwartzMap.smul_apply, SchwartzMap.sum_apply, Complex.real_smul,
-    Complex.ofReal_inv, Complex.ofReal_ofNat, SchwartzMap.sub_apply]
-  simp only [mul_ite, mul_one, mul_zero, smul_eq_mul, ite_mul, zero_mul, Finset.sum_ite_eq,
-    Finset.mem_univ, ↓reduceIte, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
-    nsmul_eq_mul]
+  simp only [smul_add, ContinuousLinearMap.add_apply, coe_smul', coe_sum', coe_comp', Pi.smul_apply,
+    Finset.sum_apply, Function.comp_apply, coe_sub', Pi.sub_apply, SchwartzMap.add_apply,
+    SchwartzMap.smul_apply, SchwartzMap.sum_apply, Complex.real_smul, Complex.ofReal_inv,
+    Complex.ofReal_ofNat, SchwartzMap.sub_apply, smul_eq_mul]
   ring
 
 /-- The operator `𝐱ᵢ𝐩ᵢ` on Schwartz maps. -/
@@ -137,31 +154,17 @@ lemma angularMomentum_commutation_lrl (hε : 0 < ε) (i j k : Fin H.d) :
   simp only [angularMomentum_commutation_angularMomentum, angularMomentum_commutation_momentum,
     angularMomentum_commutation_position, angularMomentum_commutation_radiusRegPow hε]
   simp only [comp_add, comp_sub, add_comp, sub_comp, comp_smul, smul_comp, zero_comp, add_zero]
-  ext ψ x
-  simp only [ContinuousLinearMap.sub_apply, ContinuousLinearMap.smul_apply,
-    ContinuousLinearMap.sum_apply, ContinuousLinearMap.add_apply, ContinuousLinearMap.comp_apply]
-  simp only [SchwartzMap.sub_apply, SchwartzMap.smul_apply, SchwartzMap.sum_apply,
-    SchwartzMap.add_apply, SchwartzMap.smul_apply, smul_eq_mul]
   simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
-  dsimp only [kroneckerDelta]
-  simp only [mul_ite_zero, mul_one, ite_mul, zero_mul, Finset.sum_ite_irrel, Complex.real_smul,
-    Finset.sum_const_zero, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte, smul_add]
-  simp only [angularMomentumOperator_antisymm k _]
-  simp only [mul_sub, mul_add, mul_ite_zero, Finset.mul_sum]
-  simp only [ContinuousLinearMap.neg_apply, map_neg, SchwartzMap.neg_apply]
-
-  rcases eq_or_ne i k with (⟨_, rfl⟩ | hik)
-  · simp only [↓reduceIte, angularMomentumOperator_eq_zero]
-    repeat rw [ite_cond_eq_false _ _ (eq_false hij.symm)]
-    simp only [ContinuousLinearMap.zero_apply, SchwartzMap.zero_apply]
-    ring_nf
-  · rcases eq_or_ne j k with (⟨_, rfl⟩ | hjk)
-    · simp only [↓reduceIte]
-      repeat rw [ite_cond_eq_false _ _ (eq_false hij)]
-      ring_nf
-    · repeat rw [ite_cond_eq_false _ _ (eq_false hik)]
-      repeat rw [ite_cond_eq_false _ _ (eq_false hjk)]
-      ring
+  simp only [sum_kroneckerDelta, ← Finset.smul_sum]
+  simp only [angularMomentumOperator_antisymm _ i, angularMomentumOperator_antisymm _ j]
+  ext ψ x
+  simp only [comp_neg, smul_neg, sub_neg_eq_add, neg_comp, smul_add, coe_sub', coe_smul', coe_comp',
+    Pi.sub_apply, ContinuousLinearMap.add_apply, coe_sum', Pi.smul_apply, Finset.sum_apply,
+    Function.comp_apply, ContinuousLinearMap.neg_apply, SchwartzMap.sub_apply,
+    SchwartzMap.add_apply, SchwartzMap.smul_apply, SchwartzMap.sum_apply, smul_eq_mul,
+    Complex.real_smul, Complex.ofReal_inv, Complex.ofReal_ofNat, SchwartzMap.neg_apply,
+    Complex.ofReal_mul]
+  ring
 
 /-- `⁅𝐋ᵢⱼ, 𝐀(ε)²⁆ = 0` -/
 lemma angularMomentum_commutation_lrlSqr (hε : 0 < ε) (i j : Fin H.d) :
@@ -169,8 +172,8 @@ lemma angularMomentum_commutation_lrlSqr (hε : 0 < ε) (i j : Fin H.d) :
   unfold lrlOperatorSqr
   simp only [lie_sum, lie_leibniz, H.angularMomentum_commutation_lrl hε]
   simp only [comp_sub, comp_smul, sub_comp, smul_comp]
-  dsimp only [kroneckerDelta]
-  simp [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+  simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+  simp [sum_kroneckerDelta]
 
 /-- `⁅𝐋², 𝐀(ε)²⁆ = 0` -/
 lemma angularMomentumSqr_commutation_lrlSqr (hε : 0 < ε) :
@@ -195,17 +198,13 @@ To compute the commutator `⁅𝐀ᵢ(ε), 𝐀ⱼ(ε)⁆` we take the following
 
 private lemma positionDotMomentum_commutation_position {d} (i : Fin d) :
     ⁅positionDotMomentum (d := d), 𝐱[i]⁆ = (-Complex.I * ℏ) • 𝐱[i] := by
-  unfold positionDotMomentum
-  simp only [← lie_skew 𝐩[_] _, position_commutation_position, position_commutation_momentum,
-    leibniz_lie, kroneckerDelta, sum_lie, comp_neg, comp_smul]
-  simp
+  dsimp [positionDotMomentum]
+  simp [sum_lie, leibniz_lie, ← lie_skew 𝐩[_] _, position_commutation_momentum, sum_kroneckerDelta]
 
 private lemma positionDotMomentum_commutation_momentum {d} (i : Fin d) :
     ⁅positionDotMomentum (d := d), 𝐩[i]⁆ = (Complex.I * ℏ) • 𝐩[i] := by
-  unfold positionDotMomentum
-  simp only [momentum_commutation_momentum, position_commutation_momentum, kroneckerDelta,
-    sum_lie, leibniz_lie, smul_comp]
-  simp
+  dsimp [positionDotMomentum]
+  simp [sum_lie, leibniz_lie, position_commutation_momentum, sum_kroneckerDelta']
 
 private lemma positionDotMomentum_commutation_momentumSqr {d} :
     ⁅positionDotMomentum (d := d), momentumOperatorSqr (d := d)⁆ = (2 * Complex.I * ℏ) • 𝐩² := by
@@ -485,13 +484,12 @@ private lemma pSqr_comm_rx (hε : 0 < ε) (i : Fin H.d) :
   rw [← lie_skew, radiusRegPow_commutation_momentumSqr hε]
   ext ψ x
   simp only [comp_neg, comp_smulₛₗ, RingHom.id_apply, Complex.ofReal_neg, Complex.ofReal_one,
-    mul_neg, mul_one, neg_mul, neg_smul, one_mul, neg_add_rev, neg_neg, add_comp, smul_comp,
-    sub_comp, ContinuousLinearMap.add_apply, ContinuousLinearMap.neg_apply, coe_smul', coe_comp',
-    Pi.smul_apply, Function.comp_apply, coe_sub', Pi.sub_apply, coe_sum', Finset.sum_apply, map_sum,
+    mul_neg, mul_one, neg_mul, neg_smul, one_mul, neg_sub, sub_neg_eq_add, neg_add_rev, neg_neg,
+    add_comp, neg_comp, smul_comp, ContinuousLinearMap.add_apply, ContinuousLinearMap.neg_apply,
+    coe_smul', coe_comp', Pi.smul_apply, Function.comp_apply, coe_sum', Finset.sum_apply, map_sum,
     SchwartzMap.add_apply, SchwartzMap.neg_apply, SchwartzMap.smul_apply, smul_eq_mul,
-    SchwartzMap.sub_apply, Complex.real_smul, Complex.ofReal_sub, Complex.ofReal_add,
-    Complex.ofReal_natCast, Complex.ofReal_ofNat, Complex.ofReal_mul, Complex.ofReal_pow,
-    SchwartzMap.sum_apply]
+    Complex.real_smul, Complex.ofReal_mul, Complex.ofReal_pow, Complex.ofReal_sub,
+    Complex.ofReal_ofNat, Complex.ofReal_add, Complex.ofReal_natCast, SchwartzMap.sum_apply]
   ring_nf
 
 private lemma rr_comm_pL_Lp (hε : 0 < ε) (i : Fin H.d) :
@@ -546,7 +544,7 @@ private lemma xL_Lx_eq (hε : 0 < ε) (i : Fin H.d) : ∑ j, (𝐱[j] ∘L 𝐋[
         simp only [comp_add, comp_smulₛₗ, RingHom.id_apply, comp_id, comp_sub, coe_sub', coe_comp',
           coe_smul', Pi.sub_apply, ContinuousLinearMap.add_apply, Function.comp_apply,
           Pi.smul_apply, SchwartzMap.sub_apply, SchwartzMap.add_apply, SchwartzMap.smul_apply,
-          smul_eq_mul, mul_one, Complex.real_smul, Complex.ofReal_ofNat]
+          smul_eq_mul, Complex.ofReal_one, mul_one, Complex.real_smul, Complex.ofReal_ofNat]
         ring
       _ = 𝐱[j] ∘L 𝐩[j] ∘L 𝐱[i] + 𝐱[j] ∘L 𝐱[i] ∘L 𝐩[j] - (2 : ℝ) • 𝐱[j] ∘L 𝐱[j] ∘L 𝐩[i]
           + (2 * Complex.I * ℏ * δ[i,j]) • 𝐱[j] - (Complex.I * ℏ) • 𝐱[i] := by
@@ -563,16 +561,15 @@ private lemma xL_Lx_eq (hε : 0 < ε) (i : Fin H.d) : ∑ j, (𝐱[j] ∘L 𝐋[
         ring
   simp only [Finset.sum_sub_distrib, Finset.sum_add_distrib, ← Finset.smul_sum, ← finset_sum_comp]
   rw [positionOperatorSqr_eq hε, sub_comp, smul_comp, id_comp]
+  simp only [sum_kroneckerDelta]
 
-  unfold kroneckerDelta
   ext ψ x
   simp only [ContinuousLinearMap.sub_apply, ContinuousLinearMap.add_apply,
     ContinuousLinearMap.smul_apply, ContinuousLinearMap.sum_apply, SchwartzMap.sub_apply,
     SchwartzMap.add_apply, SchwartzMap.smul_apply, SchwartzMap.sum_apply]
   simp only [coe_comp', coe_sum', Function.comp_apply, Finset.sum_apply, SchwartzMap.sum_apply,
-    Complex.real_smul, Complex.ofReal_ofNat, Complex.ofReal_pow, mul_ite, mul_one, mul_zero,
-    smul_eq_mul, ite_mul, zero_mul, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte,
-    Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul, Complex.ofReal_mul]
+    Complex.real_smul, Complex.ofReal_ofNat, Complex.ofReal_pow, smul_eq_mul, Finset.sum_const,
+    Finset.card_univ, Fintype.card_fin, nsmul_eq_mul, Complex.ofReal_mul]
   ring
 
 /-- `⁅𝐇(ε), 𝐀(ε)ᵢ⁆ = iℏkε²(¾𝐫(ε)⁻⁵(𝐱ⱼ𝐋ᵢⱼ + 𝐋ᵢⱼ𝐱ⱼ) + 3iℏ/2 𝐫(ε)⁻⁵𝐱ᵢ + 𝐫(ε)⁻³𝐩ᵢ)` -/

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/AngularMomentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/AngularMomentum.lean
@@ -33,7 +33,7 @@ def angularMomentumOperator {d : ℕ} (i j : Fin d) : 𝓢(Space d, ℂ) →L[�
   𝐱[i] ∘L 𝐩[j] - 𝐱[j] ∘L 𝐩[i]
 
 @[inherit_doc angularMomentumOperator]
-macro "𝐋[" i:term "," j:term "]" : term => `(angularMomentumOperator $i $j)
+notation "𝐋[" i "," j "]" => angularMomentumOperator i j
 
 lemma angularMomentumOperator_apply_fun {d : ℕ} (i j : Fin d) (ψ : 𝓢(Space d, ℂ)) :
     𝐋[i,j] ψ = 𝐱[i] (𝐩[j] ψ) - 𝐱[j] (𝐩[i] ψ) := rfl

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -13,7 +13,7 @@ import PhysLean.QuantumMechanics.DDimensions.Operators.AngularMomentum
 
 namespace QuantumMechanics
 noncomputable section
-open Constants
+open Complex Constants
 open KroneckerDelta
 open Bracket
 open ContinuousLinearMap SchwartzMap
@@ -45,6 +45,7 @@ lemma comp_eq_comp_sub_commute (A B : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d,
 -/
 
 /-- Position operators commute: `[xᵢ, xⱼ] = 0`. -/
+@[simp]
 lemma position_commutation_position : ⁅𝐱[i], 𝐱[j]⁆ = 0 := by
   ext
   simp [bracket, positionOperator_apply, ← mul_assoc, mul_comm]
@@ -70,36 +71,27 @@ lemma radiusRegPow_commutation_radiusRegPow (hε : 0 < ε) :
 -/
 
 /-- Momentum operators commute: `[pᵢ, pⱼ] = 0`. -/
-lemma momentum_commutation_momentum {d : ℕ} (i j : Fin d) : ⁅𝐩[i], 𝐩[j]⁆ = 0 := by
-  dsimp only [Bracket.bracket]
+@[simp]
+lemma momentum_commutation_momentum : ⁅𝐩[i], 𝐩[j]⁆ = 0 := by
   ext ψ x
-  simp only [coe_sub', coe_mul, Pi.sub_apply, Function.comp_apply, SchwartzMap.sub_apply,
-    ContinuousLinearMap.zero_apply, SchwartzMap.zero_apply, momentumOperator_apply_fun]
-  rw [Space.deriv_const_smul _ ?_, Space.deriv_const_smul _ ?_]
-  · rw [Space.deriv_commute _ (ψ.smooth _), sub_self]
-  · exact Space.deriv_differentiable (ψ.smooth _) i
-  · exact Space.deriv_differentiable (ψ.smooth _) j
+  have hdiff := Space.deriv_differentiable (ψ.smooth _)
+  calc
+    _ = 𝐩[i] (𝐩[j] ψ) x - 𝐩[j] (𝐩[i] ψ) x := by
+      simp [bracket]
+    _ = (-I * ℏ) ^ 2 • (∂[i] (∂[j] ψ) x - ∂[j] (∂[i] ψ) x) := by
+      simp only [momentumOperator_apply_fun, Space.deriv_const_smul _ (hdiff _), Pi.smul_apply,
+        ← smul_sub, smul_smul, pow_two]
+  simp [Space.deriv_commute _ (ψ.smooth 2)]
 
-lemma momentum_comp_commute {d : ℕ} (i j : Fin d) : 𝐩[i] ∘L 𝐩[j] = 𝐩[j] ∘L 𝐩[i] := by
-  rw [← sub_eq_zero]
-  exact momentum_commutation_momentum i j
+lemma momentum_comp_commute : 𝐩[i] ∘L 𝐩[j] = 𝐩[j] ∘L 𝐩[i] := by
+  rw [comp_eq_comp_add_commute, momentum_commutation_momentum, add_zero]
 
-lemma momentumSqr_commutation_momentum {d : ℕ} (i : Fin d) :
-    ⁅momentumOperatorSqr (d := d), 𝐩[i]⁆ = 0 := by
-  dsimp only [Bracket.bracket, momentumOperatorSqr]
-  rw [Finset.mul_sum, Finset.sum_mul, ← Finset.sum_sub_distrib]
-  conv_lhs =>
-    enter [2, j]
-    simp only [ContinuousLinearMap.mul_def]
-    rw [comp_assoc]
-    rw [momentum_comp_commute j i, ← comp_assoc]
-    rw [momentum_comp_commute j i, comp_assoc]
-    rw [sub_self]
-  rw [Finset.sum_const_zero]
+@[simp]
+lemma momentumSqr_commutation_momentum : ⁅momentumOperatorSqr (d := d), 𝐩[i]⁆ = 0 := by
+  simp [momentumOperatorSqr, sum_lie, leibniz_lie]
 
-lemma momentumSqr_comp_momentum_commute {d : ℕ} (i : Fin d) : 𝐩² ∘L 𝐩[i] = 𝐩[i] ∘L 𝐩² := by
-  rw [← sub_eq_zero]
-  exact momentumSqr_commutation_momentum i
+lemma momentumSqr_comp_momentum_commute : 𝐩² ∘L 𝐩[i] = 𝐩[i] ∘L 𝐩² := by
+  rw [comp_eq_comp_add_commute, momentumSqr_commutation_momentum, add_zero]
 
 /-
 ## Position / momentum commutators

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -98,60 +98,46 @@ lemma momentumSqr_comp_momentum_commute : 𝐩² ∘L 𝐩[i] = 𝐩[i] ∘L �
 -/
 
 /-- The canonical commutation relations: `[xᵢ, pⱼ] = iℏ δᵢⱼ𝟙`. -/
-lemma position_commutation_momentum {d : ℕ} (i j : Fin d) : ⁅𝐱[i], 𝐩[j]⁆ =
-    (Complex.I * ℏ * δ[i,j]) • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by
-  dsimp only [Bracket.bracket, kroneckerDelta]
+lemma position_commutation_momentum : ⁅𝐱[i], 𝐩[j]⁆ =
+    (I * ℏ * δ[i,j]) • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by
   ext ψ x
-  simp only [ContinuousLinearMap.smul_apply, SchwartzMap.smul_apply, coe_id', id_eq, smul_eq_mul,
-    coe_sub', coe_mul, Pi.sub_apply, Function.comp_apply, SchwartzMap.sub_apply]
-  rw [positionOperator_apply, momentumOperator_apply_fun]
-  rw [momentumOperator_apply, positionOperator_apply_fun]
-  simp only [neg_mul, Pi.smul_apply, smul_eq_mul, mul_neg, sub_neg_eq_add]
+  have hdiff : DifferentiableAt ℝ (fun x => x i) x := by
+    have : (fun x ↦ x i) = ⇑(Space.coordCLM i) := by
+      ext; rw [Space.coordCLM_apply, Space.coord_apply]
+    rw [this]
+    fun_prop
+  calc
+    _ = 𝐱[i] (𝐩[j] ψ) x - 𝐩[j] (𝐱[i] ψ) x := by
+      simp [bracket]
+    _ = (I * ℏ) * (-x i * ∂[j] ψ x + ∂[j] (fun x ↦ x i * ψ x) x) := by
+      simp only [positionOperator_apply_fun, momentumOperator_apply]
+      ring
+    _ = (I * ℏ) * (-x i * ∂[j] ψ x + ∂[j] ((fun x : Space d ↦ x i) • ⇑ψ) x) := rfl
+    _ = (I * ℏ) * (∂[j] (fun x : Space d ↦ x i) x * ψ x) := by
+      simp [Space.deriv_smul hdiff ψ.differentiableAt]
+    _ = (I * ℏ) * δ[i,j] * ψ x := by
+      rw [Space.deriv_component, ← kroneckerDelta, kroneckerDelta_symm]
+      ring
 
-  have h : (fun x ↦ ↑(x i) * ψ x) = (fun (x : Space d) ↦ x i) • ψ := rfl
-  rw [h]
-  rw [Space.deriv_smul (by fun_prop) (SchwartzMap.differentiableAt ψ)]
-  rw [Space.deriv_component, ite_cond_symm j i]
-  simp only [mul_add, Complex.real_smul, ite_smul, one_smul, zero_smul, mul_ite, mul_one, mul_zero,
-    ite_mul, zero_mul]
-  ring
+lemma momentum_comp_position_eq : 𝐩[j] ∘L 𝐱[i] =
+    𝐱[i] ∘L 𝐩[j] - (I * ℏ * δ[i,j]) • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by
+  rw [comp_eq_comp_sub_commute, position_commutation_momentum]
 
-lemma momentum_comp_position_eq (i j : Fin d) : 𝐩[j] ∘L 𝐱[i] =
-    𝐱[i] ∘L 𝐩[j] - (Complex.I * ℏ * δ[i,j]) • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by
-  rw [← position_commutation_momentum]
-  dsimp only [Bracket.bracket]
-  simp only [ContinuousLinearMap.mul_def, sub_sub_cancel]
+lemma position_position_commutation_momentum : ⁅𝐱[i] ∘L 𝐱[j], 𝐩[k]⁆ =
+    (I * ℏ * δ[i,k]) • 𝐱[j] + (I * ℏ * δ[j,k]) • 𝐱[i] := by
+  simp [leibniz_lie, position_commutation_momentum, add_comm]
 
-lemma position_position_commutation_momentum {d : ℕ} (i j k : Fin d) : ⁅𝐱[i] ∘L 𝐱[j], 𝐩[k]⁆ =
-    (Complex.I * ℏ * δ[i,k]) • 𝐱[j] + (Complex.I * ℏ * δ[j,k]) • 𝐱[i] := by
-  rw [leibniz_lie]
-  rw [position_commutation_momentum, position_commutation_momentum]
-  rw [ContinuousLinearMap.comp_smul, ContinuousLinearMap.smul_comp]
-  rw [id_comp, comp_id]
-  rw [add_comm]
+lemma position_commutation_momentum_momentum : ⁅𝐱[i], 𝐩[j] ∘L 𝐩[k]⁆ =
+    (I * ℏ * δ[i,k]) • 𝐩[j] + (I * ℏ * δ[i,j]) • 𝐩[k] := by
+  simp [lie_leibniz, position_commutation_momentum]
 
-lemma position_commutation_momentum_momentum {d : ℕ} (i j k : Fin d) : ⁅𝐱[i], 𝐩[j] ∘L 𝐩[k]⁆ =
-    (Complex.I * ℏ * δ[i,k]) • 𝐩[j] + (Complex.I * ℏ * δ[i,j]) • 𝐩[k] := by
-  rw [lie_leibniz]
-  rw [position_commutation_momentum, position_commutation_momentum]
-  rw [ContinuousLinearMap.comp_smul, ContinuousLinearMap.smul_comp]
-  rw [id_comp, comp_id]
-
-lemma position_commutation_momentumSqr {d : ℕ} (i : Fin d) : ⁅𝐱[i], 𝐩²⁆ =
-    (2 * Complex.I * ℏ) • 𝐩[i] := by
-  unfold momentumOperatorSqr
-  rw [lie_sum]
-  simp only [position_commutation_momentum_momentum]
-  dsimp only [kroneckerDelta]
-  simp only [mul_ite_zero, ite_zero_smul, Finset.sum_add_distrib, Finset.sum_ite_eq,
-    Finset.mem_univ, ↓reduceIte]
-  ext ψ x
-  simp only [ContinuousLinearMap.add_apply, coe_smul', Pi.smul_apply, SchwartzMap.add_apply,
-    SchwartzMap.smul_apply, smul_eq_mul]
-  ring
+lemma position_commutation_momentumSqr : ⁅𝐱[i], 𝐩²⁆ = (2 * I * ℏ) • 𝐩[i] := by
+  dsimp [momentumOperatorSqr]
+  simp [lie_sum, lie_leibniz, position_commutation_momentum, ← two_smul ℂ, smul_smul, ← mul_assoc,
+    sum_kroneckerDelta]
 
 lemma radiusRegPow_commutation_momentum (hε : 0 < ε) (i : Fin d) :
-    ⁅radiusRegPowOperator (d := d) ε s, 𝐩[i]⁆ = (s * Complex.I * ℏ) • 𝐫[ε,s-2] ∘L 𝐱[i] := by
+    ⁅radiusRegPowOperator (d := d) ε s, 𝐩[i]⁆ = (s * I * ℏ) • 𝐫[ε,s-2] ∘L 𝐱[i] := by
   dsimp only [Bracket.bracket]
   ext ψ x
   simp only [coe_sub', coe_mul, Pi.sub_apply, Function.comp_apply, SchwartzMap.sub_apply, coe_smul',
@@ -192,36 +178,54 @@ lemma radiusRegPow_commutation_momentum (hε : 0 < ε) (i : Fin d) :
   · fun_prop
 
 lemma momentum_comp_radiusRegPow_eq (hε : 0 < ε) (i : Fin d) :
-    𝐩[i] ∘L 𝐫[ε,s] = 𝐫[ε,s] ∘L 𝐩[i] - (s * Complex.I * ℏ) • 𝐫[ε,s-2] ∘L 𝐱[i] := by
-  rw [← radiusRegPow_commutation_momentum hε]
-  dsimp only [Bracket.bracket]
-  simp only [ContinuousLinearMap.mul_def, sub_sub_cancel]
+    𝐩[i] ∘L 𝐫[ε,s] = 𝐫[ε,s] ∘L 𝐩[i] - (s * I * ℏ) • 𝐫[ε,s-2] ∘L 𝐱[i] := by
+  rw [comp_eq_comp_sub_commute, radiusRegPow_commutation_momentum hε]
 
 lemma radiusRegPow_commutation_momentumSqr (hε : 0 < ε) :
     ⁅radiusRegPowOperator (d := d) ε s, momentumOperatorSqr (d := d)⁆ =
-    (2 * s * Complex.I * ℏ) • 𝐫[ε,s-2] ∘L ∑ i, 𝐱[i] ∘L 𝐩[i]
-    + (s * ℏ ^ 2) • ((d + s - 2) • 𝐫[ε,s-2] - (ε ^ 2 * (s - 2)) • 𝐫[ε,s-4]) := by
-  unfold momentumOperatorSqr
-  rw [lie_sum]
+    (2 * s * I * ℏ) • 𝐫[ε,s-2] ∘L ∑ i, 𝐱[i] ∘L 𝐩[i] + (s * (d + s - 2) * ℏ ^ 2) • 𝐫[ε,s-2]
+    - (ε ^ 2 * s * (s - 2) * ℏ ^ 2) • 𝐫[ε,s-4] := by
+  dsimp [momentumOperatorSqr]
+  simp only [lie_sum, lie_leibniz, radiusRegPow_commutation_momentum hε, comp_smul, smul_comp,
+    ← smul_add]
   conv_lhs =>
     enter [2, i]
-    rw [lie_leibniz, radiusRegPow_commutation_momentum hε]
-    rw [comp_smul, ← comp_assoc, momentum_comp_radiusRegPow_eq hε]
-    rw [sub_comp, comp_assoc, momentum_comp_position_eq]
-    simp only [kroneckerDelta, ↓reduceIte, mul_one]
-  simp only [smul_comp, comp_sub, comp_smul, comp_id, smul_sub, comp_assoc,
-    Finset.sum_add_distrib, Finset.sum_sub_distrib, ← Finset.smul_sum, Finset.sum_const,
-    Finset.card_univ, Fintype.card_fin, ← ContinuousLinearMap.comp_finset_sum]
-  rw [positionOperatorSqr_eq hε, comp_sub, radiusRegPowOperator_comp_eq hε, comp_smul, comp_id]
-  rw [← Nat.cast_smul_eq_nsmul ℂ]
+    calc
+      _ = (s * I * ℏ) • (𝐫[ε,s-2] ∘L 𝐱[i] ∘L 𝐩[i] + 𝐫[ε,s-2] ∘L 𝐩[i] ∘L 𝐱[i]
+          - (↑(s - 2) * I * ℏ) • 𝐫[ε,s-4] ∘L 𝐱[i] ∘L 𝐱[i]) := by
+        rw [add_comm, ← comp_assoc, momentum_comp_radiusRegPow_eq hε, comp_assoc, sub_comp, add_sub,
+          smul_comp, comp_assoc, comp_assoc]
+        ring_nf
+      _ = (s * I * ℏ) • ((2 : ℂ) • 𝐫[ε,s-2] ∘L 𝐱[i] ∘L 𝐩[i] - (I * ℏ) • 𝐫[ε,s-2]
+          - (↑(s - 2) * I * ℏ) • 𝐫[ε,s-4] ∘L 𝐱[i] ∘L 𝐱[i]) := by
+        rw [momentum_comp_position_eq, comp_sub, comp_smul, add_sub, ← two_smul ℂ]
+        simp [kroneckerDelta_self]
+      _ = (2 * s * I * ℏ) • 𝐫[ε,s-2] ∘L 𝐱[i] ∘L 𝐩[i] + (s * ℏ ^ 2) • 𝐫[ε,s-2]
+          + (s * (s - 2) * ℏ ^ 2) • 𝐫[ε,s-4] ∘L 𝐱[i] ∘L 𝐱[i] := by
+        simp only [sub_eq_add_neg, ← neg_smul, smul_add, smul_smul]
+        congr 3 -- match coefficients
+        · ring
+        · ring_nf
+          simp
+        · ring_nf
+          simp only [I_sq, ofReal_add, ofReal_neg, RingHom.toMonoidHom_eq_coe, OneHom.toFun_eq_coe,
+            MonoidHom.toOneHom_coe, MonoidHom.coe_coe, coe_algebraMap, ZeroHom.coe_mk, ofReal_mul,
+            ofReal_pow]
+          ring
+  simp only [Finset.sum_add_distrib, ← Finset.smul_sum, ← comp_finset_sum]
+  have h1 : (∑ i : Fin d, radiusRegPowOperator (d := d) ε (s - 2)) = (d : ℂ) • 𝐫[ε,s-2] := by
+    ext
+    rw [ContinuousLinearMap.sum_apply, SchwartzMap.sum_apply]
+    simp
+  have h2 : 𝐫[ε,s-4] ∘L ∑ i : Fin d, 𝐱[i] ∘L 𝐱[i] = 𝐫[ε,s-2] - (ε ^ 2) • 𝐫[ε,s-4] := by
+    simp only [positionOperatorSqr_eq hε, comp_sub, comp_smul, comp_id,
+      radiusRegPowOperator_comp_eq hε]
+    ring_nf
+  rw [h1, h2]
   ext ψ x
-  simp only [Complex.ofReal_sub, Complex.ofReal_ofNat, sub_add_cancel, coe_sub', Pi.sub_apply,
-    ContinuousLinearMap.add_apply, coe_smul', coe_comp', coe_sum', Pi.smul_apply,
-    Function.comp_apply, Finset.sum_apply, map_sum, SchwartzMap.sub_apply, SchwartzMap.add_apply,
-    SchwartzMap.smul_apply, SchwartzMap.sum_apply, smul_eq_mul, Complex.real_smul,
-    Complex.ofReal_pow, Complex.ofReal_add, Complex.ofReal_natCast, Complex.ofReal_mul]
-  ring_nf
-  rw [Complex.I_sq]
+  simp only [ContinuousLinearMap.add_apply, coe_smul', Pi.smul_apply, coe_sub', Pi.sub_apply,
+    SchwartzMap.add_apply, SchwartzMap.smul_apply, smul_eq_mul, real_smul, ofReal_mul,
+    SchwartzMap.sub_apply, ofReal_sub, ofReal_add, ofReal_natCast]
   ring
 
 /-

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -103,18 +103,15 @@ lemma position_commutation_momentum : ⁅𝐱[i], 𝐩[j]⁆ =
       ext; rw [Space.coordCLM_apply, Space.coord_apply]
     rw [this]
     fun_prop
-  calc
-    _ = 𝐱[i] (𝐩[j] ψ) x - 𝐩[j] (𝐱[i] ψ) x := by
-      simp [bracket]
-    _ = (I * ℏ) * (-x i * ∂[j] ψ x + ∂[j] (fun x ↦ x i * ψ x) x) := by
-      simp only [positionOperator_apply_fun, momentumOperator_apply]
-      ring
-    _ = (I * ℏ) * (-x i * ∂[j] ψ x + ∂[j] ((fun x : Space d ↦ x i) • ⇑ψ) x) := rfl
-    _ = (I * ℏ) * (∂[j] (fun x : Space d ↦ x i) x * ψ x) := by
-      simp [Space.deriv_smul hdiff ψ.differentiableAt]
-    _ = (I * ℏ) * δ[i,j] * ψ x := by
-      rw [Space.deriv_component, ← kroneckerDelta, kroneckerDelta_symm]
-      ring
+  change 𝐱[i] (𝐩[j] ψ) x - 𝐩[j] (𝐱[i] ψ) x = _
+  trans (I * ℏ) * (-x i * ∂[j] ψ x + ∂[j] ((fun x : Space d ↦ x i) • ⇑ψ) x)
+  · simp only [positionOperator_apply_fun, momentumOperator_apply_fun, Pi.smul_apply, smul_eq_mul]
+    ring_nf
+    rfl
+  simp only [Space.deriv_smul hdiff ψ.differentiableAt, Space.deriv_component, ← kroneckerDelta_eq,
+    kroneckerDelta_symm, real_smul, coe_smul', coe_id', Pi.smul_apply, id_eq,
+    SchwartzMap.smul_apply, smul_eq_mul]
+  ring
 
 lemma momentum_comp_position_eq : 𝐩[j] ∘L 𝐱[i] =
     𝐱[i] ∘L 𝐩[j] - (I * ℏ * δ[i,j]) • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -15,66 +15,55 @@ namespace QuantumMechanics
 noncomputable section
 open Constants
 open KroneckerDelta
-open SchwartzMap ContinuousLinearMap
+open Bracket
+open ContinuousLinearMap SchwartzMap
+
+variable {d : ℕ} (i j k l : Fin d)
 
 private lemma ite_cond_symm (i j : Fin d) :
     (if i = j then A else B) = (if j = i then A else B) :=
   ite_cond_congr (Eq.propIntro Eq.symm Eq.symm)
 
-lemma leibniz_lie {d : ℕ} (A B C : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
+lemma leibniz_lie (A B C : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
     ⁅A ∘L B, C⁆ = A ∘L ⁅B, C⁆ + ⁅A, C⁆ ∘L B := by
-  dsimp only [Bracket.bracket]
-  simp only [ContinuousLinearMap.mul_def, comp_assoc, comp_sub, sub_comp, sub_add_sub_cancel]
+  simp [bracket, mul_def, comp_assoc]
 
 lemma lie_leibniz {d : ℕ} (A B C : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
     ⁅A, B ∘L C⁆ = B ∘L ⁅A, C⁆ + ⁅A, B⁆ ∘L C := by
-  dsimp only [Bracket.bracket]
-  simp only [ContinuousLinearMap.mul_def, comp_assoc, comp_sub, sub_comp, sub_add_sub_cancel']
+  simp [bracket, mul_def, comp_assoc]
 
 lemma comp_eq_comp_add_commute (A B : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
     A ∘L B = B ∘L A + ⁅A, B⁆ := by
-  dsimp only [Bracket.bracket]
-  simp only [ContinuousLinearMap.mul_def, add_sub_cancel]
+  simp [bracket, mul_def]
 
 lemma comp_eq_comp_sub_commute (A B : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
     A ∘L B = B ∘L A - ⁅B, A⁆ := by
-  dsimp only [Bracket.bracket]
-  simp only [ContinuousLinearMap.mul_def, sub_sub_cancel]
+  simp [bracket, mul_def]
 
 /-
 ## Position / position commutators
 -/
 
 /-- Position operators commute: `[xᵢ, xⱼ] = 0`. -/
-lemma position_commutation_position {d : ℕ} (i j : Fin d) : ⁅𝐱[i], 𝐱[j]⁆ = 0 := by
-  dsimp only [Bracket.bracket]
-  ext ψ x
-  simp only [coe_sub', coe_mul, Pi.sub_apply, Function.comp_apply, SchwartzMap.sub_apply,
-    ContinuousLinearMap.zero_apply, SchwartzMap.zero_apply, positionOperator_apply]
-  ring
+lemma position_commutation_position : ⁅𝐱[i], 𝐱[j]⁆ = 0 := by
+  ext
+  simp [bracket, positionOperator_apply, ← mul_assoc, mul_comm]
 
-lemma position_comp_commute {d : ℕ} (i j : Fin d) : 𝐱[i] ∘L 𝐱[j] = 𝐱[j] ∘L 𝐱[i] := by
-  rw [← sub_eq_zero]
-  exact position_commutation_position i j
+lemma position_comp_commute : 𝐱[i] ∘L 𝐱[j] = 𝐱[j] ∘L 𝐱[i] := by
+  rw [comp_eq_comp_add_commute, position_commutation_position, add_zero]
 
 lemma position_commutation_radiusRegPow (hε : 0 < ε) (i : Fin d) :
     ⁅𝐱[i], radiusRegPowOperator (d := d) ε s⁆ = 0 := by
-  dsimp only [Bracket.bracket]
-  ext ψ x
-  simp only [coe_sub', coe_mul, Pi.sub_apply, Function.comp_apply, SchwartzMap.sub_apply]
-  simp only [positionOperator_apply, radiusRegPowOperator_apply hε]
-  simp only [Complex.real_smul, ContinuousLinearMap.zero_apply, SchwartzMap.zero_apply]
-  ring
+  ext
+  simp [bracket, positionOperator_apply, radiusRegPowOperator_apply hε, ← mul_assoc, mul_comm]
 
 lemma position_comp_radiusRegPow_commute (hε : 0 < ε) (i : Fin d) :
     𝐱[i] ∘L 𝐫[ε,s] = 𝐫[ε,s] ∘L 𝐱[i] := by
-  rw [← sub_eq_zero]
-  exact position_commutation_radiusRegPow hε _
+  rw [comp_eq_comp_add_commute, position_commutation_radiusRegPow hε, add_zero]
 
 lemma radiusRegPow_commutation_radiusRegPow (hε : 0 < ε) :
     ⁅radiusRegPowOperator (d := d) ε s, radiusRegPowOperator (d := d) ε t⁆ = 0 := by
-  dsimp only [Bracket.bracket]
-  simp only [ContinuousLinearMap.mul_def, radiusRegPowOperator_comp_eq hε, add_comm, sub_self]
+  simp [bracket, mul_def, radiusRegPowOperator_comp_eq hε, add_comm]
 
 /-
 ## Momentum / momentum commutators

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -28,7 +28,7 @@ lemma leibniz_lie (A B C : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
     ⁅A ∘L B, C⁆ = A ∘L ⁅B, C⁆ + ⁅A, C⁆ ∘L B := by
   simp [bracket, mul_def, comp_assoc]
 
-lemma lie_leibniz {d : ℕ} (A B C : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
+lemma lie_leibniz (A B C : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
     ⁅A, B ∘L C⁆ = B ∘L ⁅A, C⁆ + ⁅A, B⁆ ∘L C := by
   simp [bracket, mul_def, comp_assoc]
 
@@ -232,35 +232,23 @@ lemma radiusRegPow_commutation_momentumSqr (hε : 0 < ε) :
 ## Angular momentum / position commutators
 -/
 
-lemma angularMomentum_commutation_position {d : ℕ} (i j k : Fin d) : ⁅𝐋[i,j], 𝐱[k]⁆ =
-    (Complex.I * ℏ * δ[i,k]) • 𝐱[j] - (Complex.I * ℏ * δ[j,k]) • 𝐱[i] := by
-  unfold angularMomentumOperator
-  rw [sub_lie]
-  rw [leibniz_lie, leibniz_lie]
-  rw [position_commutation_position, position_commutation_position]
-  rw [← lie_skew, position_commutation_momentum]
-  rw [← lie_skew, position_commutation_momentum]
-  rw [kroneckerDelta_symm k i, kroneckerDelta_symm k j]
-  simp only [ContinuousLinearMap.comp_neg, ContinuousLinearMap.comp_smul, comp_id, zero_comp,
-    add_zero, add_comm, sub_neg_eq_add, ← sub_eq_add_neg]
+lemma angularMomentum_commutation_position : ⁅𝐋[i,j], 𝐱[k]⁆ =
+    (I * ℏ * δ[i,k]) • 𝐱[j] - (I * ℏ * δ[j,k]) • 𝐱[i] := by
+  dsimp [angularMomentumOperator]
+  simp only [sub_lie, leibniz_lie, ← lie_skew 𝐩[_] 𝐱[_], position_commutation_momentum]
+  simp [kroneckerDelta_symm, add_comm, sub_eq_add_neg]
 
 lemma angularMomentum_commutation_radiusRegPow (hε : 0 < ε) (i j : Fin d) :
     ⁅𝐋[i,j], radiusRegPowOperator (d := d) ε s⁆ = 0 := by
-  dsimp only [Bracket.bracket]
-  unfold angularMomentumOperator
-  simp only [sub_mul, ContinuousLinearMap.mul_def, ContinuousLinearMap.comp_assoc]
-  repeat rw [momentum_comp_radiusRegPow_eq hε]
-  simp only [comp_sub, comp_smulₛₗ, RingHom.id_apply, ← ContinuousLinearMap.comp_assoc]
-  repeat rw [position_comp_radiusRegPow_commute hε]
-  simp only [ContinuousLinearMap.comp_assoc]
-  rw [position_comp_commute]
-  simp only [sub_sub_sub_cancel_right, sub_self]
+  dsimp [angularMomentumOperator]
+  simp only [sub_lie, leibniz_lie, ← lie_skew 𝐩[_] _, radiusRegPow_commutation_momentum hε,
+    position_commutation_radiusRegPow hε]
+  simp [comp_neg, ← position_comp_radiusRegPow_commute hε, ← comp_assoc, position_comp_commute i j]
 
 lemma angularMomentumSqr_commutation_radiusRegPow (hε : 0 < ε) :
     ⁅angularMomentumOperatorSqr (d := d), radiusRegPowOperator (d := d) ε s⁆ = 0 := by
-  unfold angularMomentumOperatorSqr
-  simp only [sum_lie, smul_lie, leibniz_lie, angularMomentum_commutation_radiusRegPow hε,
-    comp_zero, zero_comp, add_zero, smul_zero, Finset.sum_const_zero]
+  dsimp [angularMomentumOperatorSqr]
+  simp [sum_lie, leibniz_lie, angularMomentum_commutation_radiusRegPow hε]
 
 /-
 ## Angular momentum / momentum commutators

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -282,47 +282,39 @@ lemma angularMomentumSqr_commutation_momentumSqr :
 ## Angular momentum / angular momentum commutators
 -/
 
-lemma angularMomentum_commutation_angularMomentum {d : ℕ} (i j k l : Fin d) : ⁅𝐋[i,j], 𝐋[k,l]⁆ =
-    (Complex.I * ℏ * δ[i,k]) • 𝐋[j,l] - (Complex.I * ℏ * δ[i,l]) • 𝐋[j,k]
-    - (Complex.I * ℏ * δ[j,k]) • 𝐋[i,l] + (Complex.I * ℏ * δ[j,l]) • 𝐋[i,k] := by
+lemma angularMomentum_commutation_angularMomentum : ⁅𝐋[i,j], 𝐋[k,l]⁆ =
+    (I * ℏ * δ[i,k]) • 𝐋[j,l] - (I * ℏ * δ[i,l]) • 𝐋[j,k]
+    - (I * ℏ * δ[j,k]) • 𝐋[i,l] + (I * ℏ * δ[j,l]) • 𝐋[i,k] := by
   nth_rw 2 [angularMomentumOperator]
-  rw [lie_sub]
-  rw [lie_leibniz, lie_leibniz]
-  rw [angularMomentum_commutation_momentum, angularMomentum_commutation_position]
-  rw [angularMomentum_commutation_momentum, angularMomentum_commutation_position]
-  dsimp only [angularMomentumOperator, kroneckerDelta]
-  simp only [ContinuousLinearMap.comp_sub, ContinuousLinearMap.sub_comp,
-    ContinuousLinearMap.comp_smul, ContinuousLinearMap.smul_comp]
-  ext ψ x
-  simp only [mul_ite, mul_one, mul_zero, ite_smul, zero_smul, coe_sub', Pi.sub_apply,
-    ContinuousLinearMap.add_apply, SchwartzMap.sub_apply, SchwartzMap.add_apply, smul_sub]
+  simp only [lie_sub, lie_leibniz, angularMomentum_commutation_position,
+    angularMomentum_commutation_momentum]
+  dsimp [angularMomentumOperator]
+  ext
+  simp only [comp_sub, comp_smulₛₗ, RingHom.id_apply, coe_sub', Pi.sub_apply,
+    ContinuousLinearMap.add_apply, coe_smul', coe_comp', Pi.smul_apply, Function.comp_apply,
+    SchwartzMap.sub_apply, SchwartzMap.add_apply, SchwartzMap.smul_apply, smul_eq_mul]
   ring
 
-lemma angularMomentumSqr_commutation_angularMomentum {d : ℕ} (i j : Fin d) :
+@[simp]
+lemma angularMomentumSqr_commutation_angularMomentum :
     ⁅angularMomentumOperatorSqr (d := d), 𝐋[i,j]⁆ = 0 := by
-  unfold angularMomentumOperatorSqr
-  conv_lhs =>
-    simp only [smul_lie, sum_lie, leibniz_lie, angularMomentum_commutation_angularMomentum]
-  dsimp only [kroneckerDelta]
-  simp only [comp_add, comp_sub, add_comp, sub_comp, comp_smul, smul_comp, mul_ite, mul_zero,
-    mul_one]
-  simp only [ite_smul, zero_smul]
-
-  -- Split into individual terms to do one of the sums, then recombine
-  simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib, Finset.sum_ite_irrel,
-    Finset.sum_const_zero, Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
-  simp only [← Finset.sum_add_distrib, ← Finset.sum_sub_distrib]
-
-  ext ψ x
-  simp only [angularMomentumOperator_antisymm _ i, angularMomentumOperator_antisymm j _,
-    neg_comp, comp_neg, neg_neg, smul_neg, sub_neg_eq_add]
-  simp only [ContinuousLinearMap.sum_apply, ContinuousLinearMap.add_apply,
-    ContinuousLinearMap.sub_apply, ContinuousLinearMap.smul_apply, ContinuousLinearMap.comp_apply,
-    ContinuousLinearMap.neg_apply, ContinuousLinearMap.zero_apply, SchwartzMap.add_apply,
-    SchwartzMap.sum_apply, SchwartzMap.sub_apply, SchwartzMap.smul_apply, SchwartzMap.neg_apply,
-    SchwartzMap.zero_apply]
-  ring_nf
-  rw [Finset.sum_const_zero, smul_zero]
+  dsimp [angularMomentumOperatorSqr]
+  simp only [smul_lie, sum_lie, leibniz_lie, angularMomentum_commutation_angularMomentum,
+    comp_add, comp_sub, add_comp, sub_comp, comp_smul, smul_comp, Finset.sum_add_distrib,
+    Finset.sum_sub_distrib]
+  -- Swap order of sums so that inner sum always involves δ
+  nth_rw 1 [Finset.sum_comm]
+  nth_rw 2 [Finset.sum_comm]
+  nth_rw 5 [Finset.sum_comm]
+  nth_rw 6 [Finset.sum_comm]
+  simp only [sum_kroneckerDelta', angularMomentumOperator_antisymm _ i,
+    angularMomentumOperator_antisymm j _, comp_neg, neg_comp, smul_neg, neg_neg,
+    Finset.sum_neg_distrib, ← sub_eq_add_neg, sub_neg_eq_add]
+  ext
+  simp only [ContinuousLinearMap.smul_apply, ContinuousLinearMap.add_apply,
+    ContinuousLinearMap.sub_apply, ContinuousLinearMap.zero_apply, SchwartzMap.smul_apply,
+    SchwartzMap.add_apply, SchwartzMap.sub_apply, SchwartzMap.zero_apply, smul_eq_mul]
+  ring
 
 end
 end QuantumMechanics

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -9,6 +9,39 @@ import PhysLean.QuantumMechanics.DDimensions.Operators.AngularMomentum
 
 # Commutation relations
 
+## i. Overview
+
+In this module we compute the commutators for common operators acting on Schwartz maps on `Space d`.
+
+Commutator lemmas come in three flavors:
+  - 1. `a_commutation_b` lemmas are of the form `⁅a, b⁆ = (⋯)`.
+  - 2. `a_comp_b_commute` and `a_comp_commute` lemmas are of the form `a ∘ b = b ∘ a`.
+  - 3. `a_comp_b_eq` lemmas are of the form `a ∘ b = b ∘ a + (⋯)`.
+
+## ii. Key results
+
+- `position_commutation_momentum` : The canonical commutation relations.
+- `angularMomentum_commutation_position` : The position operator transforms as a vector under
+    infinitessimal rotations.
+- `angularMomentum_commutation_radiusRegPow` : Functions of `‖x‖²` commute with the angular momenta.
+- `angularMomentum_commutation_momentum` : The momentum operator transforms as a vector under
+    infinitessimal rotations.
+- `angularMomentum_commutation_angularMomentum` : Angular momenta generate an `𝔰𝔬(d)` algebra.
+- `angularMomentumSqr_commutation_angularMomentum` : `𝐋²` is a quadratic Casimir of `𝔰𝔬(d)`.
+
+## iii. Table of contents
+
+- A. General
+- B. Commutators
+  - B.1. Position / position
+  - B.2. Momentum / momentum
+  - B.3. Position / momentum
+  - B.4. Angular momentum / position
+  - B.5. Angular momentum / momentum
+  - B.6. Angular momentum / angular momentum
+
+## iv. References
+
 -/
 
 namespace QuantumMechanics
@@ -20,9 +53,11 @@ open ContinuousLinearMap SchwartzMap
 
 variable {d : ℕ} (i j k l : Fin d)
 
-private lemma ite_cond_symm (i j : Fin d) :
-    (if i = j then A else B) = (if j = i then A else B) :=
-  ite_cond_congr (Eq.propIntro Eq.symm Eq.symm)
+/-!
+
+## A. General
+
+-/
 
 lemma leibniz_lie (A B C : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
     ⁅A ∘L B, C⁆ = A ∘L ⁅B, C⁆ + ⁅A, C⁆ ∘L B := by
@@ -40,8 +75,16 @@ lemma comp_eq_comp_sub_commute (A B : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d,
     A ∘L B = B ∘L A - ⁅B, A⁆ := by
   simp [bracket, mul_def]
 
-/-
-## Position / position commutators
+/-!
+
+## B. Commutators
+
+-/
+
+/-!
+
+### B.1. Position / position
+
 -/
 
 /-- Position operators commute: `[xᵢ, xⱼ] = 0`. -/
@@ -66,8 +109,10 @@ lemma radiusRegPow_commutation_radiusRegPow (hε : 0 < ε) :
     ⁅radiusRegPowOperator (d := d) ε s, radiusRegPowOperator (d := d) ε t⁆ = 0 := by
   simp [bracket, mul_def, radiusRegPowOperator_comp_eq hε, add_comm]
 
-/-
-## Momentum / momentum commutators
+/-!
+
+### B.2. Momentum / momentum
+
 -/
 
 /-- Momentum operators commute: `[pᵢ, pⱼ] = 0`. -/
@@ -90,8 +135,10 @@ lemma momentumSqr_commutation_momentum : ⁅momentumOperatorSqr (d := d), 𝐩[i
 lemma momentumSqr_comp_momentum_commute : 𝐩² ∘L 𝐩[i] = 𝐩[i] ∘L 𝐩² := by
   rw [comp_eq_comp_add_commute, momentumSqr_commutation_momentum, add_zero]
 
-/-
-## Position / momentum commutators
+/-!
+
+### B.3. Position / momentum
+
 -/
 
 /-- The canonical commutation relations: `[xᵢ, pⱼ] = iℏ δᵢⱼ𝟙`. -/
@@ -210,8 +257,10 @@ lemma radiusRegPow_commutation_momentumSqr (hε : 0 < ε) :
     SchwartzMap.sub_apply, ofReal_sub, ofReal_add, ofReal_natCast]
   ring
 
-/-
-## Angular momentum / position commutators
+/-!
+
+### B.4. Angular momentum / position
+
 -/
 
 lemma angularMomentum_commutation_position : ⁅𝐋[i,j], 𝐱[k]⁆ =
@@ -232,8 +281,10 @@ lemma angularMomentumSqr_commutation_radiusRegPow (hε : 0 < ε) :
   dsimp [angularMomentumOperatorSqr]
   simp [sum_lie, leibniz_lie, angularMomentum_commutation_radiusRegPow hε]
 
-/-
-## Angular momentum / momentum commutators
+/-!
+
+### B.5. Angular momentum / momentum
+
 -/
 
 lemma angularMomentum_commutation_momentum : ⁅𝐋[i,j], 𝐩[k]⁆ =
@@ -260,8 +311,10 @@ lemma angularMomentumSqr_commutation_momentumSqr :
   dsimp [angularMomentumOperatorSqr]
   simp [sum_lie, leibniz_lie]
 
-/-
-## Angular momentum / angular momentum commutators
+/-!
+
+### B.6. Angular momentum / angular momentum
+
 -/
 
 lemma angularMomentum_commutation_angularMomentum : ⁅𝐋[i,j], 𝐋[k,l]⁆ =

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -216,45 +216,16 @@ lemma radiusRegPow_commutation_momentumSqr (hε : 0 < ε) :
     - (ε ^ 2 * s * (s - 2) * ℏ ^ 2) • 𝐫[ε,s-4] := by
   dsimp [momentumOperatorSqr]
   simp only [lie_sum, lie_leibniz, radiusRegPow_commutation_momentum hε, comp_smul, smul_comp,
-    ← smul_add]
-  conv_lhs =>
-    enter [2, i]
-    calc
-      _ = (s * I * ℏ) • (𝐫[ε,s-2] ∘L 𝐱[i] ∘L 𝐩[i] + 𝐫[ε,s-2] ∘L 𝐩[i] ∘L 𝐱[i]
-          - (↑(s - 2) * I * ℏ) • 𝐫[ε,s-4] ∘L 𝐱[i] ∘L 𝐱[i]) := by
-        rw [add_comm, ← comp_assoc, momentum_comp_radiusRegPow_eq hε, comp_assoc, sub_comp, add_sub,
-          smul_comp, comp_assoc, comp_assoc]
-        ring_nf
-      _ = (s * I * ℏ) • ((2 : ℂ) • 𝐫[ε,s-2] ∘L 𝐱[i] ∘L 𝐩[i] - (I * ℏ) • 𝐫[ε,s-2]
-          - (↑(s - 2) * I * ℏ) • 𝐫[ε,s-4] ∘L 𝐱[i] ∘L 𝐱[i]) := by
-        rw [momentum_comp_position_eq, comp_sub, comp_smul, add_sub, ← two_smul ℂ]
-        simp [kroneckerDelta_self]
-      _ = (2 * s * I * ℏ) • 𝐫[ε,s-2] ∘L 𝐱[i] ∘L 𝐩[i] + (s * ℏ ^ 2) • 𝐫[ε,s-2]
-          + (s * (s - 2) * ℏ ^ 2) • 𝐫[ε,s-4] ∘L 𝐱[i] ∘L 𝐱[i] := by
-        simp only [sub_eq_add_neg, ← neg_smul, smul_add, smul_smul]
-        congr 3 -- match coefficients
-        · ring
-        · ring_nf
-          simp
-        · ring_nf
-          simp only [I_sq, ofReal_add, ofReal_neg, RingHom.toMonoidHom_eq_coe, OneHom.toFun_eq_coe,
-            MonoidHom.toOneHom_coe, MonoidHom.coe_coe, coe_algebraMap, ZeroHom.coe_mk, ofReal_mul,
-            ofReal_pow]
-          ring
-  simp only [Finset.sum_add_distrib, ← Finset.smul_sum, ← comp_finset_sum]
-  have h1 : (∑ i : Fin d, radiusRegPowOperator (d := d) ε (s - 2)) = (d : ℂ) • 𝐫[ε,s-2] := by
-    ext
-    rw [ContinuousLinearMap.sum_apply, SchwartzMap.sum_apply]
-    simp
-  have h2 : 𝐫[ε,s-4] ∘L ∑ i : Fin d, 𝐱[i] ∘L 𝐱[i] = 𝐫[ε,s-2] - (ε ^ 2) • 𝐫[ε,s-4] := by
-    simp only [positionOperatorSqr_eq hε, comp_sub, comp_smul, comp_id,
-      radiusRegPowOperator_comp_eq hε]
-    ring_nf
-  rw [h1, h2]
-  ext ψ x
-  simp only [ContinuousLinearMap.add_apply, coe_smul', Pi.smul_apply, coe_sub', Pi.sub_apply,
-    SchwartzMap.add_apply, SchwartzMap.smul_apply, smul_eq_mul, real_smul, ofReal_mul,
-    SchwartzMap.sub_apply, ofReal_sub, ofReal_add, ofReal_natCast]
+    ← smul_add, ← comp_assoc, momentum_comp_radiusRegPow_eq hε, sub_comp, smul_comp]
+  simp only [comp_assoc, momentum_comp_position_eq, comp_sub, comp_smul, comp_id,
+    ← Finset.smul_sum, Finset.sum_add_distrib, Finset.sum_sub_distrib, ← comp_finset_sum,
+    positionOperatorSqr_eq hε, comp_sub, radiusRegPowOperator_comp_eq hε, sum_kroneckerDelta_self]
+  ext
+  simp only [ofReal_sub, coe_smul', Pi.smul_apply, ContinuousLinearMap.add_apply, coe_sub',
+    Pi.sub_apply, SchwartzMap.smul_apply, SchwartzMap.add_apply, SchwartzMap.sub_apply, smul_eq_mul,
+    real_smul, ofReal_pow, ofReal_mul, ofReal_add, ofReal_natCast]
+  ring_nf
+  simp only [I_sq]
   ring
 
 /-!

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -254,46 +254,29 @@ lemma angularMomentumSqr_commutation_radiusRegPow (hε : 0 < ε) :
 ## Angular momentum / momentum commutators
 -/
 
-lemma angularMomentum_commutation_momentum {d : ℕ} (i j k : Fin d) : ⁅𝐋[i,j], 𝐩[k]⁆ =
-    (Complex.I * ℏ * δ[i,k]) • 𝐩[j] - (Complex.I * ℏ * δ[j,k]) • 𝐩[i] := by
-  unfold angularMomentumOperator
-  rw [sub_lie]
-  rw [leibniz_lie, leibniz_lie]
-  rw [momentum_commutation_momentum, momentum_commutation_momentum]
-  rw [position_commutation_momentum, position_commutation_momentum]
-  simp only [ContinuousLinearMap.smul_comp, id_comp, comp_zero, zero_add]
+lemma angularMomentum_commutation_momentum : ⁅𝐋[i,j], 𝐩[k]⁆ =
+    (I * ℏ * δ[i,k]) • 𝐩[j] - (I * ℏ * δ[j,k]) • 𝐩[i] := by
+  dsimp [angularMomentumOperator]
+  simp [sub_lie, leibniz_lie, position_commutation_momentum]
 
-lemma momentum_comp_angularMomentum_eq {d : ℕ} (i j k : Fin d) : 𝐩[k] ∘L 𝐋[i,j] =
-    𝐋[i,j] ∘L 𝐩[k] - (Complex.I * ℏ * δ[i,k]) • 𝐩[j] + (Complex.I * ℏ * δ[j,k]) • 𝐩[i] := by
-  rw [← sub_eq_zero, sub_add]
-  rw [← angularMomentum_commutation_momentum]
-  dsimp only [Bracket.bracket]
-  simp only [ContinuousLinearMap.mul_def, sub_sub_cancel, sub_eq_zero]
+lemma momentum_comp_angularMomentum_eq : 𝐩[k] ∘L 𝐋[i,j] =
+    𝐋[i,j] ∘L 𝐩[k] - (I * ℏ * δ[i,k]) • 𝐩[j] + (I * ℏ * δ[j,k]) • 𝐩[i] := by
+  rw [comp_eq_comp_sub_commute, angularMomentum_commutation_momentum, sub_add]
 
-lemma angularMomentum_commutation_momentumSqr {d : ℕ} (i j : Fin d) :
-    ⁅𝐋[i,j], momentumOperatorSqr (d := d)⁆ = 0 := by
-  unfold momentumOperatorSqr
-  conv_lhs =>
-    rw [lie_sum]
-    enter [2, k]
-    rw [lie_leibniz, angularMomentum_commutation_momentum]
-    simp only [comp_sub, comp_smulₛₗ, RingHom.id_apply, sub_comp, smul_comp]
-    rw [momentum_comp_commute _ i, momentum_comp_commute j _]
-  dsimp only [kroneckerDelta]
-  simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib, mul_ite, mul_zero, ite_smul,
-    zero_smul, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte, sub_self, add_zero]
+@[simp]
+lemma angularMomentum_commutation_momentumSqr : ⁅𝐋[i,j], momentumOperatorSqr (d := d)⁆ = 0 := by
+  dsimp [momentumOperatorSqr]
+  simp [lie_sum, lie_leibniz, angularMomentum_commutation_momentum, Finset.sum_add_distrib,
+    Finset.sum_sub_distrib, sum_kroneckerDelta]
 
-lemma momentumSqr_comp_angularMomentum_commute {d : ℕ} (i j : Fin d) :
-    𝐩² ∘L 𝐋[i,j] = 𝐋[i,j] ∘L 𝐩² := by
-  apply Eq.symm
-  rw [← sub_eq_zero]
-  exact angularMomentum_commutation_momentumSqr i j
+lemma momentumSqr_comp_angularMomentum_commute : 𝐩² ∘L 𝐋[i,j] = 𝐋[i,j] ∘L 𝐩² := by
+  rw [comp_eq_comp_sub_commute, angularMomentum_commutation_momentumSqr, sub_zero]
 
-lemma angularMomentumSqr_commutation_momentumSqr {d : ℕ} :
+@[simp]
+lemma angularMomentumSqr_commutation_momentumSqr :
     ⁅angularMomentumOperatorSqr (d := d), momentumOperatorSqr (d := d)⁆ = 0 := by
-  unfold angularMomentumOperatorSqr
-  simp only [smul_lie, sum_lie, leibniz_lie]
-  simp [angularMomentum_commutation_momentumSqr]
+  dsimp [angularMomentumOperatorSqr]
+  simp [sum_lie, leibniz_lie]
 
 /-
 ## Angular momentum / angular momentum commutators

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -75,12 +75,9 @@ lemma radiusRegPow_commutation_radiusRegPow (hε : 0 < ε) :
 lemma momentum_commutation_momentum : ⁅𝐩[i], 𝐩[j]⁆ = 0 := by
   ext ψ x
   have hdiff := Space.deriv_differentiable (ψ.smooth _)
-  calc
-    _ = 𝐩[i] (𝐩[j] ψ) x - 𝐩[j] (𝐩[i] ψ) x := by
-      simp [bracket]
-    _ = (-I * ℏ) ^ 2 • (∂[i] (∂[j] ψ) x - ∂[j] (∂[i] ψ) x) := by
-      simp only [momentumOperator_apply_fun, Space.deriv_const_smul _ (hdiff _), Pi.smul_apply,
-        ← smul_sub, smul_smul, pow_two]
+  change 𝐩[i] (𝐩[j] ψ) x - 𝐩[j] (𝐩[i] ψ) x = 0
+  simp only [momentumOperator_apply_fun, Space.deriv_const_smul _ (hdiff _), Pi.smul_apply,
+    ← smul_sub, smul_smul]
   simp [Space.deriv_commute _ (ψ.smooth 2)]
 
 lemma momentum_comp_commute : 𝐩[i] ∘L 𝐩[j] = 𝐩[j] ∘L 𝐩[i] := by
@@ -138,44 +135,32 @@ lemma position_commutation_momentumSqr : ⁅𝐱[i], 𝐩²⁆ = (2 * I * ℏ) �
 
 lemma radiusRegPow_commutation_momentum (hε : 0 < ε) (i : Fin d) :
     ⁅radiusRegPowOperator (d := d) ε s, 𝐩[i]⁆ = (s * I * ℏ) • 𝐫[ε,s-2] ∘L 𝐱[i] := by
-  dsimp only [Bracket.bracket]
   ext ψ x
-  simp only [coe_sub', coe_mul, Pi.sub_apply, Function.comp_apply, SchwartzMap.sub_apply, coe_smul',
-    coe_comp', Pi.smul_apply, SchwartzMap.smul_apply, smul_eq_mul]
-  simp only [momentumOperator_apply, positionOperator_apply, radiusRegPowOperator_apply_fun hε]
+  let g := fun r : ℝ ↦ Real.rpow r (s / 2)
+  let normSqr_ε := fun x : Space d ↦ ‖x‖ ^ 2 + ε ^ 2
+  have r_apply (φ : 𝓢(Space d, ℂ)) : 𝐫[ε,s] φ = (g ∘ normSqr_ε) • ⇑φ := by
+    simp only [radiusRegPowOperator_apply_fun hε, g, normSqr_ε]
+    rfl
+  have hne : normSqr_ε x ≠ 0 := ne_of_gt (add_pos_of_nonneg_of_pos (sq_nonneg _) (sq_pos_of_pos hε))
+  have hg : DifferentiableAt ℝ g (normSqr_ε x) := Real.differentiableAt_rpow_const_of_ne (s / 2) hne
+  have hderiv : ∂[i] (g ∘ normSqr_ε) x = s * (normSqr_ε x).rpow (s / 2 - 1) * x i := by
+    rw [Space.deriv_eq, fderiv_comp x hg (by fun_prop)]
+    dsimp [g, normSqr_ε]
+    simp only [fderiv_add_const, fderiv_norm_sq_apply, fderiv_eq_smul_deriv, smul_eq_mul]
+    rw [deriv_rpow_const (by fun_prop) (by left; exact hne)]
+    simp only [coe_smul', coe_innerSL_apply, Pi.smul_apply, Space.inner_basis, deriv_id'']
+    ring
+  have hdiffAt : DifferentiableAt ℝ (g ∘ normSqr_ε) x := by
+    refine DifferentiableAt.comp x hg ?_
+    refine DifferentiableAt.add_const (ε ^ 2) ?_
+    exact Differentiable.differentiableAt Space.norm_sq_differentiable
 
-  have hne : ∀ x : Space d, ‖x‖ ^ 2 + ε ^ 2 ≠ 0 := by
-    intro x
-    apply ne_of_gt
-    exact add_pos_of_nonneg_of_pos (sq_nonneg _) (sq_pos_of_pos hε)
-
-  have h : (fun x ↦ (‖x‖ ^ 2 + ε ^ 2) ^ (s / 2) • ψ x) =
-    (fun (x : Space d) ↦ (‖x‖ ^ 2 + ε ^ 2) ^ (s / 2)) • ψ := rfl
-  have h' : ∂[i] (fun x ↦ (‖x‖ ^ 2 + ε ^ 2) ^ (s / 2)) =
-      fun x ↦ s * (‖x‖ ^ 2 + ε ^ 2) ^ (s / 2 - 1) * x i := by
-    trans ∂[i] ((fun x ↦ x ^ (s / 2)) ∘ (fun x ↦ ‖x‖ ^ 2 + ε ^ 2))
-    · congr
-    ext x
-    rw [Space.deriv_eq, fderiv_comp]
-    · simp only [fderiv_add_const, fderiv_norm_sq_apply, comp_smul, coe_smul', coe_comp',
-        coe_innerSL_apply, Pi.smul_apply, Function.comp_apply, Space.inner_basis,
-        fderiv_eq_smul_deriv, smul_eq_mul, nsmul_eq_mul, Nat.cast_ofNat]
-      rw [deriv_rpow_const]
-      · simp only [deriv_id'', one_mul]
-        ring
-      · fun_prop
-      · left
-        exact hne _
-    · exact Real.differentiableAt_rpow_const_of_ne (s / 2) (hne x)
-    · exact Differentiable.differentiableAt (by fun_prop)
-
-  rw [h, Space.deriv_smul]
-  · rw [h']
-    simp only [neg_mul, smul_neg, Complex.real_smul, Complex.ofReal_mul, sub_neg_eq_add]
-    ring_nf
-  · refine DifferentiableAt.rpow ?_ (by fun_prop) (hne _)
-    exact Differentiable.differentiableAt (by fun_prop)
-  · fun_prop
+  change 𝐫[ε,s] (𝐩[i] ψ) x - 𝐩[i] (𝐫[ε,s] ψ) x = _
+  simp only [momentumOperator_apply_fun, r_apply, Pi.smul_apply,
+    Space.deriv_smul hdiffAt ψ.differentiableAt, hderiv]
+  dsimp [g, normSqr_ε]
+  simp only [positionOperator_apply_fun, radiusRegPowOperator_apply_fun hε, ofReal_mul, real_smul]
+  ring_nf
 
 lemma momentum_comp_radiusRegPow_eq (hε : 0 < ε) (i : Fin d) :
     𝐩[i] ∘L 𝐫[ε,s] = 𝐫[ε,s] ∘L 𝐩[i] - (s * I * ℏ) • 𝐫[ε,s-2] ∘L 𝐱[i] := by

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -28,7 +28,7 @@ def momentumOperator {d : ℕ} (i : Fin d) : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(S
     (SchwartzMap.fderivCLM ℂ (Space d) ℂ)
 
 @[inherit_doc momentumOperator]
-macro "𝐩[" i:term "]" : term => `(momentumOperator $i)
+notation "𝐩[" i "]" => momentumOperator i
 
 lemma momentumOperator_apply_fun {d : ℕ} (i : Fin d) (ψ : 𝓢(Space d, ℂ)) :
     𝐩[i] ψ = (- Complex.I * ℏ) • ∂[i] ψ := rfl

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -83,7 +83,7 @@ def radiusRegPowOperator (ε s : ℝ) : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space 
   SchwartzMap.smulLeftCLM ℂ (Complex.ofReal ∘ normRegularizedPow ε s)
 
 @[inherit_doc radiusRegPowOperator]
-macro "𝐫[" ε:term "," s:term "]" : term => `(radiusRegPowOperator $ε $s)
+notation "𝐫[" ε "," s "]" => radiusRegPowOperator ε s
 
 lemma radiusRegPowOperator_apply_fun (hε : 0 < ε) :
     𝐫[ε,s] ψ = fun x ↦ (‖x‖ ^ 2 + ε ^ 2) ^ (s / 2) • ψ x := by

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -29,7 +29,7 @@ def positionOperator (i : Fin d) : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, �
   SchwartzMap.smulLeftCLM ℂ (Complex.ofReal ∘ coordCLM i)
 
 @[inherit_doc positionOperator]
-macro "𝐱[" i:term "]" : term => `(positionOperator $i)
+notation "𝐱[" i "]" => positionOperator i
 
 lemma positionOperator_apply_fun (i : Fin d) (ψ : 𝓢(Space d, ℂ)) :
     𝐱[i] ψ = (fun x ↦ x i * ψ x) := by


### PR DESCRIPTION
- Golfing for commutation lemmas (cf. #930).
- Improved docs for [Operators/Commutation.lean](PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean).

In making some commutators `simp` lemmas a few proofs in [Hydrogen/LaplaceRungeLenzVector.lean](PhysLean/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean) broke; I have crudely fixed these but will revisit them for more golfing soon.