### PR TITLE
docs: QM operators & commutators

### DIFF
--- a/PhysLean/QuantumMechanics/DDimensions/Operators/AngularMomentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/AngularMomentum.lean
@@ -33,7 +33,7 @@ def angularMomentumOperator {d : ℕ} (i j : Fin d) : 𝓢(Space d, ℂ) →L[�
   𝐱[i] ∘L 𝐩[j] - 𝐱[j] ∘L 𝐩[i]
 
 @[inherit_doc angularMomentumOperator]
-macro "𝐋[" i:term "," j:term "]" : term => `(angularMomentumOperator $i $j)
+notation "𝐋[" i "," j "]" => angularMomentumOperator i j
 
 lemma angularMomentumOperator_apply_fun {d : ℕ} (i j : Fin d) (ψ : 𝓢(Space d, ℂ)) :
     𝐋[i,j] ψ = 𝐱[i] (𝐩[j] ψ) - 𝐱[j] (𝐩[i] ψ) := rfl

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/AngularMomentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/AngularMomentum.lean
@@ -9,10 +9,32 @@ import PhysLean.QuantumMechanics.DDimensions.Operators.Momentum
 
 # Angular momentum operator
 
-In this module we define:
-- The angular momentum operator on Schwartz maps, component-wise.
-- The angular momentum squared operator.
-- The angular momentum scalar operator in 2d and angular momentum vector operator in 3d.
+## i. Overview
+
+In this module we introduce several angular momentum operators for quantum mechanics on `Space d`.
+
+## ii. Key results
+
+Definitions:
+- `angularMomentumOperator` : (components of) the angular momentum operator acting on Schwartz maps
+    `𝓢(Space d, ℂ)` as `𝐱ᵢ∘𝐩ⱼ - 𝐱ⱼ∘𝐩ᵢ`.
+- `angularMomentumOperatorSqr` : the operator acting on Schwartz maps `𝓢(Space d, ℂ)`
+    as `½ ∑ᵢⱼ 𝐋ᵢⱼ∘𝐋ᵢⱼ`.
+- `angularMomentumOperator2D` : the (pseudo)scalar angular momentum operator for `d = 2`.
+- `angularMomentumOperator3D` : the (pseudo)vector angular momentum operator for `d = 3`.
+
+Notation:
+- `𝐋[i,j]` for `angularMomentumOperator i j`
+- `𝐋²` for `angularMomentumOperatorSqr`
+
+## iii. Table of contents
+
+- A. Angular momentum operator
+  - A.1 Antisymmetry
+- B. Angular momentum squared operator
+- C. Special cases in low dimensions
+
+## iv. References
 
 -/
 
@@ -21,9 +43,9 @@ noncomputable section
 open Constants
 open ContDiff SchwartzMap
 
-/-
+/-!
 
-# Definition
+## A. Angular momentum operator
 
 -/
 
@@ -40,6 +62,25 @@ lemma angularMomentumOperator_apply_fun {d : ℕ} (i j : Fin d) (ψ : 𝓢(Space
 
 lemma angularMomentumOperator_apply {d : ℕ} (i j : Fin d) (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
     𝐋[i,j] ψ x = 𝐱[i] (𝐩[j] ψ) x - 𝐱[j] (𝐩[i] ψ) x := rfl
+
+/-!
+
+### A.1 Antisymmetry
+
+-/
+
+/-- The angular momentum operator is antisymmetric, `𝐋ᵢⱼ = -𝐋ⱼᵢ` -/
+lemma angularMomentumOperator_antisymm {d : ℕ} (i j : Fin d) : 𝐋[i,j] = - 𝐋[j,i] :=
+  Eq.symm (neg_sub _ _)
+
+/-- Angular momentum operator components with repeated index vanish, `𝐋ᵢᵢ = 0`. -/
+lemma angularMomentumOperator_eq_zero {d : ℕ} (i : Fin d) : 𝐋[i,i] = 0 := sub_self _
+
+/-!
+
+## B. Angular momentum squared operator
+
+-/
 
 /-- The square of the angular momentum operator, `𝐋² ≔ ½ ∑ᵢⱼ 𝐋ᵢⱼ∘𝐋ᵢⱼ`. -/
 def angularMomentumOperatorSqr {d : ℕ} : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
@@ -59,22 +100,9 @@ lemma angularMomentumOperatorSqr_apply {d : ℕ} (ψ : 𝓢(Space d, ℂ)) (x : 
   rw [angularMomentumOperatorSqr_apply_fun]
   simp only [smul_apply, sum_apply, smul_eq_mul]
 
-/-
+/-!
 
-## Basic properties
-
--/
-
-/-- The angular momentum operator is antisymmetric, `𝐋ᵢⱼ = -𝐋ⱼᵢ` -/
-lemma angularMomentumOperator_antisymm {d : ℕ} (i j : Fin d) : 𝐋[i,j] = - 𝐋[j,i] :=
-  Eq.symm (neg_sub _ _)
-
-/-- Angular momentum operator components with repeated index vanish, `𝐋ᵢᵢ = 0`. -/
-lemma angularMomentumOperator_eq_zero {d : ℕ} (i : Fin d) : 𝐋[i,i] = 0 := sub_self _
-
-/-
-
-## Special cases in low dimensions
+## C. Special cases in low dimensions
 
   • d = 1 : The angular momentum operator is trivial.
 
@@ -83,13 +111,12 @@ lemma angularMomentumOperator_eq_zero {d : ℕ} (i : Fin d) : 𝐋[i,i] = 0 := s
 
   • d = 3 : The angular momentum operator has three independent components, 𝐋₀₁, 𝐋₁₂ and 𝐋₂₀.
             Dualizing using the Levi-Civita symbol produces the familiar (pseudo)vector angular
-            momentum operator with components 𝐋₀ = 𝐋₂₀, 𝐋₁ = 𝐋₂₀ and 𝐋₂ = 𝐋₀₁.
+            momentum operator with components 𝐋₀ = 𝐋₁₂, 𝐋₁ = 𝐋₂₀ and 𝐋₂ = 𝐋₀₁.
 
 -/
 
 /-- In one dimension the angular momentum operator is trivial. -/
-lemma angularMomentumOperator1D_trivial : ∀ (i j : Fin 1), 𝐋[i,j] = 0 := by
-  intro i j
+lemma angularMomentumOperator1D_trivial (i j : Fin 1) : 𝐋[i,j] = 0 := by
   fin_cases i, j
   exact angularMomentumOperator_eq_zero 0
 

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -9,6 +9,39 @@ import PhysLean.QuantumMechanics.DDimensions.Operators.AngularMomentum
 
 # Commutation relations
 
+## i. Overview
+
+In this module we compute the commutators for common operators acting on Schwartz maps on `Space d`.
+
+Commutator lemmas come in three flavors:
+  - 1. `a_commutation_b` lemmas are of the form `⁅a, b⁆ = (⋯)`.
+  - 2. `a_comp_b_commute` and `a_comp_commute` lemmas are of the form `a ∘ b = b ∘ a`.
+  - 3. `a_comp_b_eq` lemmas are of the form `a ∘ b = b ∘ a + (⋯)`.
+
+## ii. Key results
+
+- `position_commutation_momentum` : The canonical commutation relations.
+- `angularMomentum_commutation_position` : The position operator transforms as a vector under
+    infinitessimal rotations.
+- `angularMomentum_commutation_radiusRegPow` : Functions of `‖x‖²` commute with the angular momenta.
+- `angularMomentum_commutation_momentum` : The momentum operator transforms as a vector under
+    infinitessimal rotations.
+- `angularMomentum_commutation_angularMomentum` : Angular momenta generate an `𝔰𝔬(d)` algebra.
+- `angularMomentumSqr_commutation_angularMomentum` : `𝐋²` is a quadratic Casimir of `𝔰𝔬(d)`.
+
+## iii. Table of contents
+
+- A. General
+- B. Commutators
+  - B.1. Position / position
+  - B.2. Momentum / momentum
+  - B.3. Position / momentum
+  - B.4. Angular momentum / position
+  - B.5. Angular momentum / momentum
+  - B.6. Angular momentum / angular momentum
+
+## iv. References
+
 -/
 
 namespace QuantumMechanics
@@ -16,6 +49,12 @@ noncomputable section
 open Constants
 open KroneckerDelta
 open SchwartzMap ContinuousLinearMap
+
+/-!
+
+## A. General
+
+-/
 
 private lemma ite_cond_symm (i j : Fin d) :
     (if i = j then A else B) = (if j = i then A else B) :=
@@ -41,8 +80,16 @@ lemma comp_eq_comp_sub_commute (A B : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d,
   dsimp only [Bracket.bracket]
   simp only [ContinuousLinearMap.mul_def, sub_sub_cancel]
 
-/-
-## Position / position commutators
+/-!
+
+## B. Commutators
+
+-/
+
+/-!
+
+### B.1. Position / position
+
 -/
 
 /-- Position operators commute: `[xᵢ, xⱼ] = 0`. -/
@@ -76,8 +123,10 @@ lemma radiusRegPow_commutation_radiusRegPow (hε : 0 < ε) :
   dsimp only [Bracket.bracket]
   simp only [ContinuousLinearMap.mul_def, radiusRegPowOperator_comp_eq hε, add_comm, sub_self]
 
-/-
-## Momentum / momentum commutators
+/-!
+
+### B.2. Momentum / momentum
+
 -/
 
 /-- Momentum operators commute: `[pᵢ, pⱼ] = 0`. -/
@@ -112,8 +161,10 @@ lemma momentumSqr_comp_momentum_commute {d : ℕ} (i : Fin d) : 𝐩² ∘L 𝐩
   rw [← sub_eq_zero]
   exact momentumSqr_commutation_momentum i
 
-/-
-## Position / momentum commutators
+/-!
+
+### B.3. Position / momentum
+
 -/
 
 /-- The canonical commutation relations: `[xᵢ, pⱼ] = iℏ δᵢⱼ𝟙`. -/
@@ -245,8 +296,10 @@ lemma radiusRegPow_commutation_momentumSqr (hε : 0 < ε) :
   rw [Complex.I_sq]
   ring
 
-/-
-## Angular momentum / position commutators
+/-!
+
+### B.4. Angular momentum / position
+
 -/
 
 lemma angularMomentum_commutation_position {d : ℕ} (i j k : Fin d) : ⁅𝐋[i,j], 𝐱[k]⁆ =
@@ -279,8 +332,10 @@ lemma angularMomentumSqr_commutation_radiusRegPow (hε : 0 < ε) :
   simp only [sum_lie, smul_lie, leibniz_lie, angularMomentum_commutation_radiusRegPow hε,
     comp_zero, zero_comp, add_zero, smul_zero, Finset.sum_const_zero]
 
-/-
-## Angular momentum / momentum commutators
+/-!
+
+### B.5. Angular momentum / momentum
+
 -/
 
 lemma angularMomentum_commutation_momentum {d : ℕ} (i j k : Fin d) : ⁅𝐋[i,j], 𝐩[k]⁆ =
@@ -324,8 +379,10 @@ lemma angularMomentumSqr_commutation_momentumSqr {d : ℕ} :
   simp only [smul_lie, sum_lie, leibniz_lie]
   simp [angularMomentum_commutation_momentumSqr]
 
-/-
-## Angular momentum / angular momentum commutators
+/-!
+
+### B.6. Angular momentum / angular momentum
+
 -/
 
 lemma angularMomentum_commutation_angularMomentum {d : ℕ} (i j k l : Fin d) : ⁅𝐋[i,j], 𝐋[k,l]⁆ =

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -38,7 +38,7 @@ def momentumOperator : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
     (SchwartzMap.fderivCLM ℂ (Space d) ℂ)
 
 @[inherit_doc momentumOperator]
-macro "𝐩[" i:term "]" : term => `(momentumOperator $i)
+notation "𝐩[" i "]" => momentumOperator i
 
 lemma momentumOperator_apply_fun (ψ : 𝓢(Space d, ℂ)) :
     𝐩[i] ψ = (- Complex.I * ℏ) • ∂[i] ψ := rfl

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -9,17 +9,32 @@ import PhysLean.QuantumMechanics.PlanckConstant
 import PhysLean.SpaceAndTime.Space.Derivatives.Basic
 /-!
 
-# Momentum vector operator
+# Momentum operators
 
-In this module we define:
-- `momentumOperator i` acting on Schwartz maps `𝓢(Space d, ℂ)` as `-Iℏ∂ᵢ`.
-- `momentumOperatorSqr` acting on Schwartz maps `𝓢(Space d, ℂ)` as `∑ᵢ 𝐩[i]∘𝐩[i]`.
-- `momentumUnboundedOperator i`, a symmetric unbounded operator acting on the Schwartz submodule
-  of the Hilbert space `SpaceDHilbertSpace d`.
+## i. Overview
 
-We also introduce the following notation:
+In this module we introduce several momentum operators for quantum mechanics on `Space d`.
+
+## ii. Key results
+
+Definitions:
+- `momentumOperator` : (components of) the momentum vector operator acting Schwartz maps
+    `𝓢(Space d, ℂ)` as `-iℏ∂ᵢ`.
+- `momentumOperatorSqr` : operator acting on Schwartz maps `𝓢(Space d, ℂ)` as `∑ᵢ 𝐩[i]∘𝐩[i]`.
+- `momentumUnboundedOperator` : a symmetric unbounded operator acting on the Schwartz submodule
+    of the Hilbert space `SpaceDHilbertSpace d`.
+
+Notation:
 - `𝐩[i]` for `momentumOperator i`
 - `𝐩²` for `momentumOperatorSqr`
+
+## iii. Table of contents
+
+- A. Momentum vector operator
+- B. Momentum-squared operator
+- C. Unbounded momentum vector operator
+
+## iv. References
 
 -/
 
@@ -30,6 +45,12 @@ open Space
 open ContDiff SchwartzMap
 
 variable {d : ℕ} (i : Fin d)
+
+/-!
+
+## A. Momentum vector operator
+
+-/
 
 /-- Component `i` of the momentum operator is the continuous linear map
 from `𝓢(Space d, ℂ)` to itself which maps `ψ` to `-iℏ ∂ᵢψ`. -/
@@ -47,6 +68,12 @@ lemma momentumOperator_apply_fun (ψ : 𝓢(Space d, ℂ)) :
 lemma momentumOperator_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
     𝐩[i] ψ x = - Complex.I * ℏ * ∂[i] ψ x := rfl
 
+/-!
+
+## B. Momentum-squared operator
+
+-/
+
 /-- The square of the momentum operator, `𝐩² ≔ ∑ᵢ 𝐩ᵢ∘𝐩ᵢ`. -/
 def momentumOperatorSqr : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) := ∑ i, 𝐩[i] ∘L 𝐩[i]
 
