### PR TITLE
Add admissible local variations from test functions

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -1,5 +1,6 @@
 module
 
+public import Physlib.ClassicalFieldTheory.Local.Variation
 public import Physlib.ClassicalMechanics.Basic
 public import Physlib.ClassicalMechanics.DampedHarmonicOscillator.Basic
 public import Physlib.ClassicalMechanics.EulerLagrange
@@ -18,7 +19,6 @@ public import Physlib.ClassicalMechanics.Scattering.RigidSphere
 public import Physlib.ClassicalMechanics.Vibrations.LinearTriatomic
 public import Physlib.ClassicalMechanics.WaveEquation.Basic
 public import Physlib.ClassicalMechanics.WaveEquation.HarmonicWave
-public import Physlib.ClassicalFieldTheory.Local.Variation
 public import Physlib.CondensedMatter.Basic
 public import Physlib.CondensedMatter.TightBindingChain.Basic
 public import Physlib.Cosmology.Basic

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -18,6 +18,7 @@ public import Physlib.ClassicalMechanics.Scattering.RigidSphere
 public import Physlib.ClassicalMechanics.Vibrations.LinearTriatomic
 public import Physlib.ClassicalMechanics.WaveEquation.Basic
 public import Physlib.ClassicalMechanics.WaveEquation.HarmonicWave
+public import Physlib.ClassicalFieldTheory.Local.Variation
 public import Physlib.CondensedMatter.Basic
 public import Physlib.CondensedMatter.TightBindingChain.Basic
 public import Physlib.Cosmology.Basic

