### PR TITLE
refactor(QM): remove auxiliary definitions

### DIFF
--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/Basic.lean
@@ -54,7 +54,7 @@ set_option backward.isDefEq.respectTransparency false in
 /-- The hydrogen atom Hamiltonian regularized by `ε ≠ 0` is defined to be
   `𝐇(ε) ≔ (2m)⁻¹𝐩² - k·𝐫(ε)⁻¹`. -/
 def hamiltonianReg (ε : ℝˣ) : 𝓢(Space H.d, ℂ) →L[ℂ] 𝓢(Space H.d, ℂ) :=
-  (2 * H.m)⁻¹ • 𝐩² - H.k • 𝐫₀ ε (-1)
+  (2 * H.m)⁻¹ • (𝐩 ⬝ᵥ 𝐩) - H.k • 𝐫₀ ε (-1)
 
 end
 end HydrogenAtom

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -91,14 +91,11 @@ lemma lrlOperator_eq'' (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i = ∑ j, 
     ofReal_mul, ofReal_ofNat]
   ring
 
-/-- The operator `𝐱ᵢ𝐩ᵢ` on Schwartz maps. -/
-private def positionDotMomentum (d : ℕ) := ∑ i : Fin d, 𝐱 i ∘L 𝐩 i
-
 /-- The operator `𝐱ᵢ𝐩²` on Schwartz maps. -/
 private def positionCompMomentumSqr {d : ℕ} (i : Fin d) := 𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩)
 
 /-- The operator `(𝐱ⱼ𝐩ⱼ)𝐱ᵢ` on Schwartz maps. -/
-private def positionDotMomentumCompMomentum {d : ℕ} (i : Fin d) := positionDotMomentum d ∘L 𝐩 i
+private def positionDotMomentumCompMomentum {d : ℕ} (i : Fin d) := (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i
 
 /-- The operator `½iℏ(d-1)𝐩ᵢ` on Schwartz maps. -/
 private def constMomentum {d : ℕ} (i : Fin d) := (2⁻¹ * I * ℏ * (d - 1)) • 𝐩 i
@@ -149,33 +146,33 @@ To compute the commutator `⁅𝐀ᵢ(ε), 𝐀ⱼ(ε)⁆` we take the following
 -/
 
 private lemma positionDotMomentum_commutation_position {d : ℕ} (i : Fin d) :
-    ⁅positionDotMomentum d, 𝐱 i⁆ = (-I * ℏ) • 𝐱 i := by
+    ⁅𝐱[d] ⬝ᵥ 𝐩, 𝐱 i⁆ = (-I * ℏ) • 𝐱 i := by
   trans ∑ j, 𝐱 j ∘L ⁅𝐩 j, 𝐱 i⁆
-  · simp [positionDotMomentum, sum_lie, leibniz_lie]
+  · simp [dotProduct, mul_def, sum_lie, leibniz_lie]
   simp_rw [← lie_skew (𝐩 _), position_commutation_momentum, ← neg_smul, ← neg_mul, comp_smul,
     comp_id, ← Finset.smul_sum, sum_smul]
 
 private lemma positionDotMomentum_commutation_momentum {d : ℕ} (i : Fin d) :
-    ⁅positionDotMomentum d, 𝐩 i⁆ = (I * ℏ) • 𝐩 i := by
+    ⁅𝐱[d] ⬝ᵥ 𝐩, 𝐩 i⁆ = (I * ℏ) • 𝐩 i := by
   trans ∑ j, ⁅𝐱 j, 𝐩 i⁆ ∘L 𝐩 j
-  · simp [positionDotMomentum, sum_lie, leibniz_lie]
+  · simp [dotProduct, mul_def, sum_lie, leibniz_lie]
   simp_rw [position_commutation_momentum, smul_comp, id_comp, ← Finset.smul_sum, symm _ i, sum_smul]
 
 private lemma positionDotMomentum_commutation_momentumSqr (d : ℕ) :
-    ⁅positionDotMomentum d, 𝐩[d] ⬝ᵥ 𝐩⁆ = (2 * I * ℏ) • (𝐩 ⬝ᵥ 𝐩) := by
+    ⁅𝐱[d] ⬝ᵥ 𝐩, 𝐩[d] ⬝ᵥ 𝐩⁆ = (2 * I * ℏ) • (𝐩 ⬝ᵥ 𝐩) := by
   trans ∑ i, ⁅𝐱 i, 𝐩 ⬝ᵥ 𝐩⁆ ∘L 𝐩 i
-  · simp [positionDotMomentum, sum_lie, leibniz_lie, ← lie_skew (𝐩 _) (𝐩 ⬝ᵥ 𝐩)]
+  · rw [dotProduct]
+    simp [mul_def, sum_lie, leibniz_lie, ← lie_skew (𝐩 _) (𝐩 ⬝ᵥ 𝐩)]
   simp_rw [position_commutation_momentumSqr, smul_comp, ← Finset.smul_sum]
   rfl
 
 private lemma positionDotMomentum_commutation_radiusRegPow (d : ℕ) (ε : ℝˣ) (s : ℝ) :
-    ⁅positionDotMomentum d, 𝐫₀[d] ε s⁆ = (-s * I * ℏ) • (𝐫₀ ε s - ε.1 ^ 2 • 𝐫₀ ε (s-2)) := by
+    ⁅𝐱[d] ⬝ᵥ 𝐩, 𝐫₀[d] ε s⁆ = (-s * I * ℏ) • (𝐫₀ ε s - ε.1 ^ 2 • 𝐫₀ ε (s-2)) := by
   calc
-    _ = ∑ i, 𝐱 i ∘L ⁅𝐩 i, 𝐫₀ ε s⁆ := by simp [positionDotMomentum, sum_lie, leibniz_lie]
-    _ = (-s * I * ℏ) • ∑ i, 𝐱 i ∘L 𝐱 i ∘L 𝐫₀ ε (s-2) := by
+    _ = ∑ i, 𝐱 i ∘L ⁅𝐩 i, 𝐫₀ ε s⁆ := by simp [dotProduct, mul_def, sum_lie, leibniz_lie]
+    _ = (-s * I * ℏ) • (∑ i, 𝐱 i ∘L 𝐱 i) ∘L 𝐫₀ ε (s-2) := by
       simp [← lie_skew (𝐩 _), radiusRegPow_commutation_momentum, Finset.smul_sum,
-        position_comp_radiusRegPow_commute]
-    _ = (-s * I * ℏ) • (∑ i, 𝐱 i ∘L 𝐱 i) ∘L 𝐫₀ ε (s-2) := by simp [finset_sum_comp, comp_assoc]
+        position_comp_radiusRegPow_commute, finset_sum_comp, comp_assoc]
     _ = (-s * I * ℏ) • (𝐫₀ ε s - ε.1 ^ 2 • 𝐫₀ ε (s-2)) := by simp [positionOperatorSqr_eq ε]
 
 private lemma positionCompMomentumSqr_comm {d : ℕ} (i j : Fin d) :
@@ -194,30 +191,29 @@ private lemma positionCompMomentumSqr_comm_positionDotMomentumCompMomentum_add
     {d : ℕ} (i j : Fin d) : ⁅positionCompMomentumSqr i, positionDotMomentumCompMomentum j⁆ +
     ⁅positionDotMomentumCompMomentum i, positionCompMomentumSqr j⁆ = (-I * ℏ) • (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] := by
   suffices ∀ k l : Fin d, ⁅positionCompMomentumSqr k, positionDotMomentumCompMomentum l⁆
-      = (-I * ℏ) • (𝐱 k ∘L 𝐩 l - δ[k,l] • positionDotMomentum d) ∘L (𝐩 ⬝ᵥ 𝐩) by
+      = (-I * ℏ) • (𝐱 k ∘L 𝐩 l - δ[k,l] • (𝐱 ⬝ᵥ 𝐩)) ∘L (𝐩 ⬝ᵥ 𝐩) by
     nth_rw 2 [← lie_skew]
     simp_rw [this, ← sub_eq_add_neg, ← smul_sub, ← sub_comp, symm j i, sub_sub_sub_cancel_right,
       momentumSqr_comp_angularMomentum_commute, angularMomentumOperator]
   intro k l
   calc
-    _ = (positionDotMomentum d) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L (𝐩 ⬝ᵥ 𝐩)
-        + 𝐱 k ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, positionDotMomentum d⁆ ∘L 𝐩 l
-        + ⁅𝐱 k, positionDotMomentum d⁆ ∘L (𝐩 ⬝ᵥ 𝐩) ∘L 𝐩 l := by
+    _ = (𝐱 ⬝ᵥ 𝐩) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L (𝐩 ⬝ᵥ 𝐩) + 𝐱 k ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱[d] ⬝ᵥ 𝐩⁆ ∘L 𝐩 l
+        + ⁅𝐱 k, 𝐱[d] ⬝ᵥ 𝐩⁆ ∘L (𝐩 ⬝ᵥ 𝐩) ∘L 𝐩 l := by
       simp [positionCompMomentumSqr, positionDotMomentumCompMomentum, lie_leibniz, leibniz_lie,
         add_assoc, comp_assoc]
-    _ = (positionDotMomentum d) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L (𝐩 ⬝ᵥ 𝐩) + (-I * ℏ) • 𝐱 k ∘L 𝐩 l ∘L (𝐩 ⬝ᵥ 𝐩) := by
-      simp only [← lie_skew _ (positionDotMomentum d), positionDotMomentum_commutation_position,
+    _ = (𝐱 ⬝ᵥ 𝐩) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L (𝐩 ⬝ᵥ 𝐩) + (-I * ℏ) • 𝐱 k ∘L 𝐩 l ∘L (𝐩 ⬝ᵥ 𝐩) := by
+      simp only [← lie_skew _ (𝐱 ⬝ᵥ 𝐩), positionDotMomentum_commutation_position,
         positionDotMomentum_commutation_momentumSqr, momentumSqr_comp_momentum_commute,
         ← neg_smul, ← neg_mul, smul_comp, comp_smul, add_assoc, ← add_smul]
       ring_nf
-    _ = (-I * ℏ) • (𝐱 k ∘L 𝐩 l - δ[k,l] • positionDotMomentum d) ∘L (𝐩 ⬝ᵥ 𝐩) := by
-      simp_rw [add_comm, position_commutation_momentum, sub_comp, smul_sub, smul_comp, comp_smul,
-        id_comp, sub_eq_add_neg, ← neg_smul, neg_mul, neg_neg, comp_assoc]
+    _ = (-I * ℏ) • (𝐱 k ∘L 𝐩 l - δ[k,l] • (𝐱 ⬝ᵥ 𝐩)) ∘L (𝐩 ⬝ᵥ 𝐩) := by
+      simp_rw [position_commutation_momentum, sub_comp, smul_sub, smul_comp, comp_smul,
+        id_comp, sub_eq_add_neg, ← neg_smul, neg_mul, neg_neg, comp_assoc, add_comm]
 
 private lemma positionDotMomentumCompMomentum_comm {d : ℕ} (i j : Fin d) :
     ⁅positionDotMomentumCompMomentum i, positionDotMomentumCompMomentum j⁆ = 0 := by
   simp [positionDotMomentumCompMomentum, lie_leibniz, leibniz_lie, momentum_comp_commute,
-    ← lie_skew (𝐩 _) (positionDotMomentum d), positionDotMomentum_commutation_momentum, comp_assoc]
+    ← lie_skew (𝐩 _) (𝐱 ⬝ᵥ 𝐩), positionDotMomentum_commutation_momentum, comp_assoc]
 
 private lemma positionCompMomentumSqr_comm_constMomentum_add {d : ℕ} (i j : Fin d) :
     ⁅positionCompMomentumSqr i, constMomentum j⁆ +
@@ -243,15 +239,14 @@ private lemma positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add
     = (-2 * I * ℏ * H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐋[i,j] := by
   let A := ⁅𝐩[H.d] ⬝ᵥ 𝐩, radiusRegPowOperator (d := H.d) ε (-1)⁆
   have hA : 𝐱 i ∘L A ∘L 𝐱 j = 𝐱 j ∘L A ∘L 𝐱 i := by
-    suffices A = (2 * I * ℏ) • 𝐫₀ ε (-3) ∘L positionDotMomentum H.d
+    suffices A = (2 * I * ℏ) • 𝐫₀[H.d] ε (-3) ∘L (𝐱 ⬝ᵥ 𝐩)
         + ((H.d - 3) * ℏ ^ 2 : ℝ) • 𝐫₀ ε (-3) + (3 * ε.1 ^ 2 * ℏ ^ 2) • 𝐫₀ ε (-5) by
       simp_rw [this, add_comp, comp_add, smul_comp, comp_smul, ← comp_assoc,
         position_comp_radiusRegPow_commute, comp_assoc,
-        comp_eq_comp_add_commute (positionDotMomentum _), positionDotMomentum_commutation_position,
+        comp_eq_comp_add_commute (𝐱 ⬝ᵥ 𝐩), positionDotMomentum_commutation_position,
         comp_add, comp_smul, ← comp_assoc (𝐱 _) (𝐱 _) _, position_comp_commute j i]
     simp_rw [A, ← lie_skew (𝐩 ⬝ᵥ 𝐩) _, radiusRegPow_commutation_momentumSqr, neg_sub, ← sub_sub,
-      positionDotMomentum, sub_eq_add_neg, ← neg_smul, ← neg_mul, neg_neg, ofReal_neg, ofReal_one,
-      dotProduct, mul_def]
+      sub_eq_add_neg, ← neg_smul, ← neg_mul, neg_neg, ofReal_neg, ofReal_one, dotProduct, mul_def]
     ring_nf
     rw [add_rotate]
   let B (i : Fin H.d) := ⁅𝐩[H.d] ⬝ᵥ 𝐩, 𝐱 i⁆