@@ -61,7 +88,9 @@ lemma momentumOperatorSqr_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
     Function.comp_apply, map_sum]
 
 /-!
-## Unbounded momentum operators
+
+## C. Unbounded momentum vector operator
+
 -/
 
 open SpaceDHilbertSpace

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -18,7 +18,7 @@ In this module we introduce several momentum operators for quantum mechanics on 
 ## ii. Key results
 
 Definitions:
-- `momentumOperator` : (components of) the momentum vector operator acting Schwartz maps
+- `momentumOperator` : (components of) the momentum vector operator acting on Schwartz maps
     `𝓢(Space d, ℂ)` as `-iℏ∂ᵢ`.
 - `momentumOperatorSqr` : operator acting on Schwartz maps `𝓢(Space d, ℂ)` as `∑ᵢ 𝐩[i]∘𝐩[i]`.
 - `momentumUnboundedOperator` : a symmetric unbounded operator acting on the Schwartz submodule

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -44,7 +44,7 @@ def positionOperator : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
   SchwartzMap.smulLeftCLM ℂ (Complex.ofRealCLM ∘L coordCLM i)
 
 @[inherit_doc positionOperator]
-macro "𝐱[" i:term "]" : term => `(positionOperator $i)
+notation "𝐱[" i "]" => positionOperator i
 
 lemma positionOperator_apply_fun (ψ : 𝓢(Space d, ℂ)) :
     𝐱[i] ψ = smulLeftCLM ℂ (coordCLM i) • ψ := by
@@ -98,7 +98,7 @@ def radiusRegPowOperator (ε s : ℝ) : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space 
   SchwartzMap.smulLeftCLM ℂ (Complex.ofReal ∘ normRegularizedPow ε s)
 
 @[inherit_doc radiusRegPowOperator]
-macro "𝐫[" ε:term "," s:term "]" : term => `(radiusRegPowOperator $ε $s)
+notation "𝐫[" ε "," s "]" => radiusRegPowOperator ε s
 
 lemma radiusRegPowOperator_apply_fun {ε s : ℝ} (hε : 0 < ε) {ψ : 𝓢(Space d, ℂ)} :
     𝐫[ε,s] ψ = fun x ↦ (‖x‖ ^ 2 + ε ^ 2) ^ (s / 2) • ψ x := by

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -10,20 +10,36 @@ import PhysLean.SpaceAndTime.Space.Derivatives.Basic
 
 # Position operators
 