--- a/Physlib/ClassicalFieldTheory/Local/Variation.lean
+++ b/Physlib/ClassicalFieldTheory/Local/Variation.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import Physlib.Mathematics.VariationalCalculus.IsTestFunction
+/-!
+# Admissible local variations
+
+## i. Overview
+
+This module packages the admissible variations used in the local first-variation problem.
+
+For the first local stage, a variation is admissible if it is a smooth compactly supported map
+`Space n → Space m`. This reuses the existing `IsTestFunction` predicate rather than introducing a
+second support calculus.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.AdmissibleVariation` : compactly supported smooth variations.
+- `ClassicalFieldTheory.Local.IsAdmissibleVariation` : predicate form of the same notion.
+
+## iii. Table of contents
+
+- A. Admissible variations
+- B. Basic operations on admissible variations
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open Physlib
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Admissible variations
+
+-/
+
+/-- Predicate form of admissible local variations. -/
+abbrev IsAdmissibleVariation (η : Space n → Space m) : Prop := IsTestFunction η
+
+/-- An admissible local variation is a smooth compactly supported map `Space n → Space m`. -/
+structure AdmissibleVariation (n m : ℕ) where
+  toFun : Space n → Space m
+  isAdmissible : IsAdmissibleVariation toFun
+
+namespace AdmissibleVariation
+
+variable {n m : ℕ}
+
+/-!
+## B. Basic operations on admissible variations
+
+-/
+
+instance : CoeFun (AdmissibleVariation n m) (fun _ => Space n → Space m) where
+  coe η := η.toFun
+
+/-- The underlying test-function property of an admissible variation. -/
+lemma isTestFunction (η : AdmissibleVariation n m) : IsTestFunction (η.toFun) := η.isAdmissible
+
+lemma hasCompactSupport (η : AdmissibleVariation n m) : HasCompactSupport (η.toFun) :=
+  η.isTestFunction.supp
+
+noncomputable def toCompactlySupportedContinuousMap (η : AdmissibleVariation n m) :
+    CompactlySupportedContinuousMap (Space n) (Space m) :=
+  η.isTestFunction.toCompactlySupportedContinuousMap
+
+/-- The zero admissible variation. -/
+noncomputable def zero : AdmissibleVariation n m where
+  toFun := fun _ => 0
+  isAdmissible := IsTestFunction.zero
+
+noncomputable instance : Zero (AdmissibleVariation n m) := ⟨zero⟩
+
+@[simp]
+lemma zero_apply (x : Space n) : (0 : AdmissibleVariation n m) x = 0 := rfl
+
+/-- Negation of admissible variations. -/
+noncomputable def neg (η : AdmissibleVariation n m) : AdmissibleVariation n m where
+  toFun := fun x => -η x
+  isAdmissible := η.isTestFunction.neg
+
+noncomputable instance : Neg (AdmissibleVariation n m) := ⟨neg⟩
+
+@[simp]
+lemma neg_apply (η : AdmissibleVariation n m) (x : Space n) : (-η) x = -η x := rfl
+
+/-- Sum of admissible variations. -/
+noncomputable def add (η ξ : AdmissibleVariation n m) : AdmissibleVariation n m where
+  toFun := fun x => η x + ξ x
+  isAdmissible := η.isTestFunction.add ξ.isTestFunction
+
+noncomputable instance : Add (AdmissibleVariation n m) := ⟨add⟩
+
+@[simp]
+lemma add_apply (η ξ : AdmissibleVariation n m) (x : Space n) : (η + ξ) x = η x + ξ x := rfl
+
+/-- Difference of admissible variations. -/
+noncomputable def sub (η ξ : AdmissibleVariation n m) : AdmissibleVariation n m where
+  toFun := fun x => η x - ξ x
+  isAdmissible := η.isTestFunction.sub ξ.isTestFunction
+
+noncomputable instance : Sub (AdmissibleVariation n m) := ⟨sub⟩
+
+@[simp]
+lemma sub_apply (η ξ : AdmissibleVariation n m) (x : Space n) : (η - ξ) x = η x - ξ x := rfl
+
+/-- Scalar multiples of admissible variations by real constants are admissible. -/
+noncomputable def smul (c : ℝ) (η : AdmissibleVariation n m) : AdmissibleVariation n m where
+  toFun := fun x => c • η x
+  isAdmissible := IsTestFunction.smul_left (f := fun _ : Space n => c) (g := η.toFun)
+    (by fun_prop) η.isTestFunction
+
+noncomputable instance : SMul ℝ (AdmissibleVariation n m) := ⟨smul⟩
+
+@[simp]
+lemma smul_apply (c : ℝ) (η : AdmissibleVariation n m) (x : Space n) :
+    (c • η) x = c • η x := rfl
+
+lemma coord (η : AdmissibleVariation n m) (a : Fin m) :
+    IsTestFunction (fun x => (η.toFun x).coord a) := by
+  simpa [Space.coord] using IsTestFunction.coord η.isTestFunction a
+
+end AdmissibleVariation
+
+end Local
+end ClassicalFieldTheory

--- a/Physlib/ClassicalFieldTheory/Local/Variation.lean
+++ b/Physlib/ClassicalFieldTheory/Local/Variation.lean
@@ -14,7 +14,7 @@ public import Physlib.Mathematics.VariationalCalculus.IsTestFunction
 This module packages the admissible variations used in the local first-variation problem.
 
 For the first local stage, a variation is admissible if it is a smooth compactly supported map
-`Space n → U` for a real normed vector space `U`. This reuses the existing `IsTestFunction`
+`Space d → U` for a real normed vector space `U`. This reuses the existing `IsTestFunction`
 predicate rather than introducing a second support calculus.
 
 ## ii. Key results
@@ -43,80 +43,80 @@ namespace Local
 
 -/
 
-/-- An admissible local variation is a smooth compactly supported map `Space n → U`. -/
-structure AdmissibleVariation (n : ℕ) (U : Type*) [NormedAddCommGroup U] [NormedSpace ℝ U] where
+/-- An admissible local variation is a smooth compactly supported map `Space d → U`. -/
+structure AdmissibleVariation (d : ℕ) (U : Type*) [NormedAddCommGroup U] [NormedSpace ℝ U] where
   /-- The underlying variation function. -/
-  toFun : Space n → U
+  toFun : Space d → U
   /-- Smoothness and compact support of the variation. -/
   isTestFunction : IsTestFunction toFun
 
 namespace AdmissibleVariation
 
-variable {n : ℕ} {U : Type*} [NormedAddCommGroup U] [NormedSpace ℝ U]
+variable {d : ℕ} {U : Type*} [NormedAddCommGroup U] [NormedSpace ℝ U]
 
 /-!
 ## B. Basic operations on admissible variations
 
 -/
 
-instance : CoeFun (AdmissibleVariation n U) (fun _ => Space n → U) where
+instance : CoeFun (AdmissibleVariation d U) (fun _ => Space d → U) where
   coe η := η.toFun
 
 attribute [fun_prop] AdmissibleVariation.isTestFunction
 
 /-- An admissible variation has compact support. -/
-lemma hasCompactSupport (η : AdmissibleVariation n U) : HasCompactSupport (η.toFun) :=
+lemma hasCompactSupport (η : AdmissibleVariation d U) : HasCompactSupport (η.toFun) :=
   η.isTestFunction.supp
 
 /-- View an admissible variation as a compactly supported continuous map. -/
-noncomputable def toCompactlySupportedContinuousMap (η : AdmissibleVariation n U) :
-    CompactlySupportedContinuousMap (Space n) U :=
+noncomputable def toCompactlySupportedContinuousMap (η : AdmissibleVariation d U) :
+    CompactlySupportedContinuousMap (Space d) U :=
   η.isTestFunction.toCompactlySupportedContinuousMap
 
-noncomputable instance : Zero (AdmissibleVariation n U) where
+noncomputable instance : Zero (AdmissibleVariation d U) where
   zero :=
     { toFun := fun _ => 0
       isTestFunction := IsTestFunction.zero }
 
 @[simp]
-lemma zero_apply (x : Space n) : (0 : AdmissibleVariation n U) x = 0 := rfl
+lemma zero_apply (x : Space d) : (0 : AdmissibleVariation d U) x = 0 := rfl
 
-noncomputable instance : Neg (AdmissibleVariation n U) where
+noncomputable instance : Neg (AdmissibleVariation d U) where
   neg η :=
     { toFun := fun x => -η x
       isTestFunction := η.isTestFunction.neg }
 
 @[simp]
-lemma neg_apply (η : AdmissibleVariation n U) (x : Space n) : (-η) x = -η x := rfl
+lemma neg_apply (η : AdmissibleVariation d U) (x : Space d) : (-η) x = -η x := rfl
 
-noncomputable instance : Add (AdmissibleVariation n U) where
+noncomputable instance : Add (AdmissibleVariation d U) where
   add η ξ :=
     { toFun := fun x => η x + ξ x
       isTestFunction := η.isTestFunction.add ξ.isTestFunction }
 
 @[simp]
-lemma add_apply (η ξ : AdmissibleVariation n U) (x : Space n) : (η + ξ) x = η x + ξ x := rfl
+lemma add_apply (η ξ : AdmissibleVariation d U) (x : Space d) : (η + ξ) x = η x + ξ x := rfl
 
-noncomputable instance : Sub (AdmissibleVariation n U) where
+noncomputable instance : Sub (AdmissibleVariation d U) where
   sub η ξ :=
     { toFun := fun x => η x - ξ x
       isTestFunction := η.isTestFunction.sub ξ.isTestFunction }
 
 @[simp]
-lemma sub_apply (η ξ : AdmissibleVariation n U) (x : Space n) : (η - ξ) x = η x - ξ x := rfl
+lemma sub_apply (η ξ : AdmissibleVariation d U) (x : Space d) : (η - ξ) x = η x - ξ x := rfl
 
-noncomputable instance : SMul ℝ (AdmissibleVariation n U) where
+noncomputable instance : SMul ℝ (AdmissibleVariation d U) where
   smul c η :=
     { toFun := fun x => c • η x
-      isTestFunction := IsTestFunction.smul_left (f := fun _ : Space n => c) (g := η.toFun)
+      isTestFunction := IsTestFunction.smul_left (f := fun _ : Space d => c) (g := η.toFun)
         (by fun_prop) η.isTestFunction }
 
 @[simp]
-lemma smul_apply (c : ℝ) (η : AdmissibleVariation n U) (x : Space n) :
+lemma smul_apply (c : ℝ) (η : AdmissibleVariation d U) (x : Space d) :
     (c • η) x = c • η x := rfl
 
 @[fun_prop]
-lemma coord {m : ℕ} (η : AdmissibleVariation n (Space m)) (a : Fin m) :
+lemma coord {m : ℕ} (η : AdmissibleVariation d (Space m)) (a : Fin m) :
     IsTestFunction (fun x => (η.toFun x).coord a) := by
   simpa [Space.coord] using IsTestFunction.coord η.isTestFunction a
 

--- a/Physlib/ClassicalFieldTheory/Local/Variation.lean
+++ b/Physlib/ClassicalFieldTheory/Local/Variation.lean
@@ -14,13 +14,12 @@ public import Physlib.Mathematics.VariationalCalculus.IsTestFunction
 This module packages the admissible variations used in the local first-variation problem.
 
 For the first local stage, a variation is admissible if it is a smooth compactly supported map
-`Space n → Space m`. This reuses the existing `IsTestFunction` predicate rather than introducing a
-second support calculus.
+`Space n → U` for a real normed vector space `U`. This reuses the existing `IsTestFunction`
+predicate rather than introducing a second support calculus.
 
 ## ii. Key results
 
 - `ClassicalFieldTheory.Local.AdmissibleVariation` : compactly supported smooth variations.
-- `ClassicalFieldTheory.Local.IsAdmissibleVariation` : predicate form of the same notion.
 
 ## iii. Table of contents
 
@@ -44,89 +43,80 @@ namespace Local
 
 -/
 
-/-- Predicate form of admissible local variations. -/
-abbrev IsAdmissibleVariation (η : Space n → Space m) : Prop := IsTestFunction η
-
-/-- An admissible local variation is a smooth compactly supported map `Space n → Space m`. -/
-structure AdmissibleVariation (n m : ℕ) where
-  toFun : Space n → Space m
-  isAdmissible : IsAdmissibleVariation toFun
+/-- An admissible local variation is a smooth compactly supported map `Space n → U`. -/
+structure AdmissibleVariation (n : ℕ) (U : Type*) [NormedAddCommGroup U] [NormedSpace ℝ U] where
+  /-- The underlying variation function. -/
+  toFun : Space n → U
+  /-- Smoothness and compact support of the variation. -/
+  isTestFunction : IsTestFunction toFun
 
 namespace AdmissibleVariation
 
-variable {n m : ℕ}
+variable {n : ℕ} {U : Type*} [NormedAddCommGroup U] [NormedSpace ℝ U]
 
 /-!
 ## B. Basic operations on admissible variations
 
 -/
 
-instance : CoeFun (AdmissibleVariation n m) (fun _ => Space n → Space m) where
+instance : CoeFun (AdmissibleVariation n U) (fun _ => Space n → U) where
   coe η := η.toFun
 
-/-- The underlying test-function property of an admissible variation. -/
-lemma isTestFunction (η : AdmissibleVariation n m) : IsTestFunction (η.toFun) := η.isAdmissible
+attribute [fun_prop] AdmissibleVariation.isTestFunction
 
-lemma hasCompactSupport (η : AdmissibleVariation n m) : HasCompactSupport (η.toFun) :=
+/-- An admissible variation has compact support. -/
+lemma hasCompactSupport (η : AdmissibleVariation n U) : HasCompactSupport (η.toFun) :=
   η.isTestFunction.supp
 
-noncomputable def toCompactlySupportedContinuousMap (η : AdmissibleVariation n m) :
-    CompactlySupportedContinuousMap (Space n) (Space m) :=
+/-- View an admissible variation as a compactly supported continuous map. -/
+noncomputable def toCompactlySupportedContinuousMap (η : AdmissibleVariation n U) :
+    CompactlySupportedContinuousMap (Space n) U :=
   η.isTestFunction.toCompactlySupportedContinuousMap
 
-/-- The zero admissible variation. -/
-noncomputable def zero : AdmissibleVariation n m where
-  toFun := fun _ => 0
-  isAdmissible := IsTestFunction.zero
-
-noncomputable instance : Zero (AdmissibleVariation n m) := ⟨zero⟩
+noncomputable instance : Zero (AdmissibleVariation n U) where
+  zero :=
+    { toFun := fun _ => 0
+      isTestFunction := IsTestFunction.zero }
 
 @[simp]
-lemma zero_apply (x : Space n) : (0 : AdmissibleVariation n m) x = 0 := rfl
+lemma zero_apply (x : Space n) : (0 : AdmissibleVariation n U) x = 0 := rfl
 
-/-- Negation of admissible variations. -/
-noncomputable def neg (η : AdmissibleVariation n m) : AdmissibleVariation n m where
-  toFun := fun x => -η x
-  isAdmissible := η.isTestFunction.neg
-
-noncomputable instance : Neg (AdmissibleVariation n m) := ⟨neg⟩
+noncomputable instance : Neg (AdmissibleVariation n U) where
+  neg η :=
+    { toFun := fun x => -η x
+      isTestFunction := η.isTestFunction.neg }
 
 @[simp]
-lemma neg_apply (η : AdmissibleVariation n m) (x : Space n) : (-η) x = -η x := rfl
+lemma neg_apply (η : AdmissibleVariation n U) (x : Space n) : (-η) x = -η x := rfl
 
-/-- Sum of admissible variations. -/
-noncomputable def add (η ξ : AdmissibleVariation n m) : AdmissibleVariation n m where
-  toFun := fun x => η x + ξ x
-  isAdmissible := η.isTestFunction.add ξ.isTestFunction
-
-noncomputable instance : Add (AdmissibleVariation n m) := ⟨add⟩
+noncomputable instance : Add (AdmissibleVariation n U) where
+  add η ξ :=
+    { toFun := fun x => η x + ξ x
+      isTestFunction := η.isTestFunction.add ξ.isTestFunction }
 
 @[simp]
-lemma add_apply (η ξ : AdmissibleVariation n m) (x : Space n) : (η + ξ) x = η x + ξ x := rfl
+lemma add_apply (η ξ : AdmissibleVariation n U) (x : Space n) : (η + ξ) x = η x + ξ x := rfl
 
-/-- Difference of admissible variations. -/
-noncomputable def sub (η ξ : AdmissibleVariation n m) : AdmissibleVariation n m where
-  toFun := fun x => η x - ξ x
-  isAdmissible := η.isTestFunction.sub ξ.isTestFunction
-
-noncomputable instance : Sub (AdmissibleVariation n m) := ⟨sub⟩
+noncomputable instance : Sub (AdmissibleVariation n U) where
+  sub η ξ :=
+    { toFun := fun x => η x - ξ x
+      isTestFunction := η.isTestFunction.sub ξ.isTestFunction }
 
 @[simp]
-lemma sub_apply (η ξ : AdmissibleVariation n m) (x : Space n) : (η - ξ) x = η x - ξ x := rfl
+lemma sub_apply (η ξ : AdmissibleVariation n U) (x : Space n) : (η - ξ) x = η x - ξ x := rfl
 
-/-- Scalar multiples of admissible variations by real constants are admissible. -/
-noncomputable def smul (c : ℝ) (η : AdmissibleVariation n m) : AdmissibleVariation n m where
-  toFun := fun x => c • η x
-  isAdmissible := IsTestFunction.smul_left (f := fun _ : Space n => c) (g := η.toFun)
-    (by fun_prop) η.isTestFunction
-
-noncomputable instance : SMul ℝ (AdmissibleVariation n m) := ⟨smul⟩
+noncomputable instance : SMul ℝ (AdmissibleVariation n U) where
+  smul c η :=
+    { toFun := fun x => c • η x
+      isTestFunction := IsTestFunction.smul_left (f := fun _ : Space n => c) (g := η.toFun)
+        (by fun_prop) η.isTestFunction }
 
 @[simp]
-lemma smul_apply (c : ℝ) (η : AdmissibleVariation n m) (x : Space n) :
+lemma smul_apply (c : ℝ) (η : AdmissibleVariation n U) (x : Space n) :
     (c • η) x = c • η x := rfl
 
-lemma coord (η : AdmissibleVariation n m) (a : Fin m) :
+@[fun_prop]
+lemma coord {m : ℕ} (η : AdmissibleVariation n (Space m)) (a : Fin m) :
     IsTestFunction (fun x => (η.toFun x).coord a) := by
   simpa [Space.coord] using IsTestFunction.coord η.isTestFunction a
 


### PR DESCRIPTION
## Summary

This PR is the next step in a planned local Classical Field Theory development for PhysLib, aimed at a formalization of the local Euler--Lagrange criterion appearing as Theorem 5.2 in Cortés--Haupt, Chapter 5.

The overall local stack is intended to proceed through:
- multi-indices and iterated derivatives,
- admissible compactly supported variations,
- local jets,
- total derivatives,
- local lagrangians and the action functional,
- the local Euler--Lagrange operator,
- and finally the first-variation criterion.

The Zulip discussion for this development is here:
- https://leanprover.zulipchat.com/#narrow/channel/479953-PhysLib/topic/ClassicalFieldTheory/

The previous PRs, #1021, #1027, and #1028, introduced the reusable `MultiIndex` API and the basic iterated-derivative layer on `Space d`. This PR adds the corresponding notion of admissible compactly supported variation, built directly from `IsTestFunction`.

## What This PR Adds

This PR adds `Physlib/ClassicalFieldTheory/Local/Variation.lean`, together with its import in `Physlib.lean`.

Concretely, it provides:
- the structure `AdmissibleVariation d U` for compactly supported smooth maps `Space d → U`,
- coercion to the underlying function,
- the induced `IsTestFunction` and `HasCompactSupport` facts,
- the associated `CompactlySupportedContinuousMap`,
- and the basic algebraic structure on admissible variations.

It also includes the coordinatewise test-function lemma

`AdmissibleVariation.coord`

in the specialization to codomain `Space m`.

## Why This Is Needed

In the local variational problem, the admissible perturbations are compactly supported smooth maps

`η : Space d → Space m`.

This PR packages the reusable notion first at the level of a general real normed vector-space codomain `U`, and the later local field-theory PRs will specialize it to `U = Space m`.

The next PRs then use these variations to define the varied field

`f + s • η`

and later the local action variation and criticality condition.

## Scope Of This PR

This PR is intentionally limited to the variation object itself and its first basic operations.

It does not yet define:
- varied fields,
- the action functional,
- action variation,
- or criticality.

Those come in the next local-action PR, so that the variation layer can be reviewed first on its own.

## Build

Locally checked with:
- `python3 scripts/lint-style.py Physlib/ClassicalFieldTheory/Local/Variation.lean`
- `lake build Physlib.ClassicalFieldTheory.Local.Variation`
- `lake exe check_file_imports`