@@ -281,7 +276,7 @@ private lemma positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition
     ⁅positionDotMomentumCompMomentum i, constRadiusRegInvCompPosition H ε j⁆ +
     ⁅constRadiusRegInvCompPosition H ε i, positionDotMomentumCompMomentum j⁆ =
     (I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐋[i,j] := by
-  suffices ∀ k, ⁅positionDotMomentum H.d, constRadiusRegInvCompPosition H ε k⁆
+  suffices ∀ k, ⁅𝐱[H.d] ⬝ᵥ 𝐩, constRadiusRegInvCompPosition H ε k⁆
       = (-I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐱 k by
     nth_rw 2 [← lie_skew]
     simp_rw [positionDotMomentumCompMomentum, leibniz_lie, this, constRadiusRegInvCompPosition,
@@ -290,8 +285,8 @@ private lemma positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition
       smul_neg, neg_mul, neg_smul, angularMomentumOperator]
   intro k
   calc
-    _ = (H.m * H.k) • (𝐫₀ ε (-1) ∘L ⁅positionDotMomentum H.d, 𝐱 k⁆
-        + ⁅positionDotMomentum H.d, 𝐫₀ ε (-1)⁆ ∘L 𝐱 k) := by
+    _ = (H.m * H.k) • (𝐫₀ ε (-1) ∘L ⁅𝐱[H.d] ⬝ᵥ 𝐩, 𝐱 k⁆
+        + ⁅𝐱[H.d] ⬝ᵥ 𝐩, 𝐫₀ ε (-1)⁆ ∘L 𝐱 k) := by
       rw [constRadiusRegInvCompPosition, lie_smul, lie_leibniz]
     _ = -(I * ℏ) • (H.m * H.k) • (ε.1 ^ 2) • 𝐫₀ ε (-1-2) ∘L 𝐱 k := by
       simp [positionDotMomentum_commutation_position, positionDotMomentum_commutation_radiusRegPow,
@@ -329,7 +324,7 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
       - (⁅f_xdotp_p i, f_const_p j⁆ + ⁅f_const_p i, f_xdotp_p j⁆)
       + (⁅f_xdotp_p i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, f_xdotp_p j⁆)
       - (⁅f_const_p i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, f_const_p j⁆)
-  · dsimp [f_x_p_sqr, f_xdotp_p, f_const_p, f_c_rinvx, positionCompMomentumSqr, positionDotMomentum,
+  · dsimp [f_x_p_sqr, f_xdotp_p, f_const_p, f_c_rinvx, positionCompMomentumSqr,
       positionDotMomentumCompMomentum, constMomentum, constRadiusRegInvCompPosition]
     simp only [lie_add, lie_sub, add_lie, sub_lie]
     ext ψ x
@@ -363,7 +358,7 @@ private lemma r_comm_rx {d : ℕ} (ε : ℝˣ) (i : Fin d) : ⁅𝐫₀[d] ε (-
   simp [lie_leibniz, ← lie_skew (𝐫₀ _ _) (𝐱 _)]
 
 private lemma xL_Lx_eq {d : ℕ} (ε : ℝˣ) (i : Fin d) :
-    ∑ j, (𝐱 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐱 j) = (2 : ℝ) • (positionDotMomentum d) ∘L 𝐱 i
+    ∑ j, (𝐱 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐱 j) = (2 : ℝ) • (𝐱 ⬝ᵥ 𝐩) ∘L 𝐱 i
     + (-I * ℏ * (d - 3)) • 𝐱 i + ((-2 : ℝ) • 𝐫₀ ε 2 ∘L 𝐩 i + (2 * ε.1 ^ 2 : ℝ) • 𝐩 i) := by
   -- Change summand
   simp_rw [angularMomentumOperator, comp_sub, sub_comp, comp_assoc, sub_add_sub_comm,
@@ -375,7 +370,7 @@ private lemma xL_Lx_eq {d : ℕ} (ε : ℝˣ) (i : Fin d) :
   -- Split/do sums
   simp_rw [Finset.sum_sub_distrib, Finset.sum_add_distrib, ← Finset.smul_sum, ← finset_sum_comp,
     sum_smul, Finset.sum_const, Finset.card_univ, Fintype.card_fin, ← Nat.cast_smul_eq_nsmul ℂ,
-    positionOperatorSqr_eq ε, sub_comp, smul_comp, id_comp, smul_sub, positionDotMomentum]
+    positionOperatorSqr_eq ε, sub_comp, smul_comp, id_comp, smul_sub, dotProduct, mul_def]
   -- Clean up coefficients
   simp_rw [add_sub_assoc, add_right_inj, smul_smul, ← sub_smul, sub_eq_add_neg, neg_add, ← neg_smul,
     ← Complex.coe_smul, smul_smul, ofReal_neg, ofReal_mul, ofReal_pow, ofReal_ofNat, neg_neg]
@@ -386,10 +381,9 @@ private lemma pSqr_comm_rx (ε : ℝˣ) (i : Fin H.d) :
     ⁅𝐩[H.d] ⬝ᵥ 𝐩, 𝐫₀ ε (-1) ∘L 𝐱 i⁆
     = (I * ℏ) • 𝐫₀ ε (-3) ∘L ∑ j, (𝐱 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐱 j)
     + ((-2 * I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐩 i + (3 * ℏ ^ 2 * ε.1 ^ 2) • 𝐫₀ ε (-5) ∘L 𝐱 i) := by
-  trans (-2 * I * ℏ) • 𝐫₀ ε (-1) ∘L 𝐩 i
-      + (2 * I * ℏ) • 𝐫₀ ε (-3) ∘L (positionDotMomentum H.d) ∘L 𝐱 i
+  trans (-2 * I * ℏ) • 𝐫₀ ε (-1) ∘L 𝐩 i + (2 * I * ℏ) • 𝐫₀ ε (-3) ∘L (𝐱 ⬝ᵥ 𝐩) ∘L 𝐱 i
       + (ℏ ^ 2 * (H.d - 3) : ℝ) • 𝐫₀ ε (-3) ∘L 𝐱 i + (3 * ℏ ^ 2 * ε.1 ^ 2) • 𝐫₀ ε (-5) ∘L 𝐱 i
-  · rw [← lie_skew, positionDotMomentum]
+  · rw [← lie_skew]
     simp_rw [leibniz_lie, position_commutation_momentumSqr, radiusRegPow_commutation_momentumSqr,
       sub_comp, add_comp, smul_comp, comp_smul, comp_assoc, neg_add, neg_sub', neg_add,
       sub_neg_eq_add, ← neg_smul, add_assoc, ofReal_neg, ofReal_one, dotProduct, mul_def]

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -90,9 +90,6 @@ lemma lrlOperator_eq'' (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i = ∑ j, 
     ofReal_mul, ofReal_ofNat]
   ring
 
-/-- The operator `mk·𝐫(ε)⁻¹𝐱ᵢ` on Schwartz maps. -/
-private def constRadiusRegInvCompPosition (ε : ℝˣ) (i : Fin H.d) := (H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐱 i
-
 /-
 ## Angular momentum / LRL vector commutators
 -/
@@ -215,13 +212,12 @@ private lemma positionDotMomentumCompMomentum_comm_momentum_add {d : ℕ} (i j :
 
 set_option backward.isDefEq.respectTransparency false in
 private lemma positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add
-    (ε : ℝˣ) (i j : Fin H.d) : ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), constRadiusRegInvCompPosition H ε j⁆
-    + ⁅constRadiusRegInvCompPosition H ε i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆
-    = (-2 * I * ℏ * H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐋[i,j] := by
-  let A := ⁅𝐩[H.d] ⬝ᵥ 𝐩, radiusRegPowOperator (d := H.d) ε (-1)⁆
+    {d : ℕ} (ε : ℝˣ) (i j : Fin d) : ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), 𝐫₀ ε (-1) ∘L 𝐱 j⁆
+    + ⁅𝐫₀ ε (-1) ∘L 𝐱 i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ = (-2 * I * ℏ) • 𝐫₀ ε (-1) ∘L 𝐋[i,j] := by
+  let A := ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐫₀[d] ε (-1)⁆
   have hA : 𝐱 i ∘L A ∘L 𝐱 j = 𝐱 j ∘L A ∘L 𝐱 i := by
-    suffices A = (2 * I * ℏ) • 𝐫₀[H.d] ε (-3) ∘L (𝐱 ⬝ᵥ 𝐩)
-        + ((H.d - 3) * ℏ ^ 2 : ℝ) • 𝐫₀ ε (-3) + (3 * ε.1 ^ 2 * ℏ ^ 2) • 𝐫₀ ε (-5) by
+    suffices A = (2 * I * ℏ) • 𝐫₀[d] ε (-3) ∘L (𝐱 ⬝ᵥ 𝐩)
+        + ((d - 3) * ℏ ^ 2 : ℝ) • 𝐫₀ ε (-3) + (3 * ε.1 ^ 2 * ℏ ^ 2) • 𝐫₀ ε (-5) by
       simp_rw [this, add_comp, comp_add, smul_comp, comp_smul, ← comp_assoc,
         position_comp_radiusRegPow_commute, comp_assoc,
         comp_eq_comp_add_commute (𝐱 ⬝ᵥ 𝐩), positionDotMomentum_commutation_position,
@@ -230,21 +226,18 @@ private lemma positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add
       sub_eq_add_neg, ← neg_smul, ← neg_mul, neg_neg, ofReal_neg, ofReal_one, dotProduct, mul_def]
     ring_nf
     rw [add_rotate]
-  let B (i : Fin H.d) := ⁅𝐩[H.d] ⬝ᵥ 𝐩, 𝐱 i⁆
-  have hB (k : Fin H.d) : B k = (-2 * I * ℏ) • 𝐩 k := by
+  let B (i : Fin d) := ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱 i⁆
+  have hB (k : Fin d) : B k = (-2 * I * ℏ) • 𝐩 k := by
     simp [B, ← lie_skew (𝐩 ⬝ᵥ 𝐩) _, position_commutation_momentumSqr]
   calc
-    _ = (H.m * H.k) • (𝐫₀ ε (-1) ∘L 𝐱 i ∘L B j + 𝐱 i ∘L A ∘L 𝐱 j
-        - (𝐫₀ ε (-1) ∘L 𝐱 j ∘L B i + 𝐱 j ∘L A ∘L 𝐱 i)) := by
+    _ = 𝐫₀ ε (-1) ∘L 𝐱 i ∘L B j + 𝐱 i ∘L A ∘L 𝐱 j
+        - (𝐫₀ ε (-1) ∘L 𝐱 j ∘L B i + 𝐱 j ∘L A ∘L 𝐱 i) := by
       nth_rw 2 [← lie_skew]
-      simp_rw [← sub_eq_add_neg, constRadiusRegInvCompPosition, lie_smul,
-        ← smul_sub, lie_leibniz, leibniz_lie, ← sub_sub]
+      simp_rw [← sub_eq_add_neg, lie_leibniz, leibniz_lie, ← sub_sub]
       simp [A, B, comp_assoc]
-    _ = (H.m * H.k) • 𝐫₀ ε (-1) ∘L (𝐱 i ∘L B j - 𝐱 j ∘L B i) := by simp [hA]
-    _ = (-2 * I * ℏ * H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐋[i,j] := by
-      simp_rw [hB, comp_smul, ← smul_sub, comp_smul, angularMomentumOperator, ← Complex.coe_smul,
-        smul_smul, ofReal_mul]
-      ring_nf
+    _ = 𝐫₀ ε (-1) ∘L (𝐱 i ∘L B j - 𝐱 j ∘L B i) := by simp [hA]
+    _ = (-2 * I * ℏ) • 𝐫₀ ε (-1) ∘L 𝐋[i,j] := by
+      simp_rw [hB, comp_smul, ← smul_sub, comp_smul, angularMomentumOperator]
 
 private lemma momentum_comm_radiusRegPow_position_symm {d : ℕ} (ε : ℝˣ) (s : ℝ) (i j : Fin d) :
     ⁅𝐩 i, 𝐫₀ ε s ∘L 𝐱 j⁆ = ⁅𝐩 j, 𝐫₀ ε s ∘L 𝐱 i⁆ := by
@@ -253,40 +246,32 @@ private lemma momentum_comm_radiusRegPow_position_symm {d : ℕ} (ε : ℝˣ) (s
 
 set_option backward.isDefEq.respectTransparency false in
 private lemma positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition_add
-    (ε : ℝˣ) (i j : Fin H.d) :
-    ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, constRadiusRegInvCompPosition H ε j⁆ +
-    ⁅constRadiusRegInvCompPosition H ε i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ =
-    (I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐋[i,j] := by
-  suffices ∀ k, ⁅𝐱[H.d] ⬝ᵥ 𝐩, constRadiusRegInvCompPosition H ε k⁆
-      = (-I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐱 k by
+    {d : ℕ} (ε : ℝˣ) (i j : Fin d) : ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, 𝐫₀ ε (-1) ∘L 𝐱 j⁆ +
+    ⁅𝐫₀ ε (-1) ∘L 𝐱 i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ = (I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐋[i,j] := by
+  suffices ∀ k, ⁅𝐱[d] ⬝ᵥ 𝐩, 𝐫₀[d] ε (-1) ∘L 𝐱 k⁆ = (-I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐱 k by
     nth_rw 2 [← lie_skew]
-    simp_rw [leibniz_lie, this, constRadiusRegInvCompPosition,
-      lie_smul, momentum_comm_radiusRegPow_position_symm, ← sub_eq_add_neg, add_sub_add_left_eq_sub,
+    simp_rw [leibniz_lie, this,
+      momentum_comm_radiusRegPow_position_symm, ← sub_eq_add_neg, add_sub_add_left_eq_sub,
       smul_comp, ← smul_sub, comp_assoc, ← comp_sub, angularMomentumOperator_antisymm i j, comp_neg,
       smul_neg, neg_mul, neg_smul, angularMomentumOperator]
   intro k
   calc
-    _ = (H.m * H.k) • (𝐫₀ ε (-1) ∘L ⁅𝐱[H.d] ⬝ᵥ 𝐩, 𝐱 k⁆
-        + ⁅𝐱[H.d] ⬝ᵥ 𝐩, 𝐫₀ ε (-1)⁆ ∘L 𝐱 k) := by
-      rw [constRadiusRegInvCompPosition, lie_smul, lie_leibniz]
-    _ = -(I * ℏ) • (H.m * H.k) • (ε.1 ^ 2) • 𝐫₀ ε (-1-2) ∘L 𝐱 k := by
-      simp [positionDotMomentum_commutation_position, positionDotMomentum_commutation_radiusRegPow,
-        sub_comp, smul_sub, ← add_sub_assoc, smul_comm _ (I * ℏ)]
-    _ = (-I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐱 k := by
-      simp only [← Complex.coe_smul, ofReal_pow, ofReal_mul, smul_smul]
+    _ = -(I * ℏ) • (ε.1 ^ 2) • 𝐫₀ ε (-1-2) ∘L 𝐱 k := by
+      simp [lie_leibniz, positionDotMomentum_commutation_position,
+        positionDotMomentum_commutation_radiusRegPow, sub_comp, smul_sub, ← add_sub_assoc]
+    _ = (-I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐱 k := by
+      simp only [← Complex.coe_smul, ofReal_pow, smul_smul]
       ring_nf
 
 set_option backward.isDefEq.respectTransparency false in
-private lemma momentum_comm_constRadiusRegInvCompPosition_add (ε : ℝˣ) (i j : Fin H.d) :
-    ⁅𝐩 i, constRadiusRegInvCompPosition H ε j⁆ +
-    ⁅constRadiusRegInvCompPosition H ε i, 𝐩 j⁆ = 0 := by
-  nth_rw 2 [← lie_skew]
-  simp [constRadiusRegInvCompPosition, momentum_comm_radiusRegPow_position_symm]
+private lemma momentum_comm_constRadiusRegInvCompPosition_add {d : ℕ} (ε : ℝˣ) (i j : Fin d) :
+    ⁅𝐩 i, 𝐫₀ ε (-1) ∘L 𝐱 j⁆ + ⁅𝐫₀ ε (-1) ∘L 𝐱 i, 𝐩 j⁆ = 0 := by
+  rw [← lie_skew _ (𝐩 _), momentum_comm_radiusRegPow_position_symm, add_neg_cancel]
 
 set_option backward.isDefEq.respectTransparency false in
-private lemma constRadiusRegInvCompPosition_comm (ε : ℝˣ) (i j : Fin H.d) :
-    ⁅constRadiusRegInvCompPosition H ε i, constRadiusRegInvCompPosition H ε j⁆ = 0 := by
-  simp [constRadiusRegInvCompPosition, lie_leibniz, leibniz_lie, ← lie_skew (𝐫₀ _ _) (𝐱 _)]
+private lemma constRadiusRegInvCompPosition_comm {d : ℕ} (ε : ℝˣ) (i j : Fin d) :
+    ⁅𝐫₀ ε (-1) ∘L 𝐱 i, 𝐫₀ ε (-1) ∘L 𝐱 j⁆ = 0 := by
+  simp [lie_leibniz, leibniz_lie, ← lie_skew (𝐫₀ _ _) (𝐱 _)]
 
 /-- `⁅𝐀(ε)ᵢ, 𝐀(ε)ⱼ⁆ = (-2iℏm·𝐇(ε) + iℏmkε²·𝐫(ε)⁻³)𝐋ᵢⱼ` -/
 lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
@@ -294,34 +279,34 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
     + (I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3)) ∘L 𝐋[i,j] := by
   repeat rw [lrlOperator_eq]
   let c₁ : ℂ := 2⁻¹ * I * ℏ * (H.d - 1)
-  let f_c_rinvx := constRadiusRegInvCompPosition H ε
+  let c₂ : ℂ := H.m * H.k
   trans ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ + ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆
-      + ⁅f_c_rinvx i, f_c_rinvx j⁆
+      + (c₂ ^ 2) • ⁅𝐫₀ ε (-1) ∘L 𝐱 i, 𝐫₀ ε (-1) ∘L 𝐱 j⁆
       - (⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ + ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆)
       + c₁ • (⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), 𝐩 j⁆ + ⁅𝐩 i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆)
-      - (⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), f_c_rinvx j⁆ + ⁅f_c_rinvx i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆)
+      - c₂ • (⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), 𝐫₀ ε (-1) ∘L 𝐱 j⁆ + ⁅𝐫₀ ε (-1) ∘L 𝐱 i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆)
       - c₁ • (⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, 𝐩 j⁆ + ⁅𝐩 i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆)
-      + (⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆)
-      - c₁ • (⁅𝐩 i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, 𝐩 j⁆)
-  · dsimp [f_c_rinvx, constRadiusRegInvCompPosition]
-    simp only [lie_add, lie_sub, add_lie, sub_lie, lie_smul, smul_lie]
-    simp_rw [momentum_commutation_momentum, smul_zero, add_zero]
-
-    ext ψ x
-    simp only [ContinuousLinearMap.sub_apply, ContinuousLinearMap.add_apply, SchwartzMap.sub_apply,
-      SchwartzMap.add_apply]
+      + c₂ • (⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, 𝐫₀ ε (-1) ∘L 𝐱 j⁆ + ⁅𝐫₀ ε (-1) ∘L 𝐱 i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆)
+      - (c₁ * c₂) • (⁅𝐩 i, 𝐫₀ ε (-1) ∘L 𝐱 j⁆ + ⁅𝐫₀ ε (-1) ∘L 𝐱 i, 𝐩 j⁆)
+  · simp only [lie_add, add_lie, lie_sub, sub_lie, lie_smul, smul_lie,
+      momentum_commutation_momentum, smul_zero, add_zero, ← Complex.coe_smul, ofReal_mul]
+    subst c₁ c₂
+    ext
+    simp only [coe_sub', coe_smul', Pi.sub_apply, ContinuousLinearMap.add_apply, Pi.smul_apply,
+      SchwartzMap.sub_apply, SchwartzMap.add_apply, SchwartzMap.smul_apply, smul_eq_mul]
     ring
   rw [positionCompMomentumSqr_comm]
   rw [positionDotMomentumCompMomentum_comm]
   rw [positionCompMomentumSqr_comm_positionDotMomentumCompMomentum_add]
   rw [positionCompMomentumSqr_comm_momentum_add]
   rw [positionDotMomentumCompMomentum_comm_momentum_add]
-  rw [positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add H]
-  rw [positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition_add H]
-  rw [momentum_comm_constRadiusRegInvCompPosition_add H]
-  rw [constRadiusRegInvCompPosition_comm H]
-  simp only [add_zero, sub_zero, hamiltonianReg, smul_sub, ← Complex.coe_smul, smul_smul,
-    ← sub_smul, sub_add, sub_comp, smul_comp, ofReal_inv, ofReal_mul, ofReal_ofNat]
+  rw [positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add]
+  rw [positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition_add]
+  rw [momentum_comm_constRadiusRegInvCompPosition_add]
+  rw [constRadiusRegInvCompPosition_comm]
+  subst c₁ c₂
+  simp_rw [hamiltonianReg, smul_zero, add_zero, sub_zero, ← sub_smul, ← Complex.coe_smul,
+    ofReal_inv, ofReal_mul, ofReal_ofNat, smul_sub, smul_smul, add_comp, sub_comp, smul_comp]
   ring_nf
   simp
 

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -18,7 +18,7 @@ In this file we define
 
 The main results are
 - The commutators `⁅𝐋ᵢⱼ, 𝐀(ε)ₖ⁆ = iℏ(δᵢₖ𝐀(ε)ⱼ - δⱼₖ𝐀(ε)ᵢ)` in `angularMomentum_commutation_lrl`
-- The commutators `⁅𝐀(ε)ᵢ, 𝐀(ε)ⱼ⁆ = -iℏ 2m 𝐇(ε)𝐋ᵢⱼ` in `lrl_commutation_lrl`
+- The commutators `⁅𝐀(ε)ᵢ, 𝐀(ε)ⱼ⁆ = (-2iℏm·𝐇(ε) + iℏmkε²·𝐫(ε)⁻³))𝐋ᵢⱼ` in `lrl_commutation_lrl`
 - The commutators `⁅𝐇(ε), 𝐀(ε)ᵢ⁆ = iℏε²(⋯)` in `hamiltonianReg_commutation_lrl`
 - The relation `𝐀(ε)² = 2m 𝐇(ε)(𝐋² + ¼ℏ²(d-1)²) + m²k² + ε²(⋯)` in `lrlOperatorSqr_eq`
 
@@ -41,9 +41,8 @@ def lrlOperator (ε : ℝˣ) (i : Fin H.d) : 𝓢(Space H.d, ℂ) →L[ℂ] 𝓢
   (2 : ℝ)⁻¹ • ∑ j, (𝐩 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐩 j) - (H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐱 i
 
 /-- `𝐀(ε)ᵢ = 𝐱ᵢ𝐩² - (𝐱ⱼ𝐩ⱼ)𝐩ᵢ + ½iℏ(d-1)𝐩ᵢ - mk·𝐫(ε)⁻¹𝐱ᵢ` -/
-lemma lrlOperator_eq (ε : ℝˣ) (i : Fin H.d) :
-    H.lrlOperator ε i = 𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩) - (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i
-    + (2⁻¹ * I * ℏ * (H.d - 1)) • 𝐩 i - (H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐱 i := by
+lemma lrlOperator_eq (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i = 𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩)
+    - (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i + (2⁻¹ * I * ℏ * (H.d - 1)) • 𝐩 i - (H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐱 i := by
   rw [lrlOperator, sub_left_inj] -- mk·r⁻¹x terms match exactly
   calc
     _ = (2 : ℂ)⁻¹ • ∑ j, ((𝐩 j ∘L 𝐱 i) ∘L 𝐩 j + 𝐱 i ∘L 𝐩 j ∘L 𝐩 j
@@ -211,7 +210,7 @@ private lemma positionDotMomentumCompMomentum_comm_momentum_add {d : ℕ} (i j :
   simp [leibniz_lie, positionDotMomentum_commutation_momentum, momentum_comp_commute]
 
 set_option backward.isDefEq.respectTransparency false in
-private lemma positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add
+private lemma positionCompMomentumSqr_comm_radiusRegInvCompPosition_add
     {d : ℕ} (ε : ℝˣ) (i j : Fin d) : ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), 𝐫₀ ε (-1) ∘L 𝐱 j⁆
     + ⁅𝐫₀ ε (-1) ∘L 𝐱 i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ = (-2 * I * ℏ) • 𝐫₀ ε (-1) ∘L 𝐋[i,j] := by
   let A := ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐫₀[d] ε (-1)⁆
@@ -226,18 +225,16 @@ private lemma positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add
       sub_eq_add_neg, ← neg_smul, ← neg_mul, neg_neg, ofReal_neg, ofReal_one, dotProduct, mul_def]
     ring_nf
     rw [add_rotate]
-  let B (i : Fin d) := ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱 i⁆
-  have hB (k : Fin d) : B k = (-2 * I * ℏ) • 𝐩 k := by
-    simp [B, ← lie_skew (𝐩 ⬝ᵥ 𝐩) _, position_commutation_momentumSqr]
   calc
-    _ = 𝐫₀ ε (-1) ∘L 𝐱 i ∘L B j + 𝐱 i ∘L A ∘L 𝐱 j
-        - (𝐫₀ ε (-1) ∘L 𝐱 j ∘L B i + 𝐱 j ∘L A ∘L 𝐱 i) := by
+    _ = 𝐫₀ ε (-1) ∘L 𝐱 i ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱 j⁆ + 𝐱 i ∘L A ∘L 𝐱 j
+        - (𝐫₀ ε (-1) ∘L 𝐱 j ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱 i⁆ + 𝐱 j ∘L A ∘L 𝐱 i) := by
       nth_rw 2 [← lie_skew]
       simp_rw [← sub_eq_add_neg, lie_leibniz, leibniz_lie, ← sub_sub]
-      simp [A, B, comp_assoc]
-    _ = 𝐫₀ ε (-1) ∘L (𝐱 i ∘L B j - 𝐱 j ∘L B i) := by simp [hA]
+      simp [A, comp_assoc]
+    _ = 𝐫₀ ε (-1) ∘L (𝐱 i ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱 j⁆ - 𝐱 j ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱 i⁆) := by simp [hA]
     _ = (-2 * I * ℏ) • 𝐫₀ ε (-1) ∘L 𝐋[i,j] := by
-      simp_rw [hB, comp_smul, ← smul_sub, comp_smul, angularMomentumOperator]
+      simp_rw [← lie_skew _ (𝐱 _), position_commutation_momentumSqr, comp_neg, comp_smul,
+        ← neg_smul, ← neg_mul, ← smul_sub, comp_smul, angularMomentumOperator]
 
 private lemma momentum_comm_radiusRegPow_position_symm {d : ℕ} (ε : ℝˣ) (s : ℝ) (i j : Fin d) :
     ⁅𝐩 i, 𝐫₀ ε s ∘L 𝐱 j⁆ = ⁅𝐩 j, 𝐫₀ ε s ∘L 𝐱 i⁆ := by
@@ -245,7 +242,7 @@ private lemma momentum_comm_radiusRegPow_position_symm {d : ℕ} (ε : ℝˣ) (s
     radiusRegPow_commutation_momentum, position_comp_commute j i, comp_assoc]
 
 set_option backward.isDefEq.respectTransparency false in
-private lemma positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition_add
+private lemma positionDotMomentumCompMomentum_comm_radiusRegInvCompPosition_add
     {d : ℕ} (ε : ℝˣ) (i j : Fin d) : ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, 𝐫₀ ε (-1) ∘L 𝐱 j⁆ +
     ⁅𝐫₀ ε (-1) ∘L 𝐱 i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ = (I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐋[i,j] := by
   suffices ∀ k, ⁅𝐱[d] ⬝ᵥ 𝐩, 𝐫₀[d] ε (-1) ∘L 𝐱 k⁆ = (-I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐱 k by
@@ -264,12 +261,12 @@ private lemma positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition
       ring_nf
 
 set_option backward.isDefEq.respectTransparency false in
-private lemma momentum_comm_constRadiusRegInvCompPosition_add {d : ℕ} (ε : ℝˣ) (i j : Fin d) :
+private lemma momentum_comm_radiusRegInvCompPosition_add {d : ℕ} (ε : ℝˣ) (i j : Fin d) :
     ⁅𝐩 i, 𝐫₀ ε (-1) ∘L 𝐱 j⁆ + ⁅𝐫₀ ε (-1) ∘L 𝐱 i, 𝐩 j⁆ = 0 := by
   rw [← lie_skew _ (𝐩 _), momentum_comm_radiusRegPow_position_symm, add_neg_cancel]
 
 set_option backward.isDefEq.respectTransparency false in
-private lemma constRadiusRegInvCompPosition_comm {d : ℕ} (ε : ℝˣ) (i j : Fin d) :
+private lemma radiusRegInvCompPosition_comm {d : ℕ} (ε : ℝˣ) (i j : Fin d) :
     ⁅𝐫₀ ε (-1) ∘L 𝐱 i, 𝐫₀ ε (-1) ∘L 𝐱 j⁆ = 0 := by
   simp [lie_leibniz, leibniz_lie, ← lie_skew (𝐫₀ _ _) (𝐱 _)]
 
@@ -300,10 +297,10 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
   rw [positionCompMomentumSqr_comm_positionDotMomentumCompMomentum_add]
   rw [positionCompMomentumSqr_comm_momentum_add]
   rw [positionDotMomentumCompMomentum_comm_momentum_add]
-  rw [positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add]
-  rw [positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition_add]
-  rw [momentum_comm_constRadiusRegInvCompPosition_add]
-  rw [constRadiusRegInvCompPosition_comm]
+  rw [positionCompMomentumSqr_comm_radiusRegInvCompPosition_add]
+  rw [positionDotMomentumCompMomentum_comm_radiusRegInvCompPosition_add]
+  rw [momentum_comm_radiusRegInvCompPosition_add]
+  rw [radiusRegInvCompPosition_comm]
   subst c₁ c₂
   simp_rw [hamiltonianReg, smul_zero, add_zero, sub_zero, ← sub_smul, ← Complex.coe_smul,
     ofReal_inv, ofReal_mul, ofReal_ofNat, smul_sub, smul_smul, add_comp, sub_comp, smul_comp]
@@ -341,12 +338,13 @@ private lemma xL_Lx_eq {d : ℕ} (ε : ℝˣ) (i : Fin d) :
   ring_nf
 
 set_option backward.isDefEq.respectTransparency false in
-private lemma pSqr_comm_rx (ε : ℝˣ) (i : Fin H.d) :
-    ⁅𝐩[H.d] ⬝ᵥ 𝐩, 𝐫₀ ε (-1) ∘L 𝐱 i⁆
+private lemma pSqr_comm_rx {d : ℕ} (ε : ℝˣ) (i : Fin d) :
+    ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐫₀ ε (-1) ∘L 𝐱 i⁆
     = (I * ℏ) • 𝐫₀ ε (-3) ∘L ∑ j, (𝐱 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐱 j)
-    + ((-2 * I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐩 i + (3 * ℏ ^ 2 * ε.1 ^ 2) • 𝐫₀ ε (-5) ∘L 𝐱 i) := by
+    + ((-2 * I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐩 i
+      + (3 * ℏ ^ 2 * ε.1 ^ 2) • 𝐫₀ ε (-5) ∘L 𝐱 i) := by
   trans (-2 * I * ℏ) • 𝐫₀ ε (-1) ∘L 𝐩 i + (2 * I * ℏ) • 𝐫₀ ε (-3) ∘L (𝐱 ⬝ᵥ 𝐩) ∘L 𝐱 i
-      + (ℏ ^ 2 * (H.d - 3) : ℝ) • 𝐫₀ ε (-3) ∘L 𝐱 i + (3 * ℏ ^ 2 * ε.1 ^ 2) • 𝐫₀ ε (-5) ∘L 𝐱 i
+      + (ℏ ^ 2 * (d - 3) : ℝ) • 𝐫₀ ε (-3) ∘L 𝐱 i + (3 * ℏ ^ 2 * ε.1 ^ 2) • 𝐫₀ ε (-5) ∘L 𝐱 i
   · rw [← lie_skew]
     simp_rw [leibniz_lie, position_commutation_momentumSqr, radiusRegPow_commutation_momentumSqr,
       sub_comp, add_comp, smul_comp, comp_smul, comp_assoc, neg_add, neg_sub', neg_add,
@@ -378,7 +376,7 @@ lemma hamiltonianReg_commutation_lrl (ε : ℝˣ) (i : Fin H.d) :
     ⁅H.hamiltonianReg ε, H.lrlOperator ε i⁆ = (I * ℏ * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐩 i
     - (3 / 2 * ℏ ^ 2 * H.k * ε.1 ^ 2) • 𝐫₀ ε (-5) ∘L 𝐱 i := by
   trans (-2⁻¹ * H.k) • (⁅𝐩[H.d] ⬝ᵥ 𝐩, 𝐫₀ ε (-1) ∘L 𝐱 i⁆
-      + ⁅radiusRegPowOperator (d := H.d) ε (-1), ∑ j, (𝐩 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐩 j)⁆)
+      + ⁅𝐫₀[H.d] ε (-1), ∑ j, (𝐩 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐩 j)⁆)
   · have h : H.m * H.k * (H.m⁻¹ * 2⁻¹) = 2⁻¹ * H.k := by grind [m_ne_zero]
     simp [hamiltonianReg, lrlOperator, pSqr_comm_pL_Lp, r_comm_rx, h, smul_smul, sub_eq_neg_add]
   simp_rw [pSqr_comm_rx, r_comm_pL_Lp, add_neg_cancel_comm, smul_add, sub_eq_add_neg, ← neg_smul,
@@ -473,7 +471,7 @@ private lemma sum_rxpL (d : ℕ) (ε : ℝˣ) :
   rw [angularMomentumOperatorSqr]
 
 private lemma sum_prx (d : ℕ) (ε : ℝˣ) :
-    ∑ i, 𝐩 i ∘L 𝐫₀[d] ε (-1) ∘L 𝐱 i = 𝐫₀ ε (-1) ∘L ∑ i, 𝐱 i ∘L 𝐩 i
+    ∑ i, 𝐩 i ∘L 𝐫₀[d] ε (-1) ∘L 𝐱 i = 𝐫₀ ε (-1) ∘L (𝐱 ⬝ᵥ 𝐩)
     - (I * ℏ * (d - 1)) • 𝐫₀ ε (-1) - (I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) := by
   calc
     _ = ∑ i, (𝐫₀ ε (-1) ∘L 𝐩 i ∘L 𝐱 i + (I * ℏ) • 𝐫₀ ε (-3) ∘L 𝐱 i ∘L 𝐱 i) := by
@@ -486,16 +484,16 @@ private lemma sum_prx (d : ℕ) (ε : ℝˣ) :
         + (I * ℏ) • 𝐫₀ ε (-3) ∘L ∑ i, 𝐱 i ∘L 𝐱 i := by
       simp [Finset.sum_add_distrib, ← comp_finset_sum, ← Finset.smul_sum,
         ← Nat.cast_smul_eq_nsmul ℂ, smul_smul, mul_assoc, sub_eq_add_neg]
-    _ = 𝐫₀ ε (-1) ∘L ∑ i, 𝐱 i ∘L 𝐩 i
-        - (I * ℏ * (d - 1)) • 𝐫₀ ε (-1) - (I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) := by
-      simp only [positionOperatorSqr_eq ε, comp_sub, comp_smul, comp_id,
+    _ = 𝐫₀ ε (-1) ∘L (𝐱 ⬝ᵥ 𝐩) - (I * ℏ * (d - 1)) • 𝐫₀ ε (-1)
+        - (I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) := by
+      simp only [dotProduct, mul_def, positionOperatorSqr_eq ε, comp_sub, comp_smul, comp_id,
         radiusRegPowOperator_comp_eq, smul_sub, ← Complex.coe_smul, ofReal_pow, smul_smul]
       ring_nf
       simp_rw [← add_sub_assoc, add_assoc, ← add_smul, sub_eq_add_neg, ← neg_smul]
       ring_nf
 
 private lemma sum_rxp (d : ℕ) (ε : ℝˣ) :
-    ∑ i, 𝐫₀[d] ε (-1) ∘L 𝐱 i ∘L 𝐩 i = 𝐫₀ ε (-1) ∘L ∑ i, 𝐱 i ∘L 𝐩 i := by rw [comp_finset_sum]
+    ∑ i, 𝐫₀[d] ε (-1) ∘L 𝐱 i ∘L 𝐩 i = 𝐫₀ ε (-1) ∘L (𝐱 ⬝ᵥ 𝐩) := by rw [← comp_finset_sum]; rfl
 
 set_option backward.isDefEq.respectTransparency false in
 private lemma sum_rxrx (d : ℕ) (ε : ℝˣ) : ∑ i, 𝐫₀[d] ε (-1) ∘L 𝐱 i ∘L 𝐫₀ ε (-1) ∘L 𝐱 i =

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -90,9 +90,6 @@ lemma lrlOperator_eq'' (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i = ∑ j, 
     ofReal_mul, ofReal_ofNat]
   ring
 
-/-- The operator `½iℏ(d-1)𝐩ᵢ` on Schwartz maps. -/
-private def constMomentum {d : ℕ} (i : Fin d) := (2⁻¹ * I * ℏ * (d - 1)) • 𝐩 i
-
 /-- The operator `mk·𝐫(ε)⁻¹𝐱ᵢ` on Schwartz maps. -/
 private def constRadiusRegInvCompPosition (ε : ℝˣ) (i : Fin H.d) := (H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐱 i
 
@@ -156,8 +153,7 @@ private lemma positionDotMomentum_commutation_momentumSqr (d : ℕ) :
   trans ∑ i, ⁅𝐱 i, 𝐩 ⬝ᵥ 𝐩⁆ ∘L 𝐩 i
   · rw [dotProduct]
     simp [mul_def, sum_lie, leibniz_lie, ← lie_skew (𝐩 _) (𝐩 ⬝ᵥ 𝐩)]
-  simp_rw [position_commutation_momentumSqr, smul_comp, ← Finset.smul_sum]
-  rfl
+  simp_rw [position_commutation_momentumSqr, smul_comp, ← Finset.smul_sum, dotProduct, mul_def]
 
 private lemma positionDotMomentum_commutation_radiusRegPow (d : ℕ) (ε : ℝˣ) (s : ℝ) :
     ⁅𝐱[d] ⬝ᵥ 𝐩, 𝐫₀[d] ε s⁆ = (-s * I * ℏ) • (𝐫₀ ε s - ε.1 ^ 2 • 𝐫₀ ε (s-2)) := by
@@ -207,20 +203,15 @@ private lemma positionDotMomentumCompMomentum_comm {d : ℕ} (i j : Fin d) :
   simp [lie_leibniz, leibniz_lie, momentum_comp_commute,
     ← lie_skew (𝐩 _) (𝐱 ⬝ᵥ 𝐩), positionDotMomentum_commutation_momentum, comp_assoc]
 
-private lemma positionCompMomentumSqr_comm_constMomentum_add {d : ℕ} (i j : Fin d) :
-    ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), constMomentum j⁆ + ⁅constMomentum i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ = 0 := by
+private lemma positionCompMomentumSqr_comm_momentum_add {d : ℕ} (i j : Fin d) :
+    ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), 𝐩 j⁆ + ⁅𝐩 i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ = 0 := by
   nth_rw 2 [← lie_skew]
-  simp [constMomentum, leibniz_lie, position_commutation_momentum, symm j]
+  simp [leibniz_lie, position_commutation_momentum, symm j]
 
-private lemma positionDotMomentumCompMomentum_comm_constMomentum_add {d : ℕ} (i j : Fin d) :
-    ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, constMomentum j⁆ +
-    ⁅constMomentum i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ = 0 := by
+private lemma positionDotMomentumCompMomentum_comm_momentum_add {d : ℕ} (i j : Fin d) :
+    ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, 𝐩 j⁆ + ⁅𝐩 i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ = 0 := by
   nth_rw 2 [← lie_skew]
-  simp [constMomentum, leibniz_lie, positionDotMomentum_commutation_momentum, momentum_comp_commute]
-
-private lemma constMomentum_comm {d : ℕ} (i j : Fin d) :
-    ⁅constMomentum i, constMomentum j⁆ = 0 := by
-  simp [constMomentum]
+  simp [leibniz_lie, positionDotMomentum_commutation_momentum, momentum_comp_commute]
 
 set_option backward.isDefEq.respectTransparency false in
 private lemma positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add
@@ -286,11 +277,11 @@ private lemma positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition
       ring_nf
 
 set_option backward.isDefEq.respectTransparency false in
-private lemma constMomentum_comm_constRadiusRegInvCompPosition_add (ε : ℝˣ) (i j : Fin H.d) :
-    ⁅constMomentum i, constRadiusRegInvCompPosition H ε j⁆ +
-    ⁅constRadiusRegInvCompPosition H ε i, constMomentum j⁆ = 0 := by
+private lemma momentum_comm_constRadiusRegInvCompPosition_add (ε : ℝˣ) (i j : Fin H.d) :
+    ⁅𝐩 i, constRadiusRegInvCompPosition H ε j⁆ +
+    ⁅constRadiusRegInvCompPosition H ε i, 𝐩 j⁆ = 0 := by
   nth_rw 2 [← lie_skew]
-  simp [constMomentum, constRadiusRegInvCompPosition, momentum_comm_radiusRegPow_position_symm]
+  simp [constRadiusRegInvCompPosition, momentum_comm_radiusRegPow_position_symm]
 
 set_option backward.isDefEq.respectTransparency false in
 private lemma constRadiusRegInvCompPosition_comm (ε : ℝˣ) (i j : Fin H.d) :
@@ -302,20 +293,20 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
     ⁅H.lrlOperator ε i, H.lrlOperator ε j⁆ = ((-2 * I * ℏ * H.m) • H.hamiltonianReg ε
     + (I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3)) ∘L 𝐋[i,j] := by
   repeat rw [lrlOperator_eq]
-  let f_x_p_sqr (k : Fin H.d) := 𝐱 k ∘L (𝐩 ⬝ᵥ 𝐩)
-  let f_xdotp_p (k : Fin H.d) := (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 k
-  let f_const_p := constMomentum (d := H.d)
+  let c₁ : ℂ := 2⁻¹ * I * ℏ * (H.d - 1)
   let f_c_rinvx := constRadiusRegInvCompPosition H ε
-  trans ⁅f_x_p_sqr i, f_x_p_sqr j⁆ + ⁅f_xdotp_p i, f_xdotp_p j⁆
-      + ⁅f_const_p i, f_const_p j⁆ + ⁅f_c_rinvx i, f_c_rinvx j⁆
-      - (⁅f_x_p_sqr i, f_xdotp_p j⁆ + ⁅f_xdotp_p i, f_x_p_sqr j⁆)
-      + (⁅f_x_p_sqr i, f_const_p j⁆ + ⁅f_const_p i, f_x_p_sqr j⁆)
-      - (⁅f_x_p_sqr i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, f_x_p_sqr j⁆)
-      - (⁅f_xdotp_p i, f_const_p j⁆ + ⁅f_const_p i, f_xdotp_p j⁆)
-      + (⁅f_xdotp_p i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, f_xdotp_p j⁆)
-      - (⁅f_const_p i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, f_const_p j⁆)
-  · dsimp [f_x_p_sqr, f_xdotp_p, f_const_p, f_c_rinvx, constMomentum, constRadiusRegInvCompPosition]
-    simp only [lie_add, lie_sub, add_lie, sub_lie]
+  trans ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ + ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆
+      + ⁅f_c_rinvx i, f_c_rinvx j⁆
+      - (⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ + ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆)
+      + c₁ • (⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), 𝐩 j⁆ + ⁅𝐩 i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆)
+      - (⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), f_c_rinvx j⁆ + ⁅f_c_rinvx i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆)
+      - c₁ • (⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, 𝐩 j⁆ + ⁅𝐩 i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆)
+      + (⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆)
+      - c₁ • (⁅𝐩 i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, 𝐩 j⁆)
+  · dsimp [f_c_rinvx, constRadiusRegInvCompPosition]
+    simp only [lie_add, lie_sub, add_lie, sub_lie, lie_smul, smul_lie]
+    simp_rw [momentum_commutation_momentum, smul_zero, add_zero]
+
     ext ψ x
     simp only [ContinuousLinearMap.sub_apply, ContinuousLinearMap.add_apply, SchwartzMap.sub_apply,
       SchwartzMap.add_apply]
@@ -323,12 +314,11 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
   rw [positionCompMomentumSqr_comm]
   rw [positionDotMomentumCompMomentum_comm]
   rw [positionCompMomentumSqr_comm_positionDotMomentumCompMomentum_add]
-  rw [positionCompMomentumSqr_comm_constMomentum_add]
-  rw [positionDotMomentumCompMomentum_comm_constMomentum_add]
-  rw [constMomentum_comm]
+  rw [positionCompMomentumSqr_comm_momentum_add]
+  rw [positionDotMomentumCompMomentum_comm_momentum_add]
   rw [positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add H]
   rw [positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition_add H]
-  rw [constMomentum_comm_constRadiusRegInvCompPosition_add H]
+  rw [momentum_comm_constRadiusRegInvCompPosition_add H]
   rw [constRadiusRegInvCompPosition_comm H]
   simp only [add_zero, sub_zero, hamiltonianReg, smul_sub, ← Complex.coe_smul, smul_smul,
     ← sub_smul, sub_add, sub_comp, smul_comp, ofReal_inv, ofReal_mul, ofReal_ofNat]

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -90,9 +90,6 @@ lemma lrlOperator_eq'' (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i = ∑ j, 
     ofReal_mul, ofReal_ofNat]
   ring
 
-/-- The operator `(𝐱ⱼ𝐩ⱼ)𝐱ᵢ` on Schwartz maps. -/
-private def positionDotMomentumCompMomentum {d : ℕ} (i : Fin d) := (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i
-
 /-- The operator `½iℏ(d-1)𝐩ᵢ` on Schwartz maps. -/
 private def constMomentum {d : ℕ} (i : Fin d) := (2⁻¹ * I * ℏ * (d - 1)) • 𝐩 i
 
@@ -184,9 +181,9 @@ private lemma positionCompMomentumSqr_comm {d : ℕ} (i j : Fin d) :
         ← neg_mul, momentumSqr_comp_angularMomentum_commute]
 
 private lemma positionCompMomentumSqr_comm_positionDotMomentumCompMomentum_add
-    {d : ℕ} (i j : Fin d) : ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), positionDotMomentumCompMomentum j⁆ +
-    ⁅positionDotMomentumCompMomentum i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ = (-I * ℏ) • (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] := by
-  suffices ∀ k l : Fin d, ⁅𝐱 k ∘L (𝐩 ⬝ᵥ 𝐩), positionDotMomentumCompMomentum l⁆
+    {d : ℕ} (i j : Fin d) : ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ +
+    ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ = (-I * ℏ) • (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] := by
+  suffices ∀ k l : Fin d, ⁅𝐱 k ∘L (𝐩 ⬝ᵥ 𝐩), (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 l⁆
       = (-I * ℏ) • (𝐱 k ∘L 𝐩 l - δ[k,l] • (𝐱 ⬝ᵥ 𝐩)) ∘L (𝐩 ⬝ᵥ 𝐩) by
     nth_rw 2 [← lie_skew]
     simp_rw [this, ← sub_eq_add_neg, ← smul_sub, ← sub_comp, symm j i, sub_sub_sub_cancel_right,
@@ -195,7 +192,7 @@ private lemma positionCompMomentumSqr_comm_positionDotMomentumCompMomentum_add
   calc
     _ = (𝐱 ⬝ᵥ 𝐩) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L (𝐩 ⬝ᵥ 𝐩) + 𝐱 k ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱[d] ⬝ᵥ 𝐩⁆ ∘L 𝐩 l
         + ⁅𝐱 k, 𝐱[d] ⬝ᵥ 𝐩⁆ ∘L (𝐩 ⬝ᵥ 𝐩) ∘L 𝐩 l := by
-      simp [positionDotMomentumCompMomentum, lie_leibniz, leibniz_lie, add_assoc, comp_assoc]
+      simp [lie_leibniz, leibniz_lie, add_assoc, comp_assoc]
     _ = (𝐱 ⬝ᵥ 𝐩) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L (𝐩 ⬝ᵥ 𝐩) + (-I * ℏ) • 𝐱 k ∘L 𝐩 l ∘L (𝐩 ⬝ᵥ 𝐩) := by
       simp only [← lie_skew _ (𝐱 ⬝ᵥ 𝐩), positionDotMomentum_commutation_position,
         positionDotMomentum_commutation_momentumSqr, momentumSqr_comp_momentum_commute,
@@ -206,8 +203,8 @@ private lemma positionCompMomentumSqr_comm_positionDotMomentumCompMomentum_add
         id_comp, sub_eq_add_neg, ← neg_smul, neg_mul, neg_neg, comp_assoc, add_comm]
 
 private lemma positionDotMomentumCompMomentum_comm {d : ℕ} (i j : Fin d) :
-    ⁅positionDotMomentumCompMomentum i, positionDotMomentumCompMomentum j⁆ = 0 := by
-  simp [positionDotMomentumCompMomentum, lie_leibniz, leibniz_lie, momentum_comp_commute,
+    ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ = 0 := by
+  simp [lie_leibniz, leibniz_lie, momentum_comp_commute,
     ← lie_skew (𝐩 _) (𝐱 ⬝ᵥ 𝐩), positionDotMomentum_commutation_momentum, comp_assoc]
 
 private lemma positionCompMomentumSqr_comm_constMomentum_add {d : ℕ} (i j : Fin d) :
@@ -216,11 +213,10 @@ private lemma positionCompMomentumSqr_comm_constMomentum_add {d : ℕ} (i j : Fi
   simp [constMomentum, leibniz_lie, position_commutation_momentum, symm j]
 
 private lemma positionDotMomentumCompMomentum_comm_constMomentum_add {d : ℕ} (i j : Fin d) :
-    ⁅positionDotMomentumCompMomentum i, constMomentum j⁆ +
-    ⁅constMomentum i, positionDotMomentumCompMomentum j⁆ = 0 := by
+    ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, constMomentum j⁆ +
+    ⁅constMomentum i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ = 0 := by
   nth_rw 2 [← lie_skew]
-  simp [positionDotMomentumCompMomentum, constMomentum, leibniz_lie,
-    positionDotMomentum_commutation_momentum, momentum_comp_commute]
+  simp [constMomentum, leibniz_lie, positionDotMomentum_commutation_momentum, momentum_comp_commute]
 
 private lemma constMomentum_comm {d : ℕ} (i j : Fin d) :
     ⁅constMomentum i, constMomentum j⁆ = 0 := by
@@ -267,13 +263,13 @@ private lemma momentum_comm_radiusRegPow_position_symm {d : ℕ} (ε : ℝˣ) (s
 set_option backward.isDefEq.respectTransparency false in
 private lemma positionDotMomentumCompMomentum_comm_constRadiusRegInvCompPosition_add
     (ε : ℝˣ) (i j : Fin H.d) :
-    ⁅positionDotMomentumCompMomentum i, constRadiusRegInvCompPosition H ε j⁆ +
-    ⁅constRadiusRegInvCompPosition H ε i, positionDotMomentumCompMomentum j⁆ =
+    ⁅(𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i, constRadiusRegInvCompPosition H ε j⁆ +
+    ⁅constRadiusRegInvCompPosition H ε i, (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 j⁆ =
     (I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐋[i,j] := by
   suffices ∀ k, ⁅𝐱[H.d] ⬝ᵥ 𝐩, constRadiusRegInvCompPosition H ε k⁆
       = (-I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐱 k by
     nth_rw 2 [← lie_skew]
-    simp_rw [positionDotMomentumCompMomentum, leibniz_lie, this, constRadiusRegInvCompPosition,
+    simp_rw [leibniz_lie, this, constRadiusRegInvCompPosition,
       lie_smul, momentum_comm_radiusRegPow_position_symm, ← sub_eq_add_neg, add_sub_add_left_eq_sub,
       smul_comp, ← smul_sub, comp_assoc, ← comp_sub, angularMomentumOperator_antisymm i j, comp_neg,
       smul_neg, neg_mul, neg_smul, angularMomentumOperator]
@@ -307,7 +303,7 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
     + (I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3)) ∘L 𝐋[i,j] := by
   repeat rw [lrlOperator_eq]
   let f_x_p_sqr (k : Fin H.d) := 𝐱 k ∘L (𝐩 ⬝ᵥ 𝐩)
-  let f_xdotp_p := positionDotMomentumCompMomentum (d := H.d)
+  let f_xdotp_p (k : Fin H.d) := (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 k
   let f_const_p := constMomentum (d := H.d)
   let f_c_rinvx := constRadiusRegInvCompPosition H ε
   trans ⁅f_x_p_sqr i, f_x_p_sqr j⁆ + ⁅f_xdotp_p i, f_xdotp_p j⁆
@@ -318,8 +314,7 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
       - (⁅f_xdotp_p i, f_const_p j⁆ + ⁅f_const_p i, f_xdotp_p j⁆)
       + (⁅f_xdotp_p i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, f_xdotp_p j⁆)
       - (⁅f_const_p i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, f_const_p j⁆)
-  · dsimp [f_x_p_sqr, f_xdotp_p, f_const_p, f_c_rinvx,
-      positionDotMomentumCompMomentum, constMomentum, constRadiusRegInvCompPosition]
+  · dsimp [f_x_p_sqr, f_xdotp_p, f_const_p, f_c_rinvx, constMomentum, constRadiusRegInvCompPosition]
     simp only [lie_add, lie_sub, add_lie, sub_lie]
     ext ψ x
     simp only [ContinuousLinearMap.sub_apply, ContinuousLinearMap.add_apply, SchwartzMap.sub_apply,

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -47,7 +47,7 @@ def lrlOperatorSqr (ε : ℝˣ) : 𝓢(Space H.d, ℂ) →L[ℂ] 𝓢(Space H.d,
 
 /-- `𝐀(ε)ᵢ = 𝐱ᵢ𝐩² - (𝐱ⱼ𝐩ⱼ)𝐩ᵢ + ½iℏ(d-1)𝐩ᵢ - mk·𝐫(ε)⁻¹𝐱ᵢ` -/
 lemma lrlOperator_eq (ε : ℝˣ) (i : Fin H.d) :
-    H.lrlOperator ε i = 𝐱 i ∘L 𝐩² - (∑ j, 𝐱 j ∘L 𝐩 j) ∘L 𝐩 i
+    H.lrlOperator ε i = 𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩) - (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i
     + (2⁻¹ * I * ℏ * (H.d - 1)) • 𝐩 i - (H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐱 i := by
   rw [lrlOperator, sub_left_inj] -- mk·r⁻¹x terms match exactly
   calc
@@ -62,13 +62,14 @@ lemma lrlOperator_eq (ε : ℝˣ) (i : Fin H.d) :
     _ = (2 : ℂ)⁻¹ • ∑ j, ((2 : ℂ) • 𝐱 i ∘L 𝐩 j ∘L 𝐩 j - (2 : ℂ) • (𝐱 j ∘L 𝐩 j) ∘L 𝐩 i
         + (I * ℏ) • 𝐩 i - (I * ℏ) • δ[i,j] • 𝐩 j) := by
       simp_rw [sub_sub_sub_comm, sub_sub_eq_add_sub]
-    _ = 𝐱 i ∘L ∑ j, 𝐩 j ∘L 𝐩 j - (∑ j, 𝐱 j ∘L 𝐩 j) ∘L 𝐩 i + ((2⁻¹ * I * ℏ) • H.d • 𝐩 i
-        - (2⁻¹ * I * ℏ) • 𝐩 i) := by
-      simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib, ← Finset.smul_sum, sum_smul,
-        smul_add, smul_sub, smul_smul, comp_finset_sum, finset_sum_comp, mul_assoc, add_sub_assoc]
+    _ = 𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩) - (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i
+        + ((2⁻¹ * I * ℏ) • H.d • 𝐩 i - (2⁻¹ * I * ℏ) • 𝐩 i) := by
+      simp only [add_sub_assoc, Finset.sum_add_distrib, Finset.sum_sub_distrib, ← Finset.smul_sum,
+        ← comp_finset_sum, ← finset_sum_comp, sum_smul, smul_add, smul_sub, smul_smul, mul_assoc]
       norm_num
-  rw [momentumOperatorSqr, ← Nat.cast_smul_eq_nsmul ℂ, smul_smul, ← sub_smul]
-  ring_nf
+      rfl
+    _ = 𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩) - (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i + (2⁻¹ * I * ℏ * (H.d - 1)) • 𝐩 i := by
+      simp only [← Nat.cast_smul_eq_nsmul ℂ, smul_smul, ← sub_smul, mul_sub, mul_one]
 
 /-- `𝐀(ε)ᵢ = 𝐋ᵢⱼ𝐩ⱼ + ½iℏ(d-1)𝐩ᵢ - mk·𝐫(ε)⁻¹𝐱ᵢ` -/
 lemma lrlOperator_eq' (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i = ∑ j, 𝐋[i,j] ∘L 𝐩 j
@@ -77,7 +78,7 @@ lemma lrlOperator_eq' (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i = ∑ j, �
   symm
   trans ∑ j, 𝐱 i ∘L 𝐩 j ∘L 𝐩 j - ∑ j, (𝐱 j ∘L 𝐩 j) ∘L 𝐩 i
   · simp [angularMomentumOperator, comp_assoc, momentum_comp_commute]
-  simp [← comp_finset_sum, ← finset_sum_comp, momentumOperatorSqr]
+  simp [← comp_finset_sum, ← finset_sum_comp, dotProduct, mul_def]
 
 set_option backward.isDefEq.respectTransparency false in
 /-- `𝐀(ε)ᵢ = 𝐩ⱼ𝐋ᵢⱼ - ½iℏ(d-1)𝐩ᵢ - mk·𝐫(ε)⁻¹𝐱ᵢ` -/
@@ -98,7 +99,7 @@ lemma lrlOperator_eq'' (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i = ∑ j, 
 private def positionDotMomentum (d : ℕ) := ∑ i : Fin d, 𝐱 i ∘L 𝐩 i
 
 /-- The operator `𝐱ᵢ𝐩²` on Schwartz maps. -/
-private def positionCompMomentumSqr {d : ℕ} (i : Fin d) := 𝐱 i ∘L 𝐩²
+private def positionCompMomentumSqr {d : ℕ} (i : Fin d) := 𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩)
 
 /-- The operator `(𝐱ⱼ𝐩ⱼ)𝐱ᵢ` on Schwartz maps. -/
 private def positionDotMomentumCompMomentum {d : ℕ} (i : Fin d) := positionDotMomentum d ∘L 𝐩 i
@@ -166,9 +167,11 @@ private lemma positionDotMomentum_commutation_momentum {d : ℕ} (i : Fin d) :
   simp_rw [position_commutation_momentum, smul_comp, id_comp, ← Finset.smul_sum, symm _ i, sum_smul]
 
 private lemma positionDotMomentum_commutation_momentumSqr (d : ℕ) :
-    ⁅positionDotMomentum d, momentumOperatorSqr (d := d)⁆ = (2 * I * ℏ) • 𝐩² := by
-  simp [positionDotMomentum, sum_lie, leibniz_lie, ← lie_skew (𝐩 _) 𝐩²,
-    position_commutation_momentumSqr, ← Finset.smul_sum, ← momentumOperatorSqr_eq]
+    ⁅positionDotMomentum d, 𝐩[d] ⬝ᵥ 𝐩⁆ = (2 * I * ℏ) • (𝐩 ⬝ᵥ 𝐩) := by
+  trans ∑ i, ⁅𝐱 i, 𝐩 ⬝ᵥ 𝐩⁆ ∘L 𝐩 i
+  · simp [positionDotMomentum, sum_lie, leibniz_lie, ← lie_skew (𝐩 _) (𝐩 ⬝ᵥ 𝐩)]
+  simp_rw [position_commutation_momentumSqr, smul_comp, ← Finset.smul_sum]
+  rfl
 
 private lemma positionDotMomentum_commutation_radiusRegPow (d : ℕ) (ε : ℝˣ) (s : ℝ) :
     ⁅positionDotMomentum d, 𝐫₀[d] ε s⁆ = (-s * I * ℏ) • (𝐫₀ ε s - ε.1 ^ 2 • 𝐫₀ ε (s-2)) := by
@@ -181,38 +184,38 @@ private lemma positionDotMomentum_commutation_radiusRegPow (d : ℕ) (ε : ℝˣ
     _ = (-s * I * ℏ) • (𝐫₀ ε s - ε.1 ^ 2 • 𝐫₀ ε (s-2)) := by simp [positionOperatorSqr_eq ε]
 
 private lemma positionCompMomentumSqr_comm {d : ℕ} (i j : Fin d) :
-    ⁅positionCompMomentumSqr i, positionCompMomentumSqr j⁆ = (-2 * I * ℏ) • 𝐩² ∘L 𝐋[i,j] := by
+    ⁅positionCompMomentumSqr i, positionCompMomentumSqr j⁆ = (-2 * I * ℏ) • (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] := by
   calc
-    _ = (𝐱 j ∘L ⁅𝐱 i, 𝐩²⁆ + 𝐱 i ∘L ⁅momentumOperatorSqr (d := d), 𝐱 j⁆) ∘L 𝐩² := by
+    _ = (𝐱 j ∘L ⁅𝐱 i, 𝐩[d] ⬝ᵥ 𝐩⁆ + 𝐱 i ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱 j⁆) ∘L (𝐩 ⬝ᵥ 𝐩) := by
       simp [positionCompMomentumSqr, lie_leibniz, leibniz_lie, comp_assoc]
-    _ = (2 * I * ℏ) • 𝐋[j,i] ∘L 𝐩² := by
-      simp_rw [← lie_skew 𝐩² _, position_commutation_momentumSqr, comp_neg, comp_smul,
+    _ = (2 * I * ℏ) • 𝐋[j,i] ∘L (𝐩 ⬝ᵥ 𝐩) := by
+      simp_rw [← lie_skew (𝐩 ⬝ᵥ 𝐩) _, position_commutation_momentumSqr, comp_neg, comp_smul,
         ← sub_eq_add_neg, ← smul_sub, smul_comp, angularMomentumOperator]
-    _ = (-2 * I * ℏ) • 𝐩² ∘L 𝐋[i,j] := by
+    _ = (-2 * I * ℏ) • (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] := by
       rw [angularMomentumOperator_antisymm j i, neg_comp, smul_neg, ← neg_smul, ← neg_mul,
         ← neg_mul, momentumSqr_comp_angularMomentum_commute]
 
 private lemma positionCompMomentumSqr_comm_positionDotMomentumCompMomentum_add
     {d : ℕ} (i j : Fin d) : ⁅positionCompMomentumSqr i, positionDotMomentumCompMomentum j⁆ +
-    ⁅positionDotMomentumCompMomentum i, positionCompMomentumSqr j⁆ = (-I * ℏ) • 𝐩² ∘L 𝐋[i,j] := by
+    ⁅positionDotMomentumCompMomentum i, positionCompMomentumSqr j⁆ = (-I * ℏ) • (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] := by
   suffices ∀ k l : Fin d, ⁅positionCompMomentumSqr k, positionDotMomentumCompMomentum l⁆
-      = (-I * ℏ) • (𝐱 k ∘L 𝐩 l - δ[k,l] • positionDotMomentum d) ∘L 𝐩² by
+      = (-I * ℏ) • (𝐱 k ∘L 𝐩 l - δ[k,l] • positionDotMomentum d) ∘L (𝐩 ⬝ᵥ 𝐩) by
     nth_rw 2 [← lie_skew]
     simp_rw [this, ← sub_eq_add_neg, ← smul_sub, ← sub_comp, symm j i, sub_sub_sub_cancel_right,
       momentumSqr_comp_angularMomentum_commute, angularMomentumOperator]
   intro k l
   calc
-    _ = (positionDotMomentum d) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L 𝐩²
-        + 𝐱 k ∘L ⁅momentumOperatorSqr (d := d), positionDotMomentum d⁆ ∘L 𝐩 l
-        + ⁅𝐱 k, positionDotMomentum d⁆ ∘L 𝐩² ∘L 𝐩 l := by
+    _ = (positionDotMomentum d) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L (𝐩 ⬝ᵥ 𝐩)
+        + 𝐱 k ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, positionDotMomentum d⁆ ∘L 𝐩 l
+        + ⁅𝐱 k, positionDotMomentum d⁆ ∘L (𝐩 ⬝ᵥ 𝐩) ∘L 𝐩 l := by
       simp [positionCompMomentumSqr, positionDotMomentumCompMomentum, lie_leibniz, leibniz_lie,
         add_assoc, comp_assoc]
-    _ = (positionDotMomentum d) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L 𝐩² + (-I * ℏ) • 𝐱 k ∘L 𝐩 l ∘L 𝐩² := by
+    _ = (positionDotMomentum d) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L (𝐩 ⬝ᵥ 𝐩) + (-I * ℏ) • 𝐱 k ∘L 𝐩 l ∘L (𝐩 ⬝ᵥ 𝐩) := by
       simp only [← lie_skew _ (positionDotMomentum d), positionDotMomentum_commutation_position,
         positionDotMomentum_commutation_momentumSqr, momentumSqr_comp_momentum_commute,
         ← neg_smul, ← neg_mul, smul_comp, comp_smul, add_assoc, ← add_smul]
       ring_nf
-    _ = (-I * ℏ) • (𝐱 k ∘L 𝐩 l - δ[k,l] • positionDotMomentum d) ∘L 𝐩² := by
+    _ = (-I * ℏ) • (𝐱 k ∘L 𝐩 l - δ[k,l] • positionDotMomentum d) ∘L (𝐩 ⬝ᵥ 𝐩) := by
       simp_rw [add_comm, position_commutation_momentum, sub_comp, smul_sub, smul_comp, comp_smul,
         id_comp, sub_eq_add_neg, ← neg_smul, neg_mul, neg_neg, comp_assoc]
 
@@ -243,7 +246,7 @@ private lemma positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add
     (ε : ℝˣ) (i j : Fin H.d) : ⁅positionCompMomentumSqr i, constRadiusRegInvCompPosition H ε j⁆
     + ⁅constRadiusRegInvCompPosition H ε i, positionCompMomentumSqr j⁆
     = (-2 * I * ℏ * H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐋[i,j] := by
-  let A := ⁅momentumOperatorSqr (d := H.d), radiusRegPowOperator (d := H.d) ε (-1)⁆
+  let A := ⁅𝐩[H.d] ⬝ᵥ 𝐩, radiusRegPowOperator (d := H.d) ε (-1)⁆
   have hA : 𝐱 i ∘L A ∘L 𝐱 j = 𝐱 j ∘L A ∘L 𝐱 i := by
     suffices A = (2 * I * ℏ) • 𝐫₀ ε (-3) ∘L positionDotMomentum H.d
         + ((H.d - 3) * ℏ ^ 2 : ℝ) • 𝐫₀ ε (-3) + (3 * ε.1 ^ 2 * ℏ ^ 2) • 𝐫₀ ε (-5) by
@@ -251,13 +254,14 @@ private lemma positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add
         position_comp_radiusRegPow_commute, comp_assoc,
         comp_eq_comp_add_commute (positionDotMomentum _), positionDotMomentum_commutation_position,
         comp_add, comp_smul, ← comp_assoc (𝐱 _) (𝐱 _) _, position_comp_commute j i]
-    simp_rw [A, ← lie_skew 𝐩² _, radiusRegPow_commutation_momentumSqr, neg_sub, ← sub_sub,
+    simp_rw [A, ← lie_skew (𝐩 ⬝ᵥ 𝐩) _, radiusRegPow_commutation_momentumSqr, neg_sub, ← sub_sub,
       positionDotMomentum, sub_eq_add_neg, ← neg_smul, ← neg_mul, neg_neg, ofReal_neg, ofReal_one,
-      ← add_rotate]
+      dotProduct, mul_def]
     ring_nf
-  let B (i : Fin H.d) := ⁅momentumOperatorSqr (d := H.d), 𝐱 i⁆
+    rw [add_rotate]
+  let B (i : Fin H.d) := ⁅𝐩[H.d] ⬝ᵥ 𝐩, 𝐱 i⁆
   have hB (k : Fin H.d) : B k = (-2 * I * ℏ) • 𝐩 k := by
-    simp [B, ← lie_skew 𝐩² _, position_commutation_momentumSqr]
+    simp [B, ← lie_skew (𝐩 ⬝ᵥ 𝐩) _, position_commutation_momentumSqr]
   calc
     _ = (H.m * H.k) • (𝐫₀ ε (-1) ∘L 𝐱 i ∘L B j + 𝐱 i ∘L A ∘L 𝐱 j
         - (𝐫₀ ε (-1) ∘L 𝐱 j ∘L B i + 𝐱 j ∘L A ∘L 𝐱 i)) := by
@@ -357,8 +361,8 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
 -/
 
 private lemma pSqr_comm_pL_Lp {d : ℕ} (i : Fin d) :
-    ⁅momentumOperatorSqr (d := d), ∑ j, (𝐩 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐩 j)⁆ = 0 := by
-  simp [lie_sum, lie_leibniz, ← lie_skew 𝐩² 𝐋[_,_]]
+    ⁅𝐩[d] ⬝ᵥ 𝐩, ∑ j, (𝐩 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐩 j)⁆ = 0 := by
+  simp [lie_sum, lie_leibniz, ← lie_skew (𝐩 ⬝ᵥ 𝐩) 𝐋[_,_]]
 
 private lemma r_comm_rx {d : ℕ} (ε : ℝˣ) (i : Fin d) : ⁅𝐫₀[d] ε (-1), 𝐫₀ ε (-1) ∘L 𝐱 i⁆ = 0 := by
   simp [lie_leibniz, ← lie_skew (𝐫₀ _ _) (𝐱 _)]
@@ -384,7 +388,7 @@ private lemma xL_Lx_eq {d : ℕ} (ε : ℝˣ) (i : Fin d) :
 
 set_option backward.isDefEq.respectTransparency false in
 private lemma pSqr_comm_rx (ε : ℝˣ) (i : Fin H.d) :
-    ⁅momentumOperatorSqr (d := H.d), 𝐫₀ ε (-1) ∘L 𝐱 i⁆
+    ⁅𝐩[H.d] ⬝ᵥ 𝐩, 𝐫₀ ε (-1) ∘L 𝐱 i⁆
     = (I * ℏ) • 𝐫₀ ε (-3) ∘L ∑ j, (𝐱 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐱 j)
     + ((-2 * I * ℏ * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐩 i + (3 * ℏ ^ 2 * ε.1 ^ 2) • 𝐫₀ ε (-5) ∘L 𝐱 i) := by
   trans (-2 * I * ℏ) • 𝐫₀ ε (-1) ∘L 𝐩 i
@@ -393,7 +397,7 @@ private lemma pSqr_comm_rx (ε : ℝˣ) (i : Fin H.d) :
   · rw [← lie_skew, positionDotMomentum]
     simp_rw [leibniz_lie, position_commutation_momentumSqr, radiusRegPow_commutation_momentumSqr,
       sub_comp, add_comp, smul_comp, comp_smul, comp_assoc, neg_add, neg_sub', neg_add,
-      sub_neg_eq_add, ← neg_smul, add_assoc, ofReal_neg, ofReal_one]
+      sub_neg_eq_add, ← neg_smul, add_assoc, ofReal_neg, ofReal_one, dotProduct, mul_def]
     ring_nf
   rw [← add_assoc, add_left_inj, add_rotate]
   simp_rw [xL_Lx_eq ε i, comp_add, comp_smul, smul_add, ← Complex.coe_smul, smul_smul, ← comp_assoc,
@@ -420,7 +424,7 @@ set_option backward.isDefEq.respectTransparency false in
 lemma hamiltonianReg_commutation_lrl (ε : ℝˣ) (i : Fin H.d) :
     ⁅H.hamiltonianReg ε, H.lrlOperator ε i⁆ = (I * ℏ * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐩 i
     - (3 / 2 * ℏ ^ 2 * H.k * ε.1 ^ 2) • 𝐫₀ ε (-5) ∘L 𝐱 i := by
-  trans (-2⁻¹ * H.k) • (⁅momentumOperatorSqr (d := H.d), 𝐫₀ ε (-1) ∘L 𝐱 i⁆
+  trans (-2⁻¹ * H.k) • (⁅𝐩[H.d] ⬝ᵥ 𝐩, 𝐫₀ ε (-1) ∘L 𝐱 i⁆
       + ⁅radiusRegPowOperator (d := H.d) ε (-1), ∑ j, (𝐩 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐩 j)⁆)
   · have h : H.m * H.k * (H.m⁻¹ * 2⁻¹) = 2⁻¹ * H.k := by grind [m_ne_zero]
     simp [hamiltonianReg, lrlOperator, pSqr_comm_pL_Lp, r_comm_rx, h, smul_smul, sub_eq_neg_add]
@@ -472,7 +476,7 @@ private lemma sum_ppL (d : ℕ) : ∑ i : Fin d, ∑ j, 𝐩 i ∘L 𝐩 j ∘L 
   simp
 
 private lemma sum_LppL (d : ℕ) :
-    ∑ i : Fin d, ∑ j, ∑ k, 𝐋[i,j] ∘L 𝐩 j ∘L 𝐩 k ∘L 𝐋[i,k] = 𝐩² ∘L 𝐋² := by
+    ∑ i : Fin d, ∑ j, ∑ k, 𝐋[i,j] ∘L 𝐩 j ∘L 𝐩 k ∘L 𝐋[i,k] = (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋² := by
   rw [sum_symmetrize']
   conv_lhs =>
     enter [2, 2, i, 2, j, 2, k]
@@ -487,8 +491,8 @@ private lemma sum_LppL (d : ℕ) :
           momentum_comp_commute i j, sub_sub_sub_cancel_right]
       _ = 𝐋[i,j] ∘L (𝐩 k ∘L 𝐩 k) ∘L 𝐋[i,j] := by
         simp_rw [← comp_assoc, ← sub_comp, angularMomentumOperator]
-  trans (2 : ℂ)⁻¹ • ∑ i, ∑ j, 𝐋[i,j] ∘L 𝐩² ∘L 𝐋[i,j]
-  · simp_rw [← comp_finset_sum, ← finset_sum_comp, ← comp_assoc, momentumOperatorSqr]
+  trans (2 : ℂ)⁻¹ • ∑ i, ∑ j, 𝐋[i,j] ∘L (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j]
+  · simp_rw [← comp_finset_sum, ← finset_sum_comp, ← comp_assoc, dotProduct, mul_def]
   simp_rw [← comp_assoc, ← momentumSqr_comp_angularMomentum_commute, comp_assoc, ← comp_finset_sum,
     ← comp_smul, angularMomentumOperatorSqr]
 

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -15,7 +15,6 @@ public import Physlib.Meta.Linters.Sorry
 In this file we define
 - The (regularized) LRL vector operator for the quantum mechanical hydrogen atom,
   `𝐀(ε)ᵢ ≔ ½(𝐩ⱼ𝐋ᵢⱼ + 𝐋ᵢⱼ𝐩ⱼ) - mk·𝐫(ε)⁻¹𝐱ᵢ`.
-- The square of the LRL vector operator, `𝐀(ε)² ≔ 𝐀(ε)ᵢ𝐀(ε)ᵢ`.
 
 The main results are
 - The commutators `⁅𝐋ᵢⱼ, 𝐀(ε)ₖ⁆ = iℏ(δᵢₖ𝐀(ε)ⱼ - δⱼₖ𝐀(ε)ᵢ)` in `angularMomentum_commutation_lrl`
@@ -90,9 +89,6 @@ lemma lrlOperator_eq'' (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i = ∑ j, 
     Pi.smul_apply, SchwartzMap.sub_apply, SchwartzMap.add_apply, SchwartzMap.smul_apply, real_smul,
     ofReal_mul, ofReal_ofNat]
   ring
-
-/-- The operator `𝐱ᵢ𝐩²` on Schwartz maps. -/
-private def positionCompMomentumSqr {d : ℕ} (i : Fin d) := 𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩)
 
 /-- The operator `(𝐱ⱼ𝐩ⱼ)𝐱ᵢ` on Schwartz maps. -/
 private def positionDotMomentumCompMomentum {d : ℕ} (i : Fin d) := (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i
@@ -176,10 +172,10 @@ private lemma positionDotMomentum_commutation_radiusRegPow (d : ℕ) (ε : ℝˣ
     _ = (-s * I * ℏ) • (𝐫₀ ε s - ε.1 ^ 2 • 𝐫₀ ε (s-2)) := by simp [positionOperatorSqr_eq ε]
 
 private lemma positionCompMomentumSqr_comm {d : ℕ} (i j : Fin d) :
-    ⁅positionCompMomentumSqr i, positionCompMomentumSqr j⁆ = (-2 * I * ℏ) • (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] := by
+    ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ = (-2 * I * ℏ) • (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] := by
   calc
     _ = (𝐱 j ∘L ⁅𝐱 i, 𝐩[d] ⬝ᵥ 𝐩⁆ + 𝐱 i ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱 j⁆) ∘L (𝐩 ⬝ᵥ 𝐩) := by
-      simp [positionCompMomentumSqr, lie_leibniz, leibniz_lie, comp_assoc]
+      simp [lie_leibniz, leibniz_lie, comp_assoc]
     _ = (2 * I * ℏ) • 𝐋[j,i] ∘L (𝐩 ⬝ᵥ 𝐩) := by
       simp_rw [← lie_skew (𝐩 ⬝ᵥ 𝐩) _, position_commutation_momentumSqr, comp_neg, comp_smul,
         ← sub_eq_add_neg, ← smul_sub, smul_comp, angularMomentumOperator]
@@ -188,9 +184,9 @@ private lemma positionCompMomentumSqr_comm {d : ℕ} (i j : Fin d) :
         ← neg_mul, momentumSqr_comp_angularMomentum_commute]
 
 private lemma positionCompMomentumSqr_comm_positionDotMomentumCompMomentum_add
-    {d : ℕ} (i j : Fin d) : ⁅positionCompMomentumSqr i, positionDotMomentumCompMomentum j⁆ +
-    ⁅positionDotMomentumCompMomentum i, positionCompMomentumSqr j⁆ = (-I * ℏ) • (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] := by
-  suffices ∀ k l : Fin d, ⁅positionCompMomentumSqr k, positionDotMomentumCompMomentum l⁆
+    {d : ℕ} (i j : Fin d) : ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), positionDotMomentumCompMomentum j⁆ +
+    ⁅positionDotMomentumCompMomentum i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ = (-I * ℏ) • (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] := by
+  suffices ∀ k l : Fin d, ⁅𝐱 k ∘L (𝐩 ⬝ᵥ 𝐩), positionDotMomentumCompMomentum l⁆
       = (-I * ℏ) • (𝐱 k ∘L 𝐩 l - δ[k,l] • (𝐱 ⬝ᵥ 𝐩)) ∘L (𝐩 ⬝ᵥ 𝐩) by
     nth_rw 2 [← lie_skew]
     simp_rw [this, ← sub_eq_add_neg, ← smul_sub, ← sub_comp, symm j i, sub_sub_sub_cancel_right,
@@ -199,8 +195,7 @@ private lemma positionCompMomentumSqr_comm_positionDotMomentumCompMomentum_add
   calc
     _ = (𝐱 ⬝ᵥ 𝐩) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L (𝐩 ⬝ᵥ 𝐩) + 𝐱 k ∘L ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐱[d] ⬝ᵥ 𝐩⁆ ∘L 𝐩 l
         + ⁅𝐱 k, 𝐱[d] ⬝ᵥ 𝐩⁆ ∘L (𝐩 ⬝ᵥ 𝐩) ∘L 𝐩 l := by
-      simp [positionCompMomentumSqr, positionDotMomentumCompMomentum, lie_leibniz, leibniz_lie,
-        add_assoc, comp_assoc]
+      simp [positionDotMomentumCompMomentum, lie_leibniz, leibniz_lie, add_assoc, comp_assoc]
     _ = (𝐱 ⬝ᵥ 𝐩) ∘L ⁅𝐱 k, 𝐩 l⁆ ∘L (𝐩 ⬝ᵥ 𝐩) + (-I * ℏ) • 𝐱 k ∘L 𝐩 l ∘L (𝐩 ⬝ᵥ 𝐩) := by
       simp only [← lie_skew _ (𝐱 ⬝ᵥ 𝐩), positionDotMomentum_commutation_position,
         positionDotMomentum_commutation_momentumSqr, momentumSqr_comp_momentum_commute,
@@ -216,10 +211,9 @@ private lemma positionDotMomentumCompMomentum_comm {d : ℕ} (i j : Fin d) :
     ← lie_skew (𝐩 _) (𝐱 ⬝ᵥ 𝐩), positionDotMomentum_commutation_momentum, comp_assoc]
 
 private lemma positionCompMomentumSqr_comm_constMomentum_add {d : ℕ} (i j : Fin d) :
-    ⁅positionCompMomentumSqr i, constMomentum j⁆ +
-    ⁅constMomentum i, positionCompMomentumSqr j⁆ = 0 := by
+    ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), constMomentum j⁆ + ⁅constMomentum i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆ = 0 := by
   nth_rw 2 [← lie_skew]
-  simp [positionCompMomentumSqr, constMomentum, leibniz_lie, position_commutation_momentum, symm j]
+  simp [constMomentum, leibniz_lie, position_commutation_momentum, symm j]
 
 private lemma positionDotMomentumCompMomentum_comm_constMomentum_add {d : ℕ} (i j : Fin d) :
     ⁅positionDotMomentumCompMomentum i, constMomentum j⁆ +
@@ -234,8 +228,8 @@ private lemma constMomentum_comm {d : ℕ} (i j : Fin d) :
 
 set_option backward.isDefEq.respectTransparency false in
 private lemma positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add
-    (ε : ℝˣ) (i j : Fin H.d) : ⁅positionCompMomentumSqr i, constRadiusRegInvCompPosition H ε j⁆
-    + ⁅constRadiusRegInvCompPosition H ε i, positionCompMomentumSqr j⁆
+    (ε : ℝˣ) (i j : Fin H.d) : ⁅𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩), constRadiusRegInvCompPosition H ε j⁆
+    + ⁅constRadiusRegInvCompPosition H ε i, 𝐱 j ∘L (𝐩 ⬝ᵥ 𝐩)⁆
     = (-2 * I * ℏ * H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐋[i,j] := by
   let A := ⁅𝐩[H.d] ⬝ᵥ 𝐩, radiusRegPowOperator (d := H.d) ε (-1)⁆
   have hA : 𝐱 i ∘L A ∘L 𝐱 j = 𝐱 j ∘L A ∘L 𝐱 i := by
@@ -256,7 +250,7 @@ private lemma positionCompMomentumSqr_comm_constRadiusRegInvCompPosition_add
     _ = (H.m * H.k) • (𝐫₀ ε (-1) ∘L 𝐱 i ∘L B j + 𝐱 i ∘L A ∘L 𝐱 j
         - (𝐫₀ ε (-1) ∘L 𝐱 j ∘L B i + 𝐱 j ∘L A ∘L 𝐱 i)) := by
       nth_rw 2 [← lie_skew]
-      simp_rw [← sub_eq_add_neg, positionCompMomentumSqr, constRadiusRegInvCompPosition, lie_smul,
+      simp_rw [← sub_eq_add_neg, constRadiusRegInvCompPosition, lie_smul,
         ← smul_sub, lie_leibniz, leibniz_lie, ← sub_sub]
       simp [A, B, comp_assoc]
     _ = (H.m * H.k) • 𝐫₀ ε (-1) ∘L (𝐱 i ∘L B j - 𝐱 j ∘L B i) := by simp [hA]
@@ -312,7 +306,7 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
     ⁅H.lrlOperator ε i, H.lrlOperator ε j⁆ = ((-2 * I * ℏ * H.m) • H.hamiltonianReg ε
     + (I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3)) ∘L 𝐋[i,j] := by
   repeat rw [lrlOperator_eq]
-  let f_x_p_sqr := positionCompMomentumSqr (d := H.d)
+  let f_x_p_sqr (k : Fin H.d) := 𝐱 k ∘L (𝐩 ⬝ᵥ 𝐩)
   let f_xdotp_p := positionDotMomentumCompMomentum (d := H.d)
   let f_const_p := constMomentum (d := H.d)
   let f_c_rinvx := constRadiusRegInvCompPosition H ε
@@ -324,7 +318,7 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
       - (⁅f_xdotp_p i, f_const_p j⁆ + ⁅f_const_p i, f_xdotp_p j⁆)
       + (⁅f_xdotp_p i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, f_xdotp_p j⁆)
       - (⁅f_const_p i, f_c_rinvx j⁆ + ⁅f_c_rinvx i, f_const_p j⁆)
-  · dsimp [f_x_p_sqr, f_xdotp_p, f_const_p, f_c_rinvx, positionCompMomentumSqr,
+  · dsimp [f_x_p_sqr, f_xdotp_p, f_const_p, f_c_rinvx,
       positionDotMomentumCompMomentum, constMomentum, constRadiusRegInvCompPosition]
     simp only [lie_add, lie_sub, add_lie, sub_lie]
     ext ψ x

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -41,10 +41,6 @@ variable (H : HydrogenAtom)
 def lrlOperator (ε : ℝˣ) (i : Fin H.d) : 𝓢(Space H.d, ℂ) →L[ℂ] 𝓢(Space H.d, ℂ) :=
   (2 : ℝ)⁻¹ • ∑ j, (𝐩 j ∘L 𝐋[i,j] + 𝐋[i,j] ∘L 𝐩 j) - (H.m * H.k) • 𝐫₀ ε (-1) ∘L 𝐱 i
 
-/-- The square of the LRL vector operator, `𝐀(ε)² ≔ 𝐀(ε)ᵢ𝐀(ε)ᵢ`. -/
-def lrlOperatorSqr (ε : ℝˣ) : 𝓢(Space H.d, ℂ) →L[ℂ] 𝓢(Space H.d, ℂ) :=
-  ∑ i, (H.lrlOperator ε i) ∘L (H.lrlOperator ε i)
-
 /-- `𝐀(ε)ᵢ = 𝐱ᵢ𝐩² - (𝐱ⱼ𝐩ⱼ)𝐩ᵢ + ½iℏ(d-1)𝐩ᵢ - mk·𝐫(ε)⁻¹𝐱ᵢ` -/
 lemma lrlOperator_eq (ε : ℝˣ) (i : Fin H.d) :
     H.lrlOperator ε i = 𝐱 i ∘L (𝐩 ⬝ᵥ 𝐩) - (𝐱 ⬝ᵥ 𝐩) ∘L 𝐩 i
@@ -122,21 +118,20 @@ lemma angularMomentum_commutation_lrl (ε : ℝˣ) (i j k : Fin H.d) :
   sorry
 
 /-- `⁅𝐋ᵢⱼ, 𝐀(ε)²⁆ = 0` -/
-@[sorryful]
+@[sorryful, simp]
 lemma angularMomentum_commutation_lrlSqr (ε : ℝˣ) (i j : Fin H.d) :
-    ⁅𝐋[i,j], H.lrlOperatorSqr ε⁆ = 0 := by
-  unfold lrlOperatorSqr
-  simp only [lie_sum, lie_leibniz, H.angularMomentum_commutation_lrl]
+    ⁅𝐋[i,j], H.lrlOperator ε ⬝ᵥ H.lrlOperator ε⁆ = 0 := by
+  simp only [dotProduct, mul_def, lie_sum, lie_leibniz, H.angularMomentum_commutation_lrl]
   simp only [comp_sub, comp_smul, sub_comp, smul_comp]
   dsimp only [kroneckerDelta]
   simp [Finset.sum_add_distrib, Finset.sum_sub_distrib]
 
 /-- `⁅𝐋², 𝐀(ε)²⁆ = 0` -/
-@[sorryful]
+@[sorryful, simp]
 lemma angularMomentumSqr_commutation_lrlSqr (ε : ℝˣ) :
-    ⁅angularMomentumOperatorSqr (d := H.d), H.lrlOperatorSqr ε⁆ = 0 := by
+    ⁅angularMomentumOperatorSqr (d := H.d), H.lrlOperator ε ⬝ᵥ H.lrlOperator ε⁆ = 0 := by
   unfold angularMomentumOperatorSqr
-  simp [sum_lie, leibniz_lie, H.angularMomentum_commutation_lrlSqr]
+  simp [sum_lie, leibniz_lie]
 
 /-
 
@@ -556,19 +551,19 @@ set_option backward.isDefEq.respectTransparency false in
 /-- The square of the (regularized) LRL vector operator is related to the (regularized) Hamiltonian
   `𝐇(ε)` of the hydrogen atom, square of the angular momentum `𝐋²` and powers of `𝐫(ε)` as
   `𝐀(ε)² = 2m·𝐇(ε)(𝐋² + ¼ℏ²(d-1)²) + m²k²(𝟙 - ε²·𝐫(ε)⁻²) - ½(d-1)mkℏ²ε²𝐫(ε)⁻³`. -/
-lemma lrlOperatorSqr_eq (ε : ℝˣ) : H.lrlOperatorSqr ε =
+lemma lrlOperatorSqr_eq (ε : ℝˣ) : H.lrlOperator ε ⬝ᵥ H.lrlOperator ε =
     (2 * H.m) • (H.hamiltonianReg ε) ∘L
       (𝐋² + (4⁻¹ * ℏ ^ 2 * (H.d - 1) ^ 2 : ℝ) • ContinuousLinearMap.id ℂ 𝓢(Space H.d, ℂ))
     + (H.m ^ 2 * H.k ^ 2) • (ContinuousLinearMap.id ℂ 𝓢(Space H.d, ℂ) - ε.1 ^ 2 • 𝐫₀ ε (-2))
     - (2⁻¹ * ℏ^2 * H.m * H.k * (H.d - 1) * ε.1 ^ 2) • 𝐫₀ ε (-3) := by
-  dsimp [lrlOperatorSqr]
+  simp_rw [dotProduct, mul_def]
   conv_lhs => enter [2, i, 1]; rw [lrlOperator_eq']
   conv_lhs => enter [2, i, 2]; rw [lrlOperator_eq'']
   simp_rw [sub_eq_add_neg, ← neg_smul, add_comp, comp_add, smul_comp, comp_smul, finset_sum_comp,
     comp_finset_sum, Finset.sum_add_distrib, ← Finset.smul_sum, comp_assoc, sum_LppL, sum_Lpp,
     sum_Lprx, sum_ppL, sum_prx, sum_rxpL, sum_rxp, sum_rxrx, hamiltonianReg]
   simp only [sub_eq_add_neg, ← neg_smul, smul_zero, zero_add, add_zero, ← neg_mul, smul_smul,
-    ← momentumOperatorSqr_eq, ← Complex.coe_smul, ofReal_mul, ofReal_neg, ofReal_inv, ofReal_pow,
+    dotProduct, mul_def, ← Complex.coe_smul, ofReal_mul, ofReal_neg, ofReal_inv, ofReal_pow,
     smul_add, ofReal_ofNat]
   ring_nf
   ext

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -136,10 +136,10 @@ lemma momentum_comp_commute : 𝐩 i ∘L 𝐩 j = 𝐩 j ∘L 𝐩 i := by
   rw [comp_eq_comp_add_commute, momentum_commutation_momentum, add_zero]
 
 @[simp]
-lemma momentumSqr_commutation_momentum : ⁅momentumOperatorSqr (d := d), 𝐩 i⁆ = 0 := by
-  simp [momentumOperatorSqr, sum_lie, leibniz_lie]
+lemma momentumSqr_commutation_momentum : ⁅𝐩[d] ⬝ᵥ 𝐩, 𝐩 i⁆ = 0 := by
+  simp [dotProduct, mul_def, sum_lie, leibniz_lie]
 
-lemma momentumSqr_comp_momentum_commute : 𝐩² ∘L 𝐩 i = 𝐩 i ∘L 𝐩² := by
+lemma momentumSqr_comp_momentum_commute : (𝐩 ⬝ᵥ 𝐩) ∘L 𝐩 i = 𝐩 i ∘L (𝐩 ⬝ᵥ 𝐩) := by
   rw [comp_eq_comp_add_commute, momentumSqr_commutation_momentum, add_zero]
 
 /-!
@@ -177,8 +177,8 @@ lemma position_commutation_momentum_momentum : ⁅𝐱 i, 𝐩 j ∘L 𝐩 k⁆ 
   simp only [lie_leibniz, position_commutation_momentum, comp_smul, smul_comp, comp_id, id_comp,
     smul_add]
 
-lemma position_commutation_momentumSqr : ⁅𝐱 i, 𝐩²⁆ = (2 * I * ℏ) • 𝐩 i := by
-  simp only [momentumOperatorSqr, lie_sum, lie_leibniz, position_commutation_momentum, comp_smul,
+lemma position_commutation_momentumSqr : ⁅𝐱 i, 𝐩 ⬝ᵥ 𝐩⁆ = (2 * I * ℏ) • 𝐩 i := by
+  simp only [dotProduct, mul_def, lie_sum, lie_leibniz, position_commutation_momentum, comp_smul,
     smul_comp, comp_id, id_comp, ← two_smul ℂ, smul_smul, mul_assoc, ← Finset.smul_sum, sum_smul]
 
 set_option backward.isDefEq.respectTransparency false in
@@ -209,40 +209,31 @@ lemma momentum_comp_radiusRegPow_eq :
 
 set_option backward.isDefEq.respectTransparency false in
 lemma radiusRegPow_commutation_momentumSqr :
-    ⁅𝐫₀[d] ε s, momentumOperatorSqr (d := d)⁆ = (2 * s * I * ℏ) • 𝐫₀ ε (s-2) ∘L ∑ i, 𝐱 i ∘L 𝐩 i
+    ⁅𝐫₀[d] ε s, 𝐩[d] ⬝ᵥ 𝐩⁆ = (2 * s * I * ℏ) • 𝐫₀ ε (s-2) ∘L (𝐱 ⬝ᵥ 𝐩)
     + (s * (d + s - 2) * ℏ ^ 2) • 𝐫₀ ε (s-2) - (ε ^ 2 * s * (s - 2) * ℏ ^ 2) • 𝐫₀ ε (s-4) := by
   calc
     _ = (s * I * ℏ) • ∑ i, ((𝐩 i ∘L 𝐫₀ ε (s-2)) ∘L 𝐱 i + 𝐫₀ ε (s-2) ∘L 𝐱 i ∘L 𝐩 i) := by
-      simp [momentumOperatorSqr, lie_sum, lie_leibniz, radiusRegPow_commutation_momentum,
+      simp [dotProduct, mul_def, lie_sum, lie_leibniz, radiusRegPow_commutation_momentum,
         ← smul_add, ← Finset.smul_sum, comp_assoc]
     _ = (s * I * ℏ) • ∑ i, (𝐫₀ ε (s-2) ∘L 𝐩 i ∘L 𝐱 i + 𝐫₀ ε (s-2) ∘L 𝐱 i ∘L 𝐩 i
         - (↑(s - 2) * I * ℏ) • 𝐫₀ ε (s-4) ∘L 𝐱 i ∘L 𝐱 i) := by
       simp only [momentum_comp_radiusRegPow_eq, sub_comp, smul_comp, sub_add_eq_add_sub, comp_assoc]
       ring_nf
     _ = (s * I * ℏ) • ∑ i, ((2 : ℂ) • 𝐫₀ ε (s-2) ∘L 𝐱 i ∘L 𝐩 i - (I * ℏ) • 𝐫₀ ε (s-2)
-        - (↑(s - 2) * I * ℏ) • 𝐫₀ ε (s-4) ∘L 𝐱 i ∘L 𝐱 i) := by
+        - ((s - 2) * I * ℏ) • 𝐫₀ ε (s-4) ∘L 𝐱 i ∘L 𝐱 i) := by
       simp [momentum_comp_position_eq, sub_add_eq_add_sub, ← two_smul ℂ]
-  simp only [Finset.sum_sub_distrib, ← Finset.smul_sum, smul_sub, smul_smul, ← comp_finset_sum]
-  have hsumr : ∑ i : Fin d, 𝐫₀[d] ε (s-2) = (d : ℂ) • 𝐫₀ ε (s-2) := by
-    simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, Nat.cast_smul_eq_nsmul]
-  have hrxx : 𝐫₀[d] ε (s-4) ∘L ∑ i, 𝐱 i ∘L 𝐱 i = 𝐫₀ ε (s-2) - (ε ^ 2 : ℂ) • 𝐫₀ ε (s-4) := by
-    rw [positionOperatorSqr_eq ε, comp_sub, comp_smul, comp_id, radiusRegPowOperator_comp_eq,
-      ← Complex.coe_smul (ε.1 ^ 2), ofReal_pow]
-    ring_nf
-  rw [hsumr, hrxx, smul_smul, smul_sub, ← sub_add, sub_sub, ← add_smul, smul_smul]
-  simp only [sub_eq_add_neg, ← neg_smul]
-  congr 3 -- match coefficients of `r[s-4]∑xᵢpᵢ`, `r[s-2]` and `r[s-4]`
-  · ring
-  · ring_nf
-    simp only [I_sq, ofReal_add, ofReal_neg, RingHom.toMonoidHom_eq_coe, OneHom.toFun_eq_coe,
-      MonoidHom.toOneHom_coe, MonoidHom.coe_coe, coe_algebraMap, ZeroHom.coe_mk, ofReal_sub,
-      ofReal_mul, ofReal_natCast, ofReal_pow]
-    ring
-  · ring_nf
-    simp only [I_sq, ofReal_add, ofReal_neg, RingHom.toMonoidHom_eq_coe, OneHom.toFun_eq_coe,
-      MonoidHom.toOneHom_coe, MonoidHom.coe_coe, coe_algebraMap, ZeroHom.coe_mk, ofReal_sub,
-      ofReal_mul, ofReal_pow]
-    ring
+    _ = (s * I * ℏ) • ((2 : ℂ) • 𝐫₀ ε (s-2) ∘L (𝐱 ⬝ᵥ 𝐩) - (d * I * ℏ) • 𝐫₀ ε (s-2)
+        - ((s - 2) * I * ℏ) • 𝐫₀ ε (s-4) ∘L (𝐱 ⬝ᵥ 𝐱)) := by
+      simp [Finset.sum_sub_distrib, ← Finset.smul_sum, ← comp_finset_sum,
+        ← Nat.cast_smul_eq_nsmul ℂ, smul_smul, dotProduct, mul_def, mul_assoc]
+    _ = (2 * s * I * ℏ) • 𝐫₀ ε (s-2) ∘L (𝐱 ⬝ᵥ 𝐩) + (s * (d + s - 2) * ℏ ^ 2) • 𝐫₀ ε (s-2)
+        - (ε ^ 2 * s * (s - 2) * ℏ ^ 2) • 𝐫₀ ε (s-4) := by
+      simp_rw [positionOperatorSqr_eq ε, comp_sub, comp_smul, comp_id, radiusRegPowOperator_comp_eq]
+      simp only [smul_sub, smul_smul, ← Complex.coe_smul, ofReal_mul, ofReal_add, ofReal_sub,
+        ofReal_pow, ofReal_ofNat, ofReal_natCast]
+      ring_nf
+      simp_rw [← sub_add, sub_sub, ← add_smul, I_sq, sub_eq_add_neg, ← neg_smul]
+      ring_nf
 
 /-!
 
@@ -292,17 +283,17 @@ lemma momentum_comp_angularMomentum_eq : 𝐩 k ∘L 𝐋[i,j] =
   rw [comp_eq_comp_sub_commute, angularMomentum_commutation_momentum]
 
 @[simp]
-lemma angularMomentum_commutation_momentumSqr : ⁅𝐋[i,j], momentumOperatorSqr (d := d)⁆ = 0 := by
-  simp only [momentumOperatorSqr, lie_sum, lie_leibniz, angularMomentum_commutation_momentum,
+lemma angularMomentum_commutation_momentumSqr : ⁅𝐋[i,j], 𝐩[d] ⬝ᵥ 𝐩⁆ = 0 := by
+  simp only [dotProduct, mul_def, lie_sum, lie_leibniz, angularMomentum_commutation_momentum,
     comp_smul, comp_sub, smul_comp, sub_comp, ← smul_add, ← Finset.smul_sum, Finset.sum_add_distrib,
     Finset.sum_sub_distrib, sum_smul, sub_add_sub_cancel, sub_self, smul_zero]
 
-lemma momentumSqr_comp_angularMomentum_commute : 𝐩² ∘L 𝐋[i,j] = 𝐋[i,j] ∘L 𝐩² := by
+lemma momentumSqr_comp_angularMomentum_commute : (𝐩 ⬝ᵥ 𝐩) ∘L 𝐋[i,j] = 𝐋[i,j] ∘L (𝐩 ⬝ᵥ 𝐩) := by
   rw [comp_eq_comp_sub_commute, angularMomentum_commutation_momentumSqr, sub_zero]
 
 @[simp]
 lemma angularMomentumSqr_commutation_momentumSqr :
-    ⁅angularMomentumOperatorSqr (d := d), momentumOperatorSqr (d := d)⁆ = 0 := by
+    ⁅angularMomentumOperatorSqr (d := d), 𝐩[d] ⬝ᵥ 𝐩⁆ = 0 := by
   simp [angularMomentumOperatorSqr, sum_lie, leibniz_lie]
 
 /-!

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Commutation.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Commutation.lean
@@ -223,7 +223,7 @@ lemma radiusRegPow_commutation_momentumSqr :
         - ((s - 2) * I * ℏ) • 𝐫₀ ε (s-4) ∘L 𝐱 i ∘L 𝐱 i) := by
       simp [momentum_comp_position_eq, sub_add_eq_add_sub, ← two_smul ℂ]
     _ = (s * I * ℏ) • ((2 : ℂ) • 𝐫₀ ε (s-2) ∘L (𝐱 ⬝ᵥ 𝐩) - (d * I * ℏ) • 𝐫₀ ε (s-2)
-        - ((s - 2) * I * ℏ) • 𝐫₀ ε (s-4) ∘L (𝐱 ⬝ᵥ 𝐱)) := by
+        - ((s - 2) * I * ℏ) • 𝐫₀ ε (s-4) ∘L ∑ i, 𝐱 i ∘L 𝐱 i) := by
       simp [Finset.sum_sub_distrib, ← Finset.smul_sum, ← comp_finset_sum,
         ← Nat.cast_smul_eq_nsmul ℂ, smul_smul, dotProduct, mul_def, mul_assoc]
     _ = (2 * s * I * ℏ) • 𝐫₀ ε (s-2) ∘L (𝐱 ⬝ᵥ 𝐩) + (s * (d + s - 2) * ℏ ^ 2) • 𝐫₀ ε (s-2)

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -23,19 +23,16 @@ In this module we introduce several momentum operators for quantum mechanics on 
 Definitions:
 - `momentumOperator` : (components of) the momentum vector operator acting on Schwartz maps
     `𝓢(Space d, ℂ)` as `-iℏ∂ᵢ`.
-- `momentumOperatorSqr` : operator acting on Schwartz maps `𝓢(Space d, ℂ)` as `∑ᵢ 𝐩[i]∘𝐩[i]`.
 - `momentumUnboundedOperator` : a symmetric unbounded operator acting on the Schwartz submodule
     of the Hilbert space `SpaceDHilbertSpace d`.
 
 Notation:
 - `𝐩` for `momentumOperator`
-- `𝐩²` for `momentumOperatorSqr`
 
 ## iii. Table of contents
 
 - A. Momentum vector operator
-- B. Momentum-squared operator
-- C. Unbounded momentum vector operator
+- B. Unbounded momentum vector operator
 
 ## iv. References
 
@@ -78,30 +75,7 @@ lemma momentumOperator_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) : 𝐩 i ψ
 
 /-!
 
-## B. Momentum-squared operator
-
--/
-
-set_option backward.isDefEq.respectTransparency false in
-/-- The square of the momentum operator, `𝐩² ≔ ∑ᵢ 𝐩ᵢ∘𝐩ᵢ`. -/
-def momentumOperatorSqr : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) := ∑ i, 𝐩 i ∘L 𝐩 i
-
-@[inherit_doc momentumOperatorSqr]
-notation "𝐩²" => momentumOperatorSqr
-
-set_option backward.isDefEq.respectTransparency false in
-lemma momentumOperatorSqr_eq : 𝐩² = ∑ i : Fin d, 𝐩 i ∘L 𝐩 i := rfl
-
-lemma momentumOperatorSqr_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
-    𝐩² ψ x = ∑ i, 𝐩 i (𝐩 i ψ) x := by
-  dsimp only [momentumOperatorSqr]
-  rw [← SchwartzMap.coe_coeHom]
-  simp only [ContinuousLinearMap.coe_sum', ContinuousLinearMap.coe_comp', Finset.sum_apply,
-    Function.comp_apply, map_sum]
-
-/-!
-
-## C. Unbounded momentum vector operator
+## B. Unbounded momentum vector operator
 
 -/
 


### PR DESCRIPTION
Follow-up to #1031.
Removes auxiliary operators (`momentumOperatorSqr`, `positionDotMomentum`, etc.) and replaces with `dotProduct` equivalents in lemmas.