-In this module we define:
-- `positionOperator i` acting on Schwartz maps `𝓢(Space d, ℂ)` by multiplication by `xᵢ`.
-- `radiusRegPowOperator ε s` acting on Schwartz maps `𝓢(Space d, ℂ)` by multiplication
-  by `(‖x‖² + ε²)^(s/2)`, a smooth regularization of `‖x‖ˢ`.
-- `positionUnboundedOperator i`, a symmetric unbounded operator acting on the Schwartz submodule
-  of the Hilbert space `SpaceDHilbertSpace d`.
-- `radiusRegPowUnboundedOperator ε s`, a symmetric unbounded operator acting on the Schwartz
-  submodule of the Hilbert space `SpaceDHilbertSpace d`. For `s ≤ 0` this operator is bounded
-  (by `ε⁻ˢ`) and has natural domain the entire Hilbert space, but for uniformity we use the same
-  domain for all `s`.
+## i. Overview
 
-We also introduce the following notation:
+In this module we introduce several position operators for quantum mechanics on `Space d`.
+
+## ii. Key results
+
+Definitions:
+- `positionOperator` : (components of) the position vector operator acting on Schwartz maps
+    `𝓢(Space d, ℂ)` by multiplication by `xᵢ`.
+- `radiusRegPowOperator` : operator acting on Schwartz maps by multiplication by
+    `(‖x‖² + ε²)^(s/2)`, a smooth regularization of `‖x‖ˢ`.
+- `positionUnboundedOperator` : a symmetric unbounded operator acting on the Schwartz submodule
+    of the Hilbert space `SpaceDHilbertSpace d`.
+- `readiusRegPowUnboundedOperator` : a symmetric unbounded operator acting on the Schwartz
+    submodule of the Hilbert space `SpaceDHilbertSpace d`. For `s ≤ 0` this operator is in fact
+    bounded (by `|ε|ˢ`) and has natural domain the entire Hilbert space, but for uniformity we
+    use the same domain for all `s`.
+
+Notation:
 - `𝐱[i]` for `positionOperator i`
 - `𝐫[ε,s]` for `radiusRegPowOperator ε s`
