### PR TITLE
chore: lake shake on physlib

### DIFF
--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -5,9 +5,7 @@ Authors: Nicola Bernini
 -/
 module
 
-public import Physlib.Meta.Informal.SemiFormal
-public import Physlib.ClassicalMechanics.EulerLagrange
-public import Physlib.ClassicalMechanics.HamiltonsEquations
+public import Physlib.SpaceAndTime.Time.Derivatives
 /-!
 
 # The Damped Harmonic Oscillator

--- a/Physlib/ClassicalMechanics/EulerLagrange.lean
+++ b/Physlib/ClassicalMechanics/EulerLagrange.lean
@@ -6,6 +6,7 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 module
 
 public import Physlib.Mathematics.VariationalCalculus.HasVarGradient
+public import Physlib.SpaceAndTime.Time.Derivatives
 /-!
 
 # Euler-Lagrange equations

--- a/Physlib/ClassicalMechanics/HamiltonsEquations.lean
+++ b/Physlib/ClassicalMechanics/HamiltonsEquations.lean
@@ -6,6 +6,7 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 module
 
 public import Physlib.Mathematics.VariationalCalculus.HasVarGradient
+public import Physlib.SpaceAndTime.Time.Derivatives
 /-!
 
 # Hamilton's equations

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.ClassicalMechanics.EulerLagrange
 public import Physlib.ClassicalMechanics.HamiltonsEquations
+public import Mathlib.Data.Real.Hom
 /-!
 
 # The Classical Harmonic Oscillator

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/ConfigurationSpace.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/ConfigurationSpace.lean
@@ -5,8 +5,8 @@ Authors: Nicola Bernini
 -/
 module
 
-public import Mathlib.Geometry.Manifold.Diffeomorph
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.SpaceAndTime.Space.Basic
+public import Mathlib.Analysis.InnerProductSpace.Calculus
 /-!
 # Configuration space of the harmonic oscillator
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith, Lode Vermeulen
 -/
 module
 
-public import Mathlib.Analysis.CStarAlgebra.Classes
 public import Physlib.ClassicalMechanics.HarmonicOscillator.Basic
 /-!
 

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -5,7 +5,8 @@ Authors: Rein Zustand
 -/
 module
 
-public import Physlib.Mathematics.VariationalCalculus.HasVarGradient
+public import Physlib.Mathematics.InnerProductSpace.Basic
+public import Mathlib.Analysis.InnerProductSpace.Dual
 /-!
 
 # Equivalent Lagrangians under Total Derivatives

--- a/Physlib/ClassicalMechanics/Mass/MassUnit.lean
+++ b/Physlib/ClassicalMechanics/Mass/MassUnit.lean
@@ -5,8 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Geometry.Manifold.Diffeomorph
-public import Physlib.SpaceAndTime.Time.Basic
+public import Mathlib.Analysis.RCLike.Basic
 /-!
 
 # Units on Mass

--- a/Physlib/ClassicalMechanics/Pendulum/CoplanarDoublePendulum.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/CoplanarDoublePendulum.lean
@@ -5,8 +5,7 @@ Authors: Shlok Vaibhav Singh
 -/
 module
 
-public import Physlib.Meta.Informal.Basic
-public import Physlib.Meta.Sorry
+public import Physlib.Meta.Linters.Sorry
 /-!
 # Coplanar Double Pendulum
 ### Tag: LnL_1.5.1

--- a/Physlib/ClassicalMechanics/Pendulum/SlidingPendulum.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SlidingPendulum.lean
@@ -5,7 +5,7 @@ Authors: Shlok Vaibhav Singh
 -/
 module
 
-public import Physlib.Meta.Sorry
+public import Physlib.Meta.Linters.Sorry
 /-!
 # Sliding Pendulum
 ### Tag: LnL_1.5.2

--- a/Physlib/ClassicalMechanics/RigidBody/Basic.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Basic.lean
@@ -5,7 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.SpaceAndTime.Space.Derivatives.Curl
+public import Physlib.SpaceAndTime.Space.Module
+public import Physlib.Meta.Informal.Basic
 public import Mathlib.Geometry.Manifold.Algebra.SmoothFunctions
 /-!
 

--- a/Physlib/ClassicalMechanics/RigidBody/SolidSphere.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/SolidSphere.lean
@@ -6,6 +6,8 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.ClassicalMechanics.RigidBody.Basic
+public import Physlib.SpaceAndTime.Space.Integrals.Basic
+public import Physlib.Meta.Linters.Sorry
 /-!
 
 # The solid sphere as a rigid body

--- a/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
+++ b/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
@@ -6,7 +6,7 @@ Authors: Zhi Kai Pong
 module
 
 public import Physlib.SpaceAndTime.Space.CrossProduct
-public import Physlib.SpaceAndTime.TimeAndSpace.Basic
+public import Physlib.SpaceAndTime.Space.Derivatives.Laplacian
 /-!
 
 # Wave equation

--- a/Physlib/CondensedMatter/TightBindingChain/Basic.lean
+++ b/Physlib/CondensedMatter/TightBindingChain/Basic.lean
@@ -5,9 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Meta.Informal.Basic
-public import Physlib.Meta.Informal.SemiFormal
-public import Physlib.Meta.Linters.Sorry
 public import Physlib.QuantumMechanics.FiniteTarget.HilbertSpace
 /-!
 

--- a/Physlib/Cosmology/FLRW/Basic.lean
+++ b/Physlib/Cosmology/FLRW/Basic.lean
@@ -5,8 +5,10 @@ Authors: Luis Gabriel C. Bariuan, Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.SpaceAndTime.Space.Basic
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+public import Physlib.Meta.Linters.Sorry
+public import Physlib.Meta.Informal.Basic
 /-!
 
 # The Friedmann-Lemaître-Robertson-Walker metric

--- a/Physlib/Electromagnetism/Charge/ChargeUnit.lean
+++ b/Physlib/Electromagnetism/Charge/ChargeUnit.lean
@@ -5,10 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Algebra.EuclideanDomain.Basic
-public import Mathlib.Algebra.EuclideanDomain.Field
 public import Mathlib.Analysis.RCLike.Basic
-public import Physlib.Meta.TODO.Basic
 /-!
 
 # The units of charge

--- a/Physlib/Electromagnetism/Current/CircularCoil.lean
+++ b/Physlib/Electromagnetism/Current/CircularCoil.lean
@@ -5,11 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Electromagnetism.Dynamics.IsExtrema
-public import Physlib.SpaceAndTime.Space.Norm
-public import Physlib.SpaceAndTime.Space.Translations
-public import Physlib.SpaceAndTime.Space.ConstantSliceDist
-public import Physlib.SpaceAndTime.TimeAndSpace.ConstantTimeDist
+public import Physlib.Meta.TODO.Basic
 /-!
 # The electrostatics of a circular coil
 
@@ -38,8 +34,7 @@ TODO "TCGIW" "Copying the structure of the electrostatics of an infinite wire,
 
 namespace Electromagnetism
 namespace DistElectromagneticPotential
-open minkowskiMatrix SpaceTime SchwartzMap Lorentz
-attribute [-simp] Fintype.sum_sum_type
+
 attribute [-simp] Nat.succ_eq_add_one
 /-!
 

--- a/Physlib/Electromagnetism/Current/InfiniteWire.lean
+++ b/Physlib/Electromagnetism/Current/InfiniteWire.lean
@@ -7,7 +7,6 @@ module
 
 public import Physlib.Electromagnetism.Dynamics.IsExtrema
 public import Physlib.SpaceAndTime.Space.Norm
