### PR TITLE
Extend iterated Space derivatives with regularity and support lemmas

### DIFF
--- a/Physlib/SpaceAndTime/Space/Derivatives/Iterated.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Iterated.lean
@@ -44,6 +44,7 @@ of coordinate directions, and the iterated derivative is then defined by repeate
 namespace Space
 
 open Physlib
+open scoped ContDiff
 
 variable {M : Type} {d : ℕ}
 
@@ -61,23 +62,23 @@ noncomputable def iteratedDeriv [AddCommGroup M] [Module ℝ M] [TopologicalSpac
 macro "∂^[" I:term "]" : term => `(iteratedDeriv $I)
 
 private lemma iteratedDerivList_contDiff (L : List (Fin d)) {f : Space d → ℝ}
-    (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
-    ContDiff ℝ (⊤ : ℕ∞) (L.foldr (fun i g => deriv i g) f) := by
+    (hf : ContDiff ℝ ∞ f) :
+    ContDiff ℝ ∞ (L.foldr (fun i g => deriv i g) f) := by
   induction L generalizing f with
   | nil =>
       simpa using hf
   | cons i L ih =>
-      have htail : ContDiff ℝ (⊤ : ℕ∞) (L.foldr (fun j g => deriv j g) f) := ih hf
-      have hfamily : ContDiff ℝ (⊤ : ℕ∞)
+      have htail : ContDiff ℝ ∞ (L.foldr (fun j g => deriv j g) f) := ih hf
+      have hfamily : ContDiff ℝ ∞
           (fun x : Space d => fun j : Fin d => deriv j (L.foldr (fun j g => deriv j g) f) x) := by
-        simpa using (Space.deriv_contDiff (n := (⊤ : ℕ∞)) htail)
-      have hfixed : ContDiff ℝ (⊤ : ℕ∞)
+        simpa using (Space.deriv_contDiff (n := ∞) htail)
+      have hfixed : ContDiff ℝ ∞
           (fun x => deriv i (L.foldr (fun j g => deriv j g) f) x) := by
         simpa using (contDiff_apply ℝ ℝ i).comp hfamily
       simpa using hfixed
 
 private lemma iteratedDerivList_add (L : List (Fin d)) {f g : Space d → ℝ}
-    (hf : ContDiff ℝ (⊤ : ℕ∞) f) (hg : ContDiff ℝ (⊤ : ℕ∞) g) :
+    (hf : ContDiff ℝ ∞ f) (hg : ContDiff ℝ ∞ g) :
     L.foldr (fun i h => deriv i h) (f + g) =
       L.foldr (fun i h => deriv i h) f + L.foldr (fun i h => deriv i h) g := by
   induction L generalizing f g with
@@ -91,7 +92,7 @@ private lemma iteratedDerivList_add (L : List (Fin d)) {f g : Space d → ℝ}
       · exact (iteratedDerivList_contDiff L hg).differentiable (by simp)
 
 private lemma iteratedDerivList_const_smul (L : List (Fin d)) (c : ℝ) {f : Space d → ℝ}
-    (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
+    (hf : ContDiff ℝ ∞ f) :
     L.foldr (fun i h => deriv i h) (c • f) =
       c • L.foldr (fun i h => deriv i h) f := by
   induction L generalizing f with
@@ -121,19 +122,19 @@ lemma iteratedDeriv_single [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
   simp [iteratedDeriv, Physlib.MultiIndex.toList_single]
 
 lemma iteratedDeriv_add (I : MultiIndex d) {f g : Space d → ℝ}
-    (hf : ContDiff ℝ (⊤ : ℕ∞) f) (hg : ContDiff ℝ (⊤ : ℕ∞) g) :
+    (hf : ContDiff ℝ ∞ f) (hg : ContDiff ℝ ∞ g) :
     ∂^[I] (f + g) = ∂^[I] f + ∂^[I] g := by
   simpa [iteratedDeriv] using iteratedDerivList_add I.toList hf hg
 
 lemma iteratedDeriv_const_smul (I : MultiIndex d) (c : ℝ) {f : Space d → ℝ}
-    (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
+    (hf : ContDiff ℝ ∞ f) :
     ∂^[I] (c • f) = c • ∂^[I] f := by
   simpa [iteratedDeriv] using iteratedDerivList_const_smul I.toList c hf
 
 /-- Iterated spatial derivatives preserve smoothness for scalar-valued functions. -/
 lemma iteratedDeriv_contDiff (I : MultiIndex d) {f : Space d → ℝ}
-    (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
-    ContDiff ℝ (⊤ : ℕ∞) (∂^[I] f) := by
+    (hf : ContDiff ℝ ∞ f) :
+    ContDiff ℝ ∞ (∂^[I] f) := by
   simpa [iteratedDeriv] using iteratedDerivList_contDiff I.toList hf
 
 /-- The topological support of a spatial derivative is contained in that of the original
@@ -144,7 +145,7 @@ lemma tsupport_deriv_subset (i : Fin d) {f : Space d → ℝ} :
     (tsupport_fderiv_apply_subset (𝕜 := ℝ) (f := fun x => f x) (v := basis i))
 
 private lemma iteratedDerivList_commute_deriv (L : List (Fin d)) (i : Fin d)
-    {f : Space d → ℝ} (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
+    {f : Space d → ℝ} (hf : ContDiff ℝ ∞ f) :
     L.foldr (fun j g => deriv j g) (deriv i f) =
       deriv i (L.foldr (fun j g => deriv j g) f) := by
   induction L generalizing f with
@@ -156,13 +157,13 @@ private lemma iteratedDerivList_commute_deriv (L : List (Fin d)) (i : Fin d)
       rw [Space.deriv_commute (u := j) (v := i)]
       have h2 : ContDiff ℝ (2 : ℕ∞) (L.foldr (fun j g => deriv j g) f) := by
         exact (iteratedDerivList_contDiff L hf).of_le (by
-          exact_mod_cast (show (2 : ℕ) ≤ (⊤ : ℕ∞) by simp))
+          exact WithTop.coe_le_coe.mpr le_top)
       exact h2
 
 /-- An extra spatial derivative commutes with iterated spatial derivatives for smooth
 scalar-valued functions. -/
 lemma deriv_iteratedDeriv_commute (i : Fin d) (I : MultiIndex d) {f : Space d → ℝ}
-    (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
+    (hf : ContDiff ℝ ∞ f) :
     deriv i (∂^[I] f) = ∂^[I] (deriv i f) := by
   symm
   simpa [iteratedDeriv] using iteratedDerivList_commute_deriv I.toList i hf

--- a/Physlib/SpaceAndTime/Space/Derivatives/Iterated.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Iterated.lean
@@ -22,10 +22,18 @@ of coordinate directions, and the iterated derivative is then defined by repeate
 
 - `Space.iteratedDeriv` : iterated coordinate derivatives on `Space d`.
 - `∂^[I] f` : notation for the iterated derivative indexed by the multi-index `I`.
+- `Space.iteratedDeriv_add`, `Space.iteratedDeriv_const_smul` :
+  algebraic compatibility for smooth scalar-valued functions.
+- `Space.iteratedDeriv_contDiff` : smooth scalar-valued functions remain smooth after
+  iterated coordinate differentiation.
+- `Space.tsupport_iteratedDeriv_subset` :
+  the support of an iterated spatial derivative is contained in that of the original function.
 
 ## iii. Table of contents
 
 - A. Iterated derivatives on `Space d`
+- B. Algebraic and regularity lemmas
+- C. Support lemmas
 
 ## iv. References
 
@@ -52,6 +60,49 @@ noncomputable def iteratedDeriv [AddCommGroup M] [Module ℝ M] [TopologicalSpac
 @[inherit_doc iteratedDeriv]
 macro "∂^[" I:term "]" : term => `(iteratedDeriv $I)
 
+private lemma iteratedDerivList_contDiff (L : List (Fin d)) {f : Space d → ℝ}
+    (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
+    ContDiff ℝ (⊤ : ℕ∞) (L.foldr (fun i g => deriv i g) f) := by
+  induction L generalizing f with
+  | nil =>
+      simpa using hf
+  | cons i L ih =>
+      have htail : ContDiff ℝ (⊤ : ℕ∞) (L.foldr (fun j g => deriv j g) f) := ih hf
+      have hfamily : ContDiff ℝ (⊤ : ℕ∞)
+          (fun x : Space d => fun j : Fin d => deriv j (L.foldr (fun j g => deriv j g) f) x) := by
+        simpa using (Space.deriv_contDiff (n := (⊤ : ℕ∞)) htail)
+      have hfixed : ContDiff ℝ (⊤ : ℕ∞)
+          (fun x => deriv i (L.foldr (fun j g => deriv j g) f) x) := by
+        simpa using (contDiff_apply ℝ ℝ i).comp hfamily
+      simpa using hfixed
+
+private lemma iteratedDerivList_add (L : List (Fin d)) {f g : Space d → ℝ}
+    (hf : ContDiff ℝ (⊤ : ℕ∞) f) (hg : ContDiff ℝ (⊤ : ℕ∞) g) :
+    L.foldr (fun i h => deriv i h) (f + g) =
+      L.foldr (fun i h => deriv i h) f + L.foldr (fun i h => deriv i h) g := by
+  induction L generalizing f g with
+  | nil =>
+      rfl
+  | cons i L ih =>
+      simp only [List.foldr]
+      rw [ih hf hg]
+      apply Space.deriv_add
+      · exact (iteratedDerivList_contDiff L hf).differentiable (by simp)
+      · exact (iteratedDerivList_contDiff L hg).differentiable (by simp)
+
+private lemma iteratedDerivList_const_smul (L : List (Fin d)) (c : ℝ) {f : Space d → ℝ}
+    (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
+    L.foldr (fun i h => deriv i h) (c • f) =
+      c • L.foldr (fun i h => deriv i h) f := by
+  induction L generalizing f with
+  | nil =>
+      rfl
+  | cons i L ih =>
+      simp only [List.foldr]
+      rw [ih hf]
+      apply Space.deriv_const_smul
+      exact (iteratedDerivList_contDiff L hf).differentiable (by simp)
+
 @[simp]
 lemma iteratedDeriv_zero [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
     (f : Space d → M) : ∂^[0] f = f := by
@@ -68,5 +119,76 @@ lemma iteratedDeriv_single [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
     (i : Fin d) (f : Space d → M) :
     ∂^[MultiIndex.increment 0 i] f = ∂[i] f := by
   simp [iteratedDeriv, Physlib.MultiIndex.toList_single]
+
+lemma iteratedDeriv_add (I : MultiIndex d) {f g : Space d → ℝ}
+    (hf : ContDiff ℝ (⊤ : ℕ∞) f) (hg : ContDiff ℝ (⊤ : ℕ∞) g) :
+    ∂^[I] (f + g) = ∂^[I] f + ∂^[I] g := by
+  simpa [iteratedDeriv] using iteratedDerivList_add I.toList hf hg
+
+lemma iteratedDeriv_const_smul (I : MultiIndex d) (c : ℝ) {f : Space d → ℝ}
+    (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
+    ∂^[I] (c • f) = c • ∂^[I] f := by
+  simpa [iteratedDeriv] using iteratedDerivList_const_smul I.toList c hf
+
+/-- Iterated spatial derivatives preserve smoothness for scalar-valued functions. -/
+lemma iteratedDeriv_contDiff (I : MultiIndex d) {f : Space d → ℝ}
+    (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
+    ContDiff ℝ (⊤ : ℕ∞) (∂^[I] f) := by
+  simpa [iteratedDeriv] using iteratedDerivList_contDiff I.toList hf
+
+/-- The topological support of a spatial derivative is contained in that of the original
+function. -/
+lemma tsupport_deriv_subset (i : Fin d) {f : Space d → ℝ} :
+    tsupport (deriv i f) ⊆ tsupport f := by
+  simpa [deriv_eq_fderiv_fun] using
+    (tsupport_fderiv_apply_subset (𝕜 := ℝ) (f := fun x => f x) (v := basis i))
+
+private lemma iteratedDerivList_commute_deriv (L : List (Fin d)) (i : Fin d)
+    {f : Space d → ℝ} (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
+    L.foldr (fun j g => deriv j g) (deriv i f) =
+      deriv i (L.foldr (fun j g => deriv j g) f) := by
+  induction L generalizing f with
+  | nil =>
+      rfl
+  | cons j L ih =>
+      simp only [List.foldr]
+      rw [ih hf]
+      rw [Space.deriv_commute (u := j) (v := i)]
+      have h2 : ContDiff ℝ (2 : ℕ∞) (L.foldr (fun j g => deriv j g) f) := by
+        exact (iteratedDerivList_contDiff L hf).of_le (by
+          exact_mod_cast (show (2 : ℕ) ≤ (⊤ : ℕ∞) by simp))
+      exact h2
+
+/-- An extra spatial derivative commutes with iterated spatial derivatives for smooth
+scalar-valued functions. -/
+lemma deriv_iteratedDeriv_commute (i : Fin d) (I : MultiIndex d) {f : Space d → ℝ}
+    (hf : ContDiff ℝ (⊤ : ℕ∞) f) :
+    deriv i (∂^[I] f) = ∂^[I] (deriv i f) := by
+  symm
+  simpa [iteratedDeriv] using iteratedDerivList_commute_deriv I.toList i hf
+
+private lemma tsupport_iteratedDerivList_subset (L : List (Fin d)) {f : Space d → ℝ} :
+    tsupport (L.foldr (fun i g => deriv i g) f) ⊆ tsupport f := by
+  induction L generalizing f with
+  | nil =>
+      simp
+  | cons i L ih =>
+      simpa [List.foldr] using
+        (tsupport_deriv_subset i (f := L.foldr (fun j g => deriv j g) f)).trans (ih (f := f))
+
+/-- The topological support of an iterated spatial derivative is contained in that of the
+original function. -/
+lemma tsupport_iteratedDeriv_subset (I : MultiIndex d) {f : Space d → ℝ} :
+    tsupport (∂^[I] f) ⊆ tsupport f := by
+  simpa [iteratedDeriv] using tsupport_iteratedDerivList_subset I.toList (f := f)
+
+/-- An iterated spatial derivative vanishes outside the topological support of the original
+function. -/
+lemma iteratedDeriv_eq_zero_of_notMem_tsupport (I : MultiIndex d) {f : Space d → ℝ} {x : Space d}
+    (hx : x ∉ tsupport f) :
+    ∂^[I] f x = 0 := by
+  apply Function.notMem_support.mp
+  intro hxI
+  exact hx ((tsupport_iteratedDeriv_subset I) (subset_tsupport _ hxI))
 
 end Space


### PR DESCRIPTION
## Summary

This PR is the third step in a planned local Classical Field Theory development for PhysLib, aimed at a formalization of the local Euler--Lagrange criterion appearing as Theorem 5.2 in Cortés--Haupt, Chapter 5.

The overall local stack is intended to proceed through:
- multi-indices and iterated derivatives,
- admissible compactly supported variations,
- local jets,
- total derivatives,
- local lagrangians and the action functional,
- the local Euler--Lagrange operator,
- and finally the first-variation criterion.

The Zulip discussion for this development is here:
- https://leanprover.zulipchat.com/#narrow/channel/479953-PhysLib/topic/ClassicalFieldTheory/

The previous two PRs introduced the reusable `MultiIndex` API in #1021 and the core definition of iterated coordinate derivative in #1027. This PR adds the small regularity, linearity, and support lemmas needed to use iterated derivatives later in the local jet and first-variation arguments.

## What This PR Adds

This PR extends `Physlib/SpaceAndTime/Space/Derivatives/Iterated.lean` with:
- `Space.iteratedDeriv_add`,
- `Space.iteratedDeriv_const_smul`,
- `Space.iteratedDeriv_contDiff`,
- `Space.deriv_iteratedDeriv_commute`,
- `Space.tsupport_deriv_subset`,
- `Space.tsupport_iteratedDeriv_subset`,
- and `Space.iteratedDeriv_eq_zero_of_notMem_tsupport`.

These results are stated using the notation `∂^[I] f` introduced in the previous PR.

## Why This Is Needed

The next stage of the development packages iterated coordinate derivatives into local jet data. For that, the iterated-derivative API already needs three basic kinds of control:

- algebraic compatibility, so that jet evaluation behaves well with linear combinations of fields;
- regularity preservation, so that smooth fields still yield smooth derivative coordinates;
- and support control, so that compactly supported variations remain manageable after differentiation.

These are also exactly the ingredients later reused in the first-variation and integration-by-parts arguments.

## Scope Of This PR

This PR is intentionally limited to the reusable analytic API around iterated spatial derivatives.

It does not yet introduce:
- local jets,
- field variations,
- or any field-theory-specific definitions.

Those appear in the following PRs, once this derivative layer is in place.

## Build

Locally checked with:
- `python3 scripts/lint-style.py Physlib/SpaceAndTime/Space/Derivatives/Iterated.lean`
- `lake build Physlib.SpaceAndTime.Space.Derivatives.Iterated`
- `lake exe check_file_imports`