+
+## iii. Table of contents
+
+- A. Position vector operator
+- B. Regularized radius operator
+- C. Unbounded position vector operator
+- D. Unbounded regularized radius operator
+
+## iv. References
 
 -/
 
@@ -35,7 +51,9 @@ open Function SchwartzMap ContDiff
 variable {d : ℕ} (i : Fin d)
 
 /-!
-## Position vector operator
+
+## A. Position vector operator
+
 -/
 
 /-- Component `i` of the position operator is the continuous linear map
@@ -60,7 +78,7 @@ lemma positionOperator_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) : 𝐱[i] �
 
 /-!
 
-## Radius operator
+## B. Regularized radius operator
 
 -/
 TODO "ZGCNP" "Incorporate normRegularizedPow into Space.Norm"
@@ -142,7 +160,9 @@ lemma positionOperatorSqr_eq {ε : ℝ} (hε : 0 < ε) : ∑ i, 𝐱[i] ∘L �
     add_smul, ← pow_two]
 
 /-!
-## Unbounded position operators
+
+## C. Unbounded position vector operator
+
 -/
 
 open SpaceDHilbertSpace
@@ -167,6 +187,12 @@ lemma positionOperatorSchwartz_isSymmetric : (positionOperatorSchwartz i).IsSymm
 def positionUnboundedOperator : UnboundedOperator (SpaceDHilbertSpace d) :=
   UnboundedOperator.ofSymmetric (hE := schwartzSubmodule_dense d) (positionOperatorSchwartz i)
     (positionOperatorSchwartz_isSymmetric i)
+
+/-!
+
+## D. Unbounded regularized radius operator
+
+-/
 
 /-- The (regularized) radius operators defined on the Schwartz submodule. -/
 def radiusRegPowOperatorSchwartz (ε s : ℝ) : schwartzSubmodule d →ₗ[ℂ] schwartzSubmodule d :=


### PR DESCRIPTION
- Added / improved docs for `x`, `p` and `L` operators and their commutators.
- Changed macros → notation