-public import Physlib.SpaceAndTime.Space.Translations
 public import Physlib.SpaceAndTime.Space.ConstantSliceDist
 public import Physlib.SpaceAndTime.TimeAndSpace.ConstantTimeDist
 /-!

--- a/Physlib/Electromagnetism/Dynamics/Basic.lean
+++ b/Physlib/Electromagnetism/Dynamics/Basic.lean
@@ -5,7 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Electromagnetism.Basic
+public import Physlib.Relativity.SpeedOfLight
+public import Mathlib.Data.Real.Sqrt
 /-!
 
 # Free space

--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.Electromagnetism.Kinematics.MagneticField
 public import Physlib.Electromagnetism.Dynamics.Basic
+public import Physlib.Mathematics.VariationalCalculus.HasVarGradient
 /-!
 
 # The kinetic term

--- a/Physlib/Electromagnetism/Dynamics/Lagrangian.lean
+++ b/Physlib/Electromagnetism/Dynamics/Lagrangian.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.Electromagnetism.Dynamics.CurrentDensity
 public import Physlib.Electromagnetism.Dynamics.KineticTerm
+public import Physlib.Relativity.Tensors.RealTensor.Vector.MinkowskiProduct
 /-!
 
 # The Lagrangian in electromagnetism

--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -5,9 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Electromagnetism.Basic
-public import Physlib.SpaceAndTime.SpaceTime.TimeSlice
-public import Physlib.Mathematics.VariationalCalculus.HasVarGradient
+public import Physlib.SpaceAndTime.SpaceTime.Derivatives
+public import Physlib.Mathematics.VariationalCalculus.HasVarAdjDeriv
 /-!
 
 # The Electromagnetic Potential

--- a/Physlib/Electromagnetism/Kinematics/ElectricField.lean
+++ b/Physlib/Electromagnetism/Kinematics/ElectricField.lean
@@ -8,6 +8,7 @@ module
 public import Physlib.Electromagnetism.Kinematics.VectorPotential
 public import Physlib.Electromagnetism.Kinematics.ScalarPotential
 public import Physlib.Electromagnetism.Kinematics.FieldStrength
+public import Physlib.Electromagnetism.Basic
 /-!
 
 # The Electric Field

--- a/Physlib/Electromagnetism/Kinematics/FieldStrength.lean
+++ b/Physlib/Electromagnetism/Kinematics/FieldStrength.lean
@@ -6,6 +6,9 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Electromagnetism.Kinematics.EMPotential
+public import Physlib.Relativity.Tensors.Elab
+public import Physlib.Relativity.Tensors.RealTensor.Metrics.Basic
+public import Mathlib.Data.Real.Hom
 /-!
 
 # The Field Strength Tensor

--- a/Physlib/Electromagnetism/Kinematics/ScalarPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/ScalarPotential.lean
@@ -6,6 +6,8 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Electromagnetism.Kinematics.EMPotential
+public import Physlib.SpaceAndTime.SpaceTime.TimeSlice
+public import Mathlib.Data.Real.Hom
 /-!
 
 # The Scalar Potential

--- a/Physlib/Electromagnetism/Kinematics/VectorPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/VectorPotential.lean
@@ -6,6 +6,8 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Electromagnetism.Kinematics.EMPotential
+public import Physlib.SpaceAndTime.SpaceTime.TimeSlice
+public import Mathlib.Data.Real.Hom
 /-!
 
 # The vector Potential

--- a/Physlib/Mathematics/Calculus/Divergence.lean
+++ b/Physlib/Mathematics/Calculus/Divergence.lean
@@ -5,9 +5,9 @@ Authors: Tomas Skrivan
 -/
 module
 
-public import Mathlib.Analysis.InnerProductSpace.Trace
+public import Mathlib.LinearAlgebra.Trace
 public import Physlib.Mathematics.Calculus.AdjFDeriv
-public import Physlib.SpaceAndTime.TimeAndSpace.Basic
+public import Physlib.SpaceAndTime.Space.Derivatives.Div
 /-!
 
 # Divergence

--- a/Physlib/Mathematics/Distribution/Basic.lean
+++ b/Physlib/Mathematics/Distribution/Basic.lean
@@ -5,8 +5,9 @@ Authors: Kenny Lau, Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Analysis.Distribution.TemperedDistribution
 public import Physlib.Meta.TODO.Basic
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
+public import Mathlib.Topology.Algebra.Module.PointwiseConvergence
 /-!
 
 # Distributions
@@ -392,7 +393,7 @@ outputs `η a • v`.
 
 section DiracDelta
 
-open TemperedDistribution ContinuousLinearMap
+open ContinuousLinearMap
 
 variable [NormedSpace ℝ E] [NormedSpace 𝕜 F]
 

--- a/Physlib/Mathematics/Distribution/PowMul.lean
+++ b/Physlib/Mathematics/Distribution/PowMul.lean
@@ -5,8 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Mathematics.Distribution.Basic
-public import Mathlib.MeasureTheory.Constructions.HaarToSphere
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Basic
 /-!
 
 ## The multiple of a Schwartz map by `x`

--- a/Physlib/Mathematics/Fin.lean
+++ b/Physlib/Mathematics/Fin.lean
@@ -5,8 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Tactic.Polyrith
-public import Mathlib.Tactic.Linarith
+public import Mathlib.Algebra.Order.Group.Nat
+public import Mathlib.Algebra.Order.Monoid.NatCast
 public import Mathlib.Logic.Equiv.Fin.Basic
 /-!
 # Fin lemmas

--- a/Physlib/Mathematics/Fin/Involutions.lean
+++ b/Physlib/Mathematics/Fin/Involutions.lean
@@ -5,12 +5,10 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Tactic.Polyrith
-public import Mathlib.Tactic.Linarith
-public import Mathlib.Data.Nat.Factorial.DoubleFactorial
 public import Mathlib.Data.Finset.Sort
 public import Mathlib.Data.Fintype.Pi
 public import Mathlib.Data.Fintype.Prod
+public import Mathlib.Data.Nat.Factorial.DoubleFactorial
 /-!
 # Fin involutions
 

--- a/Physlib/Mathematics/Geometry/Metric/PseudoRiemannian/Defs.lean
+++ b/Physlib/Mathematics/Geometry/Metric/PseudoRiemannian/Defs.lean
@@ -6,7 +6,6 @@ Authors: Matteo Cipollina
 module
 
 public import Mathlib.Analysis.InnerProductSpace.Basic
-public import Mathlib.Analysis.RCLike.Lemmas
 public import Mathlib.Geometry.Manifold.MFDeriv.Defs
 public import Mathlib.LinearAlgebra.BilinearForm.Properties
 public import Mathlib.LinearAlgebra.QuadraticForm.Real

--- a/Physlib/Mathematics/Geometry/Metric/Riemannian/Defs.lean
+++ b/Physlib/Mathematics/Geometry/Metric/Riemannian/Defs.lean
@@ -6,7 +6,6 @@ Authors: Matteo Cipollina
 module
 
 public import Physlib.Mathematics.Geometry.Metric.PseudoRiemannian.Defs
-public import Mathlib.Algebra.Lie.OfAssociative
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 /-!
 # Riemannian Metric Definitions

--- a/Physlib/Mathematics/InnerProductSpace/Basic.lean
+++ b/Physlib/Mathematics/InnerProductSpace/Basic.lean
@@ -6,10 +6,7 @@ Authors: Tomas Skrivan
 module
 
 public import Mathlib.Analysis.InnerProductSpace.Calculus
-public import Mathlib.Analysis.InnerProductSpace.Completion
 public import Mathlib.Analysis.InnerProductSpace.ProdL2
-public import Mathlib.Data.Real.Hom
-public import Mathlib.Data.Real.StarOrdered
 /-!
 
 # Inner product space

--- a/Physlib/Mathematics/InnerProductSpace/Calculus.lean
+++ b/Physlib/Mathematics/InnerProductSpace/Calculus.lean
@@ -6,7 +6,6 @@ Authors: Tomas Skrivan
 module
 
 public import Physlib.Mathematics.InnerProductSpace.Basic
-public import Mathlib.Analysis.InnerProductSpace.Adjoint
 /-!
 
 # Generalization of calculus results to `InnerProductSpace'`

--- a/Physlib/Mathematics/LinearMaps.lean
+++ b/Physlib/Mathematics/LinearMaps.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Tactic.Polyrith
 public import Mathlib.Algebra.Module.LinearMap.Defs
 public import Mathlib.Data.Fintype.BigOperators
 public import Physlib.Meta.TODO.Basic

--- a/Physlib/Mathematics/List/InsertIdx.lean
+++ b/Physlib/Mathematics/List/InsertIdx.lean
@@ -5,8 +5,10 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Data.List.Sort
-public import Mathlib.Algebra.Order.Ring.Nat
+public import Mathlib.Algebra.GroupWithZero.Nat
+public import Mathlib.Algebra.Order.Group.Nat
+public import Mathlib.Algebra.Order.ZeroLEOne
+public import Mathlib.Data.Fin.SuccPred
 /-!
 # List lemmas
 

--- a/Physlib/Mathematics/Trigonometry/Tanh.lean
+++ b/Physlib/Mathematics/Trigonometry/Tanh.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Topology.Algebra.Polynomial
 public import Mathlib.Analysis.Calculus.Deriv.Polynomial
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
-public import Mathlib.Analysis.Distribution.SchwartzSpace.Deriv
+public import Mathlib.Analysis.Distribution.TemperateGrowth
 /-!
 # Properties of Tanh
 We want to prove that the reflectionless potential is a Schwartz map.

--- a/Physlib/Mathematics/VariationalCalculus/Basic.lean
+++ b/Physlib/Mathematics/VariationalCalculus/Basic.lean
@@ -6,6 +6,7 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 module
 
 public import Physlib.Mathematics.VariationalCalculus.IsTestFunction
+public import Mathlib.Analysis.Calculus.BumpFunction.InnerProduct
 /-!
 
 # Fundamental lemma of the calculus of variations

--- a/Physlib/Mathematics/VariationalCalculus/HasVarAdjoint.lean
+++ b/Physlib/Mathematics/VariationalCalculus/HasVarAdjoint.lean
@@ -6,6 +6,7 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 module
 
 public import Physlib.Mathematics.VariationalCalculus.IsLocalizedfunctionTransform
+public import Physlib.Mathematics.VariationalCalculus.Basic
 /-!
 # Variational adjoint
 

--- a/Physlib/Mathematics/VariationalCalculus/IsLocalizedfunctionTransform.lean
+++ b/Physlib/Mathematics/VariationalCalculus/IsLocalizedfunctionTransform.lean
@@ -5,7 +5,8 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Mathematics.VariationalCalculus.Basic
+public import Physlib.SpaceAndTime.Space.Derivatives.Div
+public import Physlib.Mathematics.Calculus.AdjFDeriv
 /-!
 
 # Localized function transforms

--- a/Physlib/Mathematics/VariationalCalculus/IsTestFunction.lean
+++ b/Physlib/Mathematics/VariationalCalculus/IsTestFunction.lean
@@ -6,6 +6,7 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 module
 
 public import Physlib.Mathematics.Calculus.Divergence
+public import Mathlib.Topology.ContinuousMap.CompactlySupported
 /-!
 
 # Test functions

--- a/Physlib/Meta/Basic.lean
+++ b/Physlib/Meta/Basic.lean
@@ -6,8 +6,6 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Mathlib.Lean.Expr.Basic
-public import ImportGraph.Imports.RequiredModules
-public import Lean.Elab.DocString
 /-!
 
 ## Basic Lean meta programming commands

--- a/Physlib/Meta/Notes/NoteFile.lean
+++ b/Physlib/Meta/Notes/NoteFile.lean
@@ -5,7 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Lean.Environment
+public import Lean.Setup
 /-!
 
 # Note file

--- a/Physlib/Optics/Polarization/Basic.lean
+++ b/Physlib/Optics/Polarization/Basic.lean
@@ -5,7 +5,6 @@ Authors: Zhi Kai Pong
 -/
 module
 
-public import Physlib.Electromagnetism.Vacuum.HarmonicWave
 /-!
 
 # Polarization

--- a/Physlib/Particles/BeyondTheStandardModel/TwoHDM/Basic.lean
+++ b/Physlib/Particles/BeyondTheStandardModel/TwoHDM/Basic.lean
@@ -5,9 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Particles.StandardModel.HiggsBoson.Potential
-public import Mathlib.Analysis.Matrix.Normed
-public import Mathlib.Analysis.Matrix.Order
+public import Physlib.Particles.StandardModel.HiggsBoson.Basic
 /-!
 
 # The Two Higgs Doublet Model

--- a/Physlib/Particles/FlavorPhysics/CKMMatrix/Basic.lean
+++ b/Physlib/Particles/FlavorPhysics/CKMMatrix/Basic.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.LinearAlgebra.UnitaryGroup
 public import Mathlib.Analysis.Complex.Trigonometric
-public import Mathlib.Tactic.Polyrith
 /-!
 # The CKM Matrix
 

--- a/Physlib/Particles/NeutrinoPhysics/Basic.lean
+++ b/Physlib/Particles/NeutrinoPhysics/Basic.lean
@@ -6,8 +6,7 @@ Authors: Prabhoda Chandra Sarjapur
 module
 
 public import Mathlib.LinearAlgebra.UnitaryGroup
-public import Mathlib.Analysis.Complex.Trigonometric
-public import Mathlib.Tactic.Polyrith
+public import Mathlib.Analysis.Complex.Exponential
 /-!
 
 # The PMNS matrix

--- a/Physlib/Particles/StandardModel/Basic.lean
+++ b/Physlib/Particles/StandardModel/Basic.lean
@@ -5,9 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Geometry.Manifold.Instances.Real
-public import Physlib.Meta.Informal.SemiFormal
 public import Physlib.SpaceAndTime.SpaceTime.Basic
+public import Physlib.Meta.Linters.Sorry
 /-!
 # The Standard Model
 

--- a/Physlib/Particles/StandardModel/HiggsBoson/Basic.lean
+++ b/Physlib/Particles/StandardModel/HiggsBoson/Basic.lean
@@ -6,7 +6,6 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Particles.StandardModel.Basic
-public import Mathlib.Analysis.InnerProductSpace.Adjoint
 public import Mathlib.Geometry.Manifold.VectorBundle.SmoothSection
 /-!
 

--- a/Physlib/Particles/StandardModel/Representations.lean
+++ b/Physlib/Particles/StandardModel/Representations.lean
@@ -5,7 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Geometry.Manifold.Instances.Real
+public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.LinearAlgebra.UnitaryGroup
 /-!
 # Representations appearing in the Standard Model
 
