### PR TITLE
feat: remove `unfold deriv`

### DIFF
--- a/PhysLean/SpaceAndTime/Space/Derivatives/Basic.lean
+++ b/PhysLean/SpaceAndTime/Space/Derivatives/Basic.lean
@@ -79,6 +79,10 @@ lemma deriv_eq [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
     (μ : Fin d) (f : Space d → M) (x : Space d) :
     deriv μ f x = fderiv ℝ f x (basis μ) := by rfl
 
+lemma deriv_eq_fderiv_fun  [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
+    (μ : Fin d) (f : Space d → M) :
+    deriv μ f = fun x => fderiv ℝ (fun x => f x) x (basis μ) := by rfl
+
 lemma deriv_eq_fderiv_basis [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
     (μ : Fin d) (f : Space d → M) (x : Space d) :
     deriv μ f x = fderiv ℝ f x (basis μ) := by rfl
@@ -122,7 +126,7 @@ lemma deriv_const [NormedAddCommGroup M] [NormedSpace ℝ M] (m : M) (μ : Fin d
 lemma deriv_add [NormedAddCommGroup M] [NormedSpace ℝ M]
     (f1 f2 : Space d → M) (hf1 : Differentiable ℝ f1) (hf2 : Differentiable ℝ f2) :
     ∂[u] (f1 + f2) = ∂[u] f1 + ∂[u] f2 := by
-  unfold deriv
+  rw [deriv_eq_fderiv_fun]
   ext x
   rw [fderiv_add]
   rfl
@@ -133,7 +137,7 @@ lemma deriv_coord_add (f1 f2 : Space d → EuclideanSpace ℝ (Fin d))
     (hf1 : Differentiable ℝ f1) (hf2 : Differentiable ℝ f2) :
     (∂[u] (fun x => f1 x i + f2 x i)) =
       (∂[u] (fun x => f1 x i)) + (∂[u] (fun x => f2 x i)) := by
-  unfold deriv
+  rw [deriv_eq_fderiv_fun, deriv_eq_fderiv_fun, deriv_eq_fderiv_fun]
   simp only
   ext x
   rw [fderiv_fun_add]
@@ -151,26 +155,23 @@ lemma deriv_smul [NormedAddCommGroup M] [NormedSpace ℝ M] [NontriviallyNormedF
     [NormedAlgebra ℝ 𝕜] [NormedSpace 𝕜 M] {c : Space d → 𝕜} {f : Space d → M}
     (hc : DifferentiableAt ℝ c x) (hf : DifferentiableAt ℝ f x) :
     ∂[u] (c • f) x = c x • ∂[u] f x + ∂[u] c x • f x := by
-  unfold deriv
-  rw [fderiv_smul hc hf]
+  rw [deriv_eq_fderiv_basis, deriv_eq_fderiv_basis, deriv_eq_fderiv_basis, fderiv_smul hc hf]
   rfl
 
 /-- Space derivatives on scalar times function. -/
 lemma deriv_const_smul [NormedAddCommGroup M] [NormedSpace ℝ M] [Semiring R]
     [Module R M] [SMulCommClass ℝ R M] [ContinuousConstSMul R M] {f : Space d → M} (c : R)
     (h : Differentiable ℝ f) : ∂[u] (c • f) = c • ∂[u] f := by
-  unfold deriv
+  rw [deriv_eq_fderiv_fun, deriv_eq_fderiv_fun]
   ext x
-  rw [fderiv_const_smul]
-  rw [ContinuousLinearMap.coe_smul', Pi.smul_apply, Pi.smul_apply]
+  rw [fderiv_const_smul, ContinuousLinearMap.coe_smul', Pi.smul_apply, Pi.smul_apply]
   fun_prop
 
 /-- Coordinate-wise scalar multiplication on space derivatives. -/
 lemma deriv_coord_smul (f : Space d → EuclideanSpace ℝ (Fin d)) (k : ℝ)
     (hf : Differentiable ℝ f) :
     ∂[u] (fun x => k * f x i) x = k * ∂[u] (fun x => f x i) x := by
-  unfold deriv
-  rw [fderiv_const_mul]
+  rw [deriv_eq_fderiv_basis, deriv_eq_fderiv_basis, fderiv_const_mul]
   simp only [ContinuousLinearMap.coe_smul', Pi.smul_apply, smul_eq_mul]
   fun_prop
 
@@ -183,7 +184,7 @@ lemma deriv_coord_smul (f : Space d → EuclideanSpace ℝ (Fin d)) (k : ℝ)
 /-- Derivatives on space commute with one another. -/
 lemma deriv_commute [NormedAddCommGroup M] [NormedSpace ℝ M]
     (f : Space d → M) (hf : ContDiff ℝ 2 f) : ∂[u] (∂[v] f) = ∂[v] (∂[u] f) := by
-  unfold deriv
+  rw [deriv_eq_fderiv_fun, deriv_eq_fderiv_fun, deriv_eq_fderiv_fun, deriv_eq_fderiv_fun]
   ext x
   rw [fderiv_clm_apply, fderiv_clm_apply]
   simp only [fderiv_fun_const, Pi.ofNat_apply, ContinuousLinearMap.comp_zero, zero_add,

--- a/PhysLean/SpaceAndTime/Space/Derivatives/Curl.lean
+++ b/PhysLean/SpaceAndTime/Space/Derivatives/Curl.lean
@@ -168,7 +168,7 @@ lemma deriv_coord_2nd_add (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
     ∂[i] (fun x => ∂[u] (fun x => f x u) x + (∂[v] (fun x => f x v) x + ∂[w] (fun x => f x w) x)) =
     (∂[i] (∂[u] (fun x => f x u))) + (∂[i] (∂[v] (fun x => f x v))) +
     (∂[i] (∂[w] (fun x => f x w))) := by
-  unfold deriv
+  repeat rw [deriv_eq_fderiv_fun]
   ext x
   rw [fderiv_fun_add, fderiv_fun_add]
   simp only [ContinuousLinearMap.add_apply, Pi.add_apply]
@@ -179,7 +179,7 @@ lemma deriv_coord_2nd_add (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
 lemma deriv_coord_2nd_sub (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContDiff ℝ 2 f) :
     ∂[u] (fun x => ∂[v] (fun x => f x w) x - ∂[w] (fun x => f x v) x) =
     (∂[u] (∂[v] (fun x => f x w))) - (∂[u] (∂[w] (fun x => f x v))) := by
-  unfold deriv
+  repeat rw [deriv_eq_fderiv_fun]
   ext x
   simp only [Pi.sub_apply]
   rw [fderiv_fun_sub]


### PR DESCRIPTION
Removing the use of `unfold deriv` in PhysLib. This is to make the API more robust against changes in definitions.  