@@ -17,7 +18,6 @@ This file defines the basic representations which appear in the Standard Model.
 
 namespace StandardModel
 
-open Manifold
 open Matrix
 open Complex
 open ComplexConjugate

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/AllowsTerm.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/AllowsTerm.lean
@@ -6,7 +6,6 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Particles.SuperSymmetry.SU5.ChargeSpectrum.OfPotentialTerm
-public import Mathlib.Tactic.FinCases
 /-!
 
 # Charges allowing terms

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/Basic.lean
@@ -9,7 +9,6 @@ public import Mathlib.Data.Finset.Powerset
 public import Mathlib.Data.Finset.Prod
 public import Mathlib.Data.Finset.Sort
 public import Mathlib.Data.Finset.Option
-public import Physlib.Particles.SuperSymmetry.SU5.Potential
 /-!
 
 # Charge Spectrum

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/Map.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/Map.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.Particles.SuperSymmetry.SU5.ChargeSpectrum.Yukawa
 public import Physlib.Particles.SuperSymmetry.SU5.ChargeSpectrum.Completions
+public import Mathlib.Tactic.FinCases
 /-!
 
 # Mapping charge spectra values

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/MinimallyAllowsTerm/FinsetTerms.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/MinimallyAllowsTerm/FinsetTerms.lean
@@ -5,7 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Particles.SuperSymmetry.SU5.ChargeSpectrum.PhenoConstrained
+public import Mathlib.Tactic.FinCases
 public import Physlib.Particles.SuperSymmetry.SU5.ChargeSpectrum.MinimallyAllowsTerm.Basic
 /-!
 

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/OfFieldLabel.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/OfFieldLabel.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Particles.SuperSymmetry.SU5.ChargeSpectrum.Basic
+public import Physlib.Particles.SuperSymmetry.SU5.FieldLabels
 /-!
 
 # Charges associated with a field label

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/OfPotentialTerm.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/OfPotentialTerm.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Particles.SuperSymmetry.SU5.ChargeSpectrum.OfFieldLabel
+public import Physlib.Particles.SuperSymmetry.SU5.Potential
 public import Mathlib.Tactic.Abel
 /-!
 

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/PhenoConstrained.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/PhenoConstrained.lean
@@ -6,7 +6,6 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Particles.SuperSymmetry.SU5.ChargeSpectrum.AllowsTerm
-public import Mathlib.Tactic.Polyrith
 /-!
 
 # Pheno constrained charge spectra

--- a/Physlib/QFT/AnomalyCancellation/Basic.lean
+++ b/Physlib/QFT/AnomalyCancellation/Basic.lean
@@ -7,7 +7,6 @@ module
 
 public import Physlib.Mathematics.LinearMaps
 public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
-public import Physlib.Meta.Linters.Sorry
 public import Mathlib.Tactic.Cases
 /-!
 # Anomaly cancellation conditions

--- a/Physlib/QFT/PerturbationTheory/FeynmanDiagrams/Basic.lean
+++ b/Physlib/QFT/PerturbationTheory/FeynmanDiagrams/Basic.lean
@@ -5,10 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Tactic.FinCases
-public import Mathlib.CategoryTheory.Comma.Over.Basic
-public import Mathlib.CategoryTheory.IsomorphismClasses
-public import Mathlib.Data.Fintype.Perm
 /-!
 # Feynman diagrams
 

--- a/Physlib/QFT/PerturbationTheory/FieldStatistics/Basic.lean
+++ b/Physlib/QFT/PerturbationTheory/FieldStatistics/Basic.lean
@@ -10,6 +10,7 @@ public import Mathlib.Tactic.FinCases
 public import Mathlib.Algebra.BigOperators.Group.Finset.Piecewise
 public import Mathlib.Data.Fintype.Card
 public import Mathlib.Algebra.FreeMonoid.Basic
+public import Mathlib.Data.List.Sort
 /-!
 
 # Field statistics

--- a/Physlib/QFT/PerturbationTheory/WickContraction/ExtractEquiv.lean
+++ b/Physlib/QFT/PerturbationTheory/WickContraction/ExtractEquiv.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
 module
-meta import Mathlib.Data.Fintype.Sigma
+
 meta import Physlib.QFT.PerturbationTheory.WickContraction.InsertAndContractNat
 import all Init.Data.Fin.Fold
 public import Physlib.QFT.PerturbationTheory.WickContraction.InsertAndContractNat

--- a/Physlib/QFT/PerturbationTheory/WickContraction/Perm.lean
+++ b/Physlib/QFT/PerturbationTheory/WickContraction/Perm.lean
@@ -7,7 +7,7 @@ module
 
 public import Physlib.QFT.PerturbationTheory.WickAlgebra.WickTerm
 public import Physlib.QFT.PerturbationTheory.WickContraction.IsFull
-public import Physlib.Meta.Informal.SemiFormal
+public import Physlib.Meta.Linters.Sorry
 /-!
 
 # Permutations of Wick contractions

--- a/Physlib/QFT/PerturbationTheory/WickContraction/Sign/Basic.lean
+++ b/Physlib/QFT/PerturbationTheory/WickContraction/Sign/Basic.lean
@@ -6,7 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.QFT.PerturbationTheory.WickContraction.Basic
-public import Physlib.QFT.PerturbationTheory.Koszul.KoszulSign
+public import Physlib.QFT.PerturbationTheory.FieldStatistics.ExchangeSign
 /-!
 
 # Sign associated with a contraction

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.QuantumMechanics.DDimensions.Hydrogen.Basic
 public import Physlib.QuantumMechanics.DDimensions.Operators.Commutation
+public import Physlib.Meta.Linters.Sorry
 /-!
 
 # Laplace-Runge-Lenz vector

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -8,6 +8,7 @@ module
 public import Physlib.QuantumMechanics.DDimensions.Operators.Unbounded
 public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.SchwartzSubmodule
 public import Physlib.SpaceAndTime.Space.Integrals.NormPow
+public import Physlib.SpaceAndTime.Space.Derivatives.Basic
 /-!
 
 # Position operators

--- a/Physlib/QuantumMechanics/FiniteTarget/HilbertSpace.lean
+++ b/Physlib/QuantumMechanics/FiniteTarget/HilbertSpace.lean
@@ -5,8 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Analysis.CStarAlgebra.Classes
-public import Physlib.Meta.TODO.Basic
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 /-!
 

--- a/Physlib/QuantumMechanics/OneDimension/GeneralPotential/Basic.lean
+++ b/Physlib/QuantumMechanics/OneDimension/GeneralPotential/Basic.lean
@@ -6,7 +6,6 @@ Authors: Ammar Husain
 module
 
 public import Physlib.QuantumMechanics.OneDimension.Operators.Momentum
-public import Physlib.QuantumMechanics.OneDimension.Operators.Position
 
 /-!
 
@@ -20,7 +19,7 @@ namespace QuantumMechanics
 
 namespace OneDimension
 
-open Physlib HilbertSpace Constants
+open HilbertSpace Constants
 
 private lemma fun_add {α : Type*} (f g : α → ℂ) :
   (fun x ↦ f x) + (fun x ↦ g x) = fun x ↦ f x + g x := by

--- a/Physlib/QuantumMechanics/OneDimension/HarmonicOscillator/Basic.lean
+++ b/Physlib/QuantumMechanics/OneDimension/HarmonicOscillator/Basic.lean
@@ -71,7 +71,7 @@ structure HarmonicOscillator where
 
 namespace HarmonicOscillator
 open Constants
-open Physlib HilbertSpace
+open HilbertSpace
 open MeasureTheory
 
 variable (Q : HarmonicOscillator)

--- a/Physlib/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean
+++ b/Physlib/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean
@@ -5,10 +5,9 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.MeasureTheory.Function.L2Space
-public import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
-public import Physlib.Meta.Linters.Sorry
 public import Mathlib.Analysis.InnerProductSpace.Dual
+public import Mathlib.MeasureTheory.Function.L2Space
+public import Mathlib.MeasureTheory.Measure.Haar.OfBasis
 /-!
 
 # Hilbert space for one dimension quantum mechanics

--- a/Physlib/QuantumMechanics/OneDimension/HilbertSpace/Gaussians.lean
+++ b/Physlib/QuantumMechanics/OneDimension/HilbertSpace/Gaussians.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.Basic
+public import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
 /-!
 
 # Gaussians and the hilbert space

--- a/Physlib/QuantumMechanics/OneDimension/HilbertSpace/PlaneWaves.lean
+++ b/Physlib/QuantumMechanics/OneDimension/HilbertSpace/PlaneWaves.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.SchwartzSubmodule
 public import Mathlib.Analysis.Distribution.TemperedDistribution
 /-!
 

--- a/Physlib/QuantumMechanics/OneDimension/HilbertSpace/PositionStates.lean
+++ b/Physlib/QuantumMechanics/OneDimension/HilbertSpace/PositionStates.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.SchwartzSubmodule
 public import Mathlib.Analysis.Distribution.TemperedDistribution
 /-!
 

--- a/Physlib/QuantumMechanics/OneDimension/HilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/OneDimension/HilbertSpace/SchwartzSubmodule.lean
@@ -6,7 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.Basic
-public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Basic
 /-!
 
 # Schwartz submodule of the Hilbert space

--- a/Physlib/QuantumMechanics/OneDimension/Operators/Momentum.lean
+++ b/Physlib/QuantumMechanics/OneDimension/Operators/Momentum.lean
@@ -5,7 +5,11 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
+public import Mathlib.Analysis.Calculus.FDeriv.Star
 public import Physlib.QuantumMechanics.OneDimension.Operators.Unbounded
+public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.SchwartzSubmodule
+public import Physlib.QuantumMechanics.PlanckConstant
+public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.PlaneWaves
 /-!
 
 # Momentum operator

--- a/Physlib/QuantumMechanics/OneDimension/Operators/Parity.lean
+++ b/Physlib/QuantumMechanics/OneDimension/Operators/Parity.lean
@@ -5,8 +5,9 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.PositionStates
+public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.SchwartzSubmodule
 public import Physlib.QuantumMechanics.OneDimension.Operators.Unbounded
+public import Mathlib.MeasureTheory.Measure.Haar.Unique
 /-!
 
 # Parity operator

--- a/Physlib/QuantumMechanics/OneDimension/Operators/Position.lean
+++ b/Physlib/QuantumMechanics/OneDimension/Operators/Position.lean
@@ -8,6 +8,7 @@ module
 public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.PositionStates
 public import Physlib.QuantumMechanics.OneDimension.Operators.Unbounded
 public import Physlib.Mathematics.Distribution.PowMul
+public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.SchwartzSubmodule
 /-!
 
 # Position operator
@@ -26,7 +27,6 @@ namespace QuantumMechanics
 
 namespace OneDimension
 noncomputable section
-open Constants
 open HilbertSpace
 
 /-!

--- a/Physlib/QuantumMechanics/OneDimension/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/OneDimension/Operators/Unbounded.lean
@@ -5,9 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.PlaneWaves
-public import Physlib.QuantumMechanics.PlanckConstant
-public import Mathlib.Analysis.Calculus.FDeriv.Star
+public import Physlib.QuantumMechanics.OneDimension.HilbertSpace.Basic
 /-!
 
 # Unbounded operators
@@ -25,7 +23,6 @@ namespace QuantumMechanics
 
 namespace OneDimension
 noncomputable section
-open Constants
 open HilbertSpace
 
 /-- An unbounded operator on the one-dimensional Hilbert space,

--- a/Physlib/QuantumMechanics/OneDimension/ReflectionlessPotential/Basic.lean
+++ b/Physlib/QuantumMechanics/OneDimension/ReflectionlessPotential/Basic.lean
@@ -5,10 +5,7 @@ Authors: Afiq Hatta
 -/
 module
 
-public import Physlib.QuantumMechanics.OneDimension.Operators.Parity
 public import Physlib.QuantumMechanics.OneDimension.Operators.Momentum
-public import Physlib.QuantumMechanics.OneDimension.Operators.Position
-public import Physlib.SpaceAndTime.Time.Basic
 public import Physlib.Mathematics.Trigonometry.Tanh
 /-!
 
@@ -30,7 +27,6 @@ annihilation operators
 
 namespace QuantumMechanics
 open Real
-open Space
 open SchwartzMap
 open HilbertSpace
 open NNReal

--- a/Physlib/Relativity/LorentzAlgebra/ExponentialMap.lean
+++ b/Physlib/Relativity/LorentzAlgebra/ExponentialMap.lean
@@ -5,7 +5,6 @@ Authors: Matteo Cipollina
 -/
 module
 
-public import Mathlib.Analysis.Normed.Field.Instances
 public import Physlib.Mathematics.DataStructures.Matrix.LieTrace
 public import Physlib.Relativity.LorentzAlgebra.Basic
 public import Physlib.Relativity.LorentzGroup.Restricted.Basic

--- a/Physlib/Relativity/LorentzGroup/Boosts/Apply.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Apply.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Relativity.LorentzGroup.Boosts.Basic
+public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
 /-!
 
 ## Boosts applied to Lorentz vectors

--- a/Physlib/Relativity/LorentzGroup/Boosts/Basic.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Basic.lean
@@ -5,7 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.SpaceAndTime.SpaceTime.Basic
+public import Physlib.Relativity.LorentzGroup.Basic
 /-!
 # Boosts in the Lorentz group
 

--- a/Physlib/Relativity/LorentzGroup/Boosts/Generalized.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Generalized.lean
@@ -6,7 +6,6 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Relativity.LorentzGroup.Restricted.Basic
-public import Physlib.Meta.Linters.Sorry
 /-!
 
 # Generalized Boosts

--- a/Physlib/Relativity/LorentzGroup/Restricted/FromBoostRotation.lean
+++ b/Physlib/Relativity/LorentzGroup/Restricted/FromBoostRotation.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Relativity.LorentzGroup.Rotations
+public import Physlib.Relativity.LorentzGroup.Boosts.Generalized
 /-!
 # The construction of an element of the Lorentz group from a boost and a rotation
 

--- a/Physlib/Relativity/LorentzGroup/Rotations.lean
+++ b/Physlib/Relativity/LorentzGroup/Rotations.lean
@@ -5,7 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Relativity.LorentzGroup.Boosts.Generalized
+public import Physlib.Relativity.LorentzGroup.Restricted.Basic
 /-!
 # Rotations
 

--- a/Physlib/Relativity/PauliMatrices/Basic.lean
+++ b/Physlib/Relativity/PauliMatrices/Basic.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Algebra.Lie.OfAssociative
 public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.LinearAlgebra.Matrix.Trace
 /-!

--- a/Physlib/Relativity/SpeedOfLight.lean
+++ b/Physlib/Relativity/SpeedOfLight.lean
@@ -5,8 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Algebra.Lie.Classical
-public import Mathlib.Analysis.Normed.Ring.Lemmas
+public import Mathlib.Data.Real.Basic
 /-!
 
 # The Speed of Light
@@ -33,7 +32,6 @@ and should be thought of as the speed of light in some chosen but arbitrary syst
 -/
 
 @[expose] public section
-open Matrix
 
 /-!
 

--- a/Physlib/Relativity/Tensors/Basic.lean
+++ b/Physlib/Relativity/Tensors/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Physlib.Relativity.Tensors.TensorSpecies.Basic
 public import Mathlib.Topology.Algebra.Module.ModuleTopology
 public import Mathlib.Analysis.RCLike.Basic
+public import Physlib.Meta.TODO.Basic
 /-!
 
 # Tensors

--- a/Physlib/Relativity/Tensors/Color/Basic.lean
+++ b/Physlib/Relativity/Tensors/Color/Basic.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.CategoryTheory.Core
 public import Mathlib.CategoryTheory.Comma.Over.Basic
 public import Mathlib.CategoryTheory.Monoidal.Braided.Basic
-public import Physlib.Meta.TODO.Basic
 /-!
 
 # Color

--- a/Physlib/Relativity/Tensors/ComplexTensor/Weyl/Modules.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/Weyl/Modules.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Algebra.Lie.OfAssociative
 public import Mathlib.Analysis.Complex.Basic
 /-!
 

--- a/Physlib/Relativity/Tensors/RealTensor/CoVector/Basic.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/CoVector/Basic.lean
@@ -5,9 +5,9 @@ Authors: Matteo Cipollina, Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Relativity.Tensors.RealTensor.Metrics.Basic
-public import Mathlib.Geometry.Manifold.IsManifold.Basic
-public import Physlib.Relativity.Tensors.Elab
+public import Physlib.Relativity.Tensors.Tensorial
+public import Physlib.Relativity.Tensors.RealTensor.Basic
+public import Mathlib.Geometry.Manifold.ChartedSpace
 /-!
 
 # Lorentz co vectors

--- a/Physlib/Relativity/Tensors/RealTensor/Derivative.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Derivative.lean
@@ -5,7 +5,9 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Relativity.Tensors.ComplexTensor.Basic
+public import Mathlib.Analysis.Calculus.FDeriv.Prod
+public import Physlib.Relativity.Tensors.Product
+public import Physlib.Relativity.Tensors.RealTensor.Basic
 /-!
 
 ## Derivative of Real Lorentz tensors

--- a/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith, Nikolai Kashcheev
 -/
 module
 
-public import Physlib.Meta.Linters.Sorry
 public import Physlib.Relativity.Tensors.ComplexTensor.Basic
 /-!
 

--- a/Physlib/Relativity/Tensors/RealTensor/Vector/Basic.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Vector/Basic.lean
@@ -5,9 +5,9 @@ Authors: Matteo Cipollina, Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Relativity.Tensors.RealTensor.Metrics.Basic
-public import Physlib.Relativity.Tensors.Elab
 public import Mathlib.Geometry.Manifold.IsManifold.Basic
+public import Physlib.Relativity.Tensors.RealTensor.Basic
+public import Physlib.Relativity.Tensors.Tensorial
 /-!
 
 # Lorentz Vectors

--- a/Physlib/Relativity/Tensors/RealTensor/Vector/MinkowskiProduct.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Vector/MinkowskiProduct.lean
@@ -6,6 +6,8 @@ Authors: Matteo Cipollina, Joseph Tooby-Smith
 module
 
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
+public import Physlib.Relativity.Tensors.Elab
+public import Physlib.Relativity.Tensors.RealTensor.Metrics.Basic
 /-!
 
 # Minkowski product on Lorentz vectors

--- a/Physlib/SpaceAndTime/Space/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Basic.lean
@@ -5,14 +5,9 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Meta.Informal.Basic
 public import Physlib.Meta.TODO.Basic
-public import Physlib.Meta.Linters.Sorry
-public import Mathlib.Topology.ContinuousMap.CompactlySupported
-public import Mathlib.Geometry.Manifold.IsManifold.Basic
-public import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
-public import Mathlib.Analysis.InnerProductSpace.Calculus
-public import Mathlib.Geometry.Manifold.Diffeomorph
+public import Mathlib.Analysis.InnerProductSpace.PiL2
+public import Mathlib.Geometry.Manifold.ContMDiff.Defs
 /-!
 
 # Space

--- a/Physlib/SpaceAndTime/Space/ConstantSliceDist.lean
+++ b/Physlib/SpaceAndTime/Space/ConstantSliceDist.lean
@@ -5,6 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
+public import Mathlib.Analysis.Calculus.ContDiff.FiniteDimension
+public import Physlib.SpaceAndTime.Space.Derivatives.Basic
 public import Physlib.SpaceAndTime.Space.Slice
 /-!
 

--- a/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
@@ -6,9 +6,9 @@ Authors: Zhi Kai Pong, Joseph Tooby-Smith, Lode Vermeulen
 module
 
 public import Mathlib.Analysis.Calculus.FDeriv.Symmetric
-public import Mathlib.Analysis.Calculus.Gradient.Basic
-public import Physlib.SpaceAndTime.Space.DistOfFunction
-public import Mathlib.Geometry.Manifold.MFDeriv.FDeriv
+public import Physlib.Mathematics.Distribution.Basic
+public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
+public import Physlib.SpaceAndTime.Space.Module
 /-!
 
 # Derivatives on Space

--- a/Physlib/SpaceAndTime/Space/Derivatives/Div.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Div.lean
@@ -6,6 +6,7 @@ Authors: Zhi Kai Pong, Joseph Tooby-Smith, Lode Vermeulen
 module
 
 public import Physlib.SpaceAndTime.Space.Derivatives.Grad
+public import Physlib.SpaceAndTime.Space.DistOfFunction
 /-!
 
 # Divergence on Space

--- a/Physlib/SpaceAndTime/Space/Derivatives/Grad.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Grad.lean
@@ -6,6 +6,8 @@ Authors: Zhi Kai Pong, Joseph Tooby-Smith, Lode Vermeulen
 module
 
 public import Physlib.SpaceAndTime.Space.Derivatives.Basic
+public import Physlib.SpaceAndTime.Space.IsDistBounded
+public import Mathlib.Analysis.Calculus.Gradient.Basic
 /-!
 
 # Gradient of functions and distributions on `Space d`

--- a/Physlib/SpaceAndTime/Space/Derivatives/MultiIndex.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/MultiIndex.lean
@@ -6,7 +6,6 @@ Authors: Juan Jose Fernandez Morales
 
 module
 
-public import Mathlib.Algebra.BigOperators.Pi
 public import Mathlib.Algebra.BigOperators.Fin
 
 /-!

--- a/Physlib/SpaceAndTime/Space/DistOfFunction.lean
+++ b/Physlib/SpaceAndTime/Space/DistOfFunction.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.SpaceAndTime.Space.IsDistBounded
 public import Mathlib.MeasureTheory.SpecificCodomains.WithLp
+public import Physlib.Mathematics.Distribution.Basic
 /-!
 
 # Distributions from functions on space

--- a/Physlib/SpaceAndTime/Space/Integrals/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Integrals/Basic.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.SpaceAndTime.Space.Module
+public import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
 /-!
 
 # Integrals in Space

--- a/Physlib/SpaceAndTime/Space/Integrals/NormPow.lean
+++ b/Physlib/SpaceAndTime/Space/Integrals/NormPow.lean
@@ -5,7 +5,9 @@ Authors: Gregory J. Loges
 -/
 module
 
-public import Physlib.SpaceAndTime.Space.Norm
+public import Physlib.SpaceAndTime.Space.Module
+public import Mathlib.MeasureTheory.Constructions.HaarToSphere
+public import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 /-!
 
 # Integrability of norm powers on subsets of Space

--- a/Physlib/SpaceAndTime/Space/Integrals/RadialAngularMeasure.lean
+++ b/Physlib/SpaceAndTime/Space/Integrals/RadialAngularMeasure.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Mathematics.Distribution.Basic
 public import Physlib.SpaceAndTime.Space.Integrals.Basic
 /-!
 
@@ -40,7 +39,7 @@ This file is equivalent to `invPowMeasure`, which will slowly be deprecated.
 -/
 
 @[expose] public section
-open SchwartzMap NNReal Real
+open NNReal Real
 noncomputable section
 
 variable (𝕜 : Type) {E F F' : Type} [RCLike 𝕜] [NormedAddCommGroup E] [NormedAddCommGroup F]

--- a/Physlib/SpaceAndTime/Space/IsDistBounded.lean
+++ b/Physlib/SpaceAndTime/Space/IsDistBounded.lean
@@ -6,7 +6,9 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.SpaceAndTime.Space.Integrals.RadialAngularMeasure
-public import Physlib.SpaceAndTime.Time.Derivatives
+public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Deriv
 public import Mathlib.Tactic.Cases
 /-!
 

--- a/Physlib/SpaceAndTime/Space/LengthUnit.lean
+++ b/Physlib/SpaceAndTime/Space/LengthUnit.lean
@@ -5,8 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Geometry.Manifold.Diffeomorph
-public import Physlib.SpaceAndTime.Time.Basic
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+public import Physlib.Meta.TODO.Basic
 /-!
 
 # Units on Length

--- a/Physlib/SpaceAndTime/Space/Module.lean
+++ b/Physlib/SpaceAndTime/Space/Module.lean
@@ -8,6 +8,7 @@ module
 public import Physlib.SpaceAndTime.Space.Basic
 public import Mathlib.Geometry.Manifold.Diffeomorph
 public import Mathlib.Analysis.Distribution.TemperateGrowth
+public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 /-!
 
 # The structure of a module on Space

--- a/Physlib/SpaceAndTime/Space/Norm.lean
+++ b/Physlib/SpaceAndTime/Space/Norm.lean
@@ -6,8 +6,6 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.SpaceAndTime.Space.Derivatives.Div
-public import Mathlib.Analysis.InnerProductSpace.NormPow
-public import Mathlib.Analysis.Calculus.FDeriv.Norm
 /-!
 
 # The norm on space

--- a/Physlib/SpaceAndTime/Space/Slice.lean
+++ b/Physlib/SpaceAndTime/Space/Slice.lean
@@ -5,8 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Analysis.Calculus.ContDiff.FiniteDimension
-public import Physlib.SpaceAndTime.Space.Derivatives.Basic
+public import Physlib.SpaceAndTime.Space.Module
+public import Mathlib.MeasureTheory.Constructions.Polish.Basic
 /-!
 
 # Slices of space
@@ -37,7 +37,7 @@ extracts the `i`th coordinate on `Space d.succ`.
 -/
 
 @[expose] public section
-open SchwartzMap NNReal
+open NNReal
 noncomputable section
 
 variable (𝕜 : Type) {E F F' : Type} [RCLike 𝕜] [NormedAddCommGroup E] [NormedAddCommGroup F]

--- a/Physlib/SpaceAndTime/Space/Translations.lean
+++ b/Physlib/SpaceAndTime/Space/Translations.lean
@@ -5,7 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.SpaceAndTime.Space.Derivatives.Curl
+public import Physlib.SpaceAndTime.Space.Derivatives.Div
 /-!
 
 # Translations on space

--- a/Physlib/SpaceAndTime/SpaceTime/Basic.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Basic.lean
@@ -5,10 +5,10 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Relativity.Tensors.RealTensor.Vector.MinkowskiProduct
 public import Physlib.Relativity.SpeedOfLight
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
 public import Physlib.SpaceAndTime.Space.Integrals.Basic
+public import Physlib.SpaceAndTime.Time.Basic
 /-!
 # Spacetime
 

--- a/Physlib/SpaceAndTime/SpaceTime/Boosts.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Boosts.lean
@@ -6,8 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Relativity.LorentzGroup.Boosts.Basic
-public import Physlib.Meta.Informal.SemiFormal
-public import Physlib.Mathematics.FDerivCurry
+public import Physlib.SpaceAndTime.SpaceTime.Basic
 /-!
 
 # Boosts of space time

--- a/Physlib/SpaceAndTime/SpaceTime/Derivatives.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Derivatives.lean
@@ -8,6 +8,8 @@ module
 public import Physlib.SpaceAndTime.SpaceTime.LorentzAction
 public import Physlib.Relativity.Tensors.RealTensor.CoVector.Basic
 public import Mathlib.Analysis.InnerProductSpace.TensorProduct
+public import Physlib.SpaceAndTime.Space.Derivatives.Basic
+public import Physlib.SpaceAndTime.Time.Derivatives
 /-!
 
 # Derivatives on SpaceTime

--- a/Physlib/SpaceAndTime/SpaceTime/LorentzAction.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/LorentzAction.lean
@@ -5,7 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.SpaceAndTime.Space.Derivatives.Basic
+public import Physlib.SpaceAndTime.SpaceTime.Basic
+public import Physlib.Mathematics.Distribution.Basic
 /-!
 
 # Lorentz group actions related to SpaceTime

--- a/Physlib/SpaceAndTime/SpaceTime/TimeSlice.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/TimeSlice.lean
@@ -7,8 +7,6 @@ module
 
 public import Physlib.SpaceAndTime.SpaceTime.Derivatives
 public import Physlib.SpaceAndTime.TimeAndSpace.Basic
-public import Physlib.Meta.Informal.SemiFormal
-public import Physlib.Mathematics.FDerivCurry
 /-!
 # Time slice
 

--- a/Physlib/SpaceAndTime/Time/Basic.lean
+++ b/Physlib/SpaceAndTime/Time/Basic.lean
@@ -5,7 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.SpaceAndTime.Space.Basic
+public import Mathlib.Analysis.Calculus.FDeriv.Linear
+public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 /-!
 # Time
 

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -5,7 +5,9 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.SpaceAndTime.SpaceTime.Basic
+public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
+public import Physlib.SpaceAndTime.Space.Module
+public import Physlib.SpaceAndTime.Time.Basic
 /-!
 
 # Time Derivatives

--- a/Physlib/SpaceAndTime/Time/TimeTransMan.lean
+++ b/Physlib/SpaceAndTime/Time/TimeTransMan.lean
@@ -5,7 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.SpaceAndTime.Time.Derivatives
+public import Mathlib.Geometry.Manifold.Diffeomorph
+public import Physlib.SpaceAndTime.Time.Basic
 public import Physlib.SpaceAndTime.Time.TimeUnit
 /-!
 

--- a/Physlib/SpaceAndTime/Time/TimeUnit.lean
+++ b/Physlib/SpaceAndTime/Time/TimeUnit.lean
@@ -5,8 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Geometry.Manifold.Diffeomorph
-public import Physlib.SpaceAndTime.Time.Basic
+public import Mathlib.Analysis.RCLike.Basic
 /-!
 
 # Units on time

--- a/Physlib/SpaceAndTime/TimeAndSpace/Basic.lean
+++ b/Physlib/SpaceAndTime/TimeAndSpace/Basic.lean
@@ -6,6 +6,7 @@ Authors: Zhi Kai Pong, Joseph Tooby-Smith
 module
 
 public import Physlib.SpaceAndTime.Space.Derivatives.Curl
+public import Physlib.SpaceAndTime.Time.Derivatives
 /-!
 
 # Functions and distributions on Time and Space d

--- a/Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean
+++ b/Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean
@@ -5,13 +5,9 @@ Authors: Matteo Cipollina, Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Thermodynamics.Temperature.Basic
-public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
-public import Mathlib.Analysis.Calculus.ParametricIntegral
-public import Physlib.Meta.Informal.SemiFormal
-public import Physlib.Meta.Linters.Sorry
-public import Mathlib.Analysis.SpecialFunctions.Log.Summable
 public import Mathlib.MeasureTheory.Integral.Prod
+public import Mathlib.Topology.MetricSpace.Polish
+public import Physlib.Thermodynamics.Temperature.Basic
 /-!
 # Canonical Ensemble: Core Definitions
 

--- a/Physlib/StatisticalMechanics/CanonicalEnsemble/Finite.lean
+++ b/Physlib/StatisticalMechanics/CanonicalEnsemble/Finite.lean
@@ -5,7 +5,6 @@ Authors: Matteo Cipollina, Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Algebra.Lie.OfAssociative
 public import Physlib.StatisticalMechanics.CanonicalEnsemble.Lemmas
 /-!
 # Finite Canonical Ensemble

--- a/Physlib/StatisticalMechanics/CanonicalEnsemble/Lemmas.lean
+++ b/Physlib/StatisticalMechanics/CanonicalEnsemble/Lemmas.lean
@@ -6,6 +6,7 @@ Authors: Matteo Cipollina, Joseph Tooby-Smith
 module
 
 public import Physlib.StatisticalMechanics.CanonicalEnsemble.Basic
+public import Mathlib.Analysis.SpecialFunctions.Log.Deriv
 /-!
 # Canonical Ensemble: Thermodynamic Identities and Relations
 

--- a/Physlib/StringTheory/FTheory/SU5/Charges/AnomalyFree.lean
+++ b/Physlib/StringTheory/FTheory/SU5/Charges/AnomalyFree.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.StringTheory.FTheory.SU5.Quanta.Basic
 public import Physlib.Particles.SuperSymmetry.SU5.ChargeSpectrum.Map
+public import Physlib.StringTheory.FTheory.SU5.Charges.Viable
 /-!
 
 # Anomaly cancellation

--- a/Physlib/StringTheory/FTheory/SU5/Charges/OfRationalSection.lean
+++ b/Physlib/StringTheory/FTheory/SU5/Charges/OfRationalSection.lean
@@ -7,7 +7,6 @@ module
 
 public import Physlib.Meta.TODO.Basic
 public import Mathlib.Data.Fintype.Sets
-public import Mathlib.Algebra.BigOperators.Group.List.Basic
 /-!
 
 # Allowed charges

--- a/Physlib/StringTheory/FTheory/SU5/Quanta/Basic.lean
+++ b/Physlib/StringTheory/FTheory/SU5/Quanta/Basic.lean
@@ -7,7 +7,6 @@ module
 
 public import Physlib.StringTheory.FTheory.SU5.Quanta.FiveQuanta
 public import Physlib.StringTheory.FTheory.SU5.Quanta.TenQuanta
-public import Physlib.StringTheory.FTheory.SU5.Charges.Viable
 /-!
 
 # Quanta of representations

--- a/Physlib/StringTheory/FTheory/SU5/Quanta/IsViable.lean
+++ b/Physlib/StringTheory/FTheory/SU5/Quanta/IsViable.lean
@@ -6,7 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.StringTheory.FTheory.SU5.Charges.AnomalyFree
-public import Physlib.Particles.SuperSymmetry.SU5.ChargeSpectrum.ZMod
+public import Mathlib.Data.ZMod.Defs
 /-!
 
 # Viable Quanta with Yukawa

--- a/Physlib/Thermodynamics/Temperature/Basic.lean
+++ b/Physlib/Thermodynamics/Temperature/Basic.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Analysis.Calculus.Deriv.Inv
 public import Mathlib.Analysis.InnerProductSpace.Basic
 public import Physlib.StatisticalMechanics.BoltzmannConstant
-public import Physlib.Meta.TODO.Basic
 /-!
 
 # Temperature

--- a/Physlib/Thermodynamics/Temperature/TemperatureUnits.lean
+++ b/Physlib/Thermodynamics/Temperature/TemperatureUnits.lean
@@ -5,8 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Geometry.Manifold.Diffeomorph
-public import Physlib.SpaceAndTime.Time.Basic
+public import Mathlib.Analysis.RCLike.Basic
 /-!
 
 # Units on Temperature

--- a/Physlib/Units/Basic.lean
+++ b/Physlib/Units/Basic.lean
@@ -11,6 +11,7 @@ public import Physlib.ClassicalMechanics.Mass.MassUnit
 public import Physlib.Electromagnetism.Charge.ChargeUnit
 public import Physlib.Thermodynamics.Temperature.TemperatureUnits
 public import Physlib.Units.Dimension
+public import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
 /-!
 
 # Dimensions and unit

--- a/Physlib/Units/FDeriv.lean
+++ b/Physlib/Units/FDeriv.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Units.WithDim.Basic
+public import Mathlib.Analysis.Calculus.FDeriv.Equiv
 /-!
 
 # Dimensional invariance of fderiv

--- a/Physlib/Units/Integral.lean
+++ b/Physlib/Units/Integral.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Units.UnitDependent
+public import Mathlib.MeasureTheory.Integral.Bochner.Basic
 /-!
 
 # Dimensional invariance of the integral

--- a/Physlib/Units/UnitDependent.lean
+++ b/Physlib/Units/UnitDependent.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Units.Basic
+public import Mathlib.Topology.Algebra.Module.StrongTopology
 /-!
 
 ## Types which depend on dimensions

--- a/Physlib/Units/WithDim/Mass.lean
+++ b/Physlib/Units/WithDim/Mass.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Units.Basic
 /-!
 # Mass
 
@@ -15,5 +14,3 @@ in an arbitrary (but given) set of units.
 -/
 
 @[expose] public section
-open Dimension
-open NNReal

--- a/Physlib/Units/WithDim/Momentum.lean
+++ b/Physlib/Units/WithDim/Momentum.lean
@@ -5,8 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Units.WithDim.Velocity
-public import Physlib.Units.WithDim.Mass
 public import Physlib.Units.WithDim.Basic
 /-!
 # Momentum

--- a/Physlib/Units/WithDim/Velocity.lean
+++ b/Physlib/Units/WithDim/Velocity.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Units.Basic
 /-!
 # Velocity
 
@@ -15,4 +14,3 @@ in `d`-dimensional space, in an arbitrary (but given) set of units.
 -/
 
 @[expose] public section
-open Dimension


### PR DESCRIPTION
Ran `lake shake --add-public --keep-implied --keep-prefix --explain Physlib`

shake is not perfect yet and there are various places where it broke the code or I have to run #min_imports manually for comparison. Also can't guarantee that there are no mistakes but maybe this is good enough as a first pass. Hopefully later on we can also integrate shake into CI so we don't have to do this manually anymore.