### PR TITLE
refactor: Tensor components

### DIFF
--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -1054,8 +1054,7 @@ lemma gradKineticTerm_eq_tensorDeriv {d} {𝓕 : FreeSpace}
     funext j
     fin_cases j
     simp only [Fin.zero_eta, Matrix.cons_val_zero, Fin.cast_eq_self,
-      ComponentIdx.prodEquiv, ComponentIdx.prodIndexEquiv, Equiv.piCongr_symm_apply,
-      Sum.elim_inl, finCongr_symm, finCongr_apply, Sum.elim_inr, Equiv.coe_fn_mk]
+      ComponentIdx.prod, Equiv.coe_fn_mk]
     simp only [ComponentIdx.DropPairSection.ofFinEquiv, Equiv.coe_fn_mk,
       ComponentIdx.DropPairSection.ofFin, Fin.cast_eq_self, Function.comp_apply, left_eq_dite_iff]
     intro h
@@ -1065,7 +1064,7 @@ lemma gradKineticTerm_eq_tensorDeriv {d} {𝓕 : FreeSpace}
   congr
   · apply finSumFinEquiv.injective
     simp only [Function.comp_apply, Fin.cast_eq_self, Equiv.apply_symm_apply]
-    simp [ComponentIdx.prodEquiv, ComponentIdx.prodIndexEquiv]
+    simp [ComponentIdx.prod]
     simp [ComponentIdx.DropPairSection.ofFinEquiv, ComponentIdx.DropPairSection.ofFin]
     intro _ h
     apply False.elim
@@ -1073,7 +1072,7 @@ lemma gradKineticTerm_eq_tensorDeriv {d} {𝓕 : FreeSpace}
     decide
   · apply finSumFinEquiv.injective
     simp only [Function.comp_apply, Fin.cast_eq_self, Equiv.apply_symm_apply]
-    simp [ComponentIdx.prodEquiv, ComponentIdx.prodIndexEquiv]
+    simp [ComponentIdx.prod]
     simp [ComponentIdx.DropPairSection.ofFinEquiv, ComponentIdx.DropPairSection.ofFin]
     split_ifs
     · rename_i h
@@ -1269,7 +1268,7 @@ lemma gradKineticTerm_eq_distTensorDeriv {d} {𝓕 : FreeSpace}
     rw [hb]
     rw [Module.Basis.repr_reindex_apply]
     congr 1
-    simp [ComponentIdx.prodEquiv,ComponentIdx.prodIndexEquiv, Vector.indexEquiv]
+    simp [ComponentIdx.prod, Vector.indexEquiv]
     apply And.intro
     · rw [@Equiv.eq_symm_apply]
       rfl
@@ -1283,7 +1282,7 @@ lemma gradKineticTerm_eq_distTensorDeriv {d} {𝓕 : FreeSpace}
     simp [Lorentz.CoVector.indexEquiv]
     funext j
     fin_cases j
-    simp [ComponentIdx.prodEquiv, ComponentIdx.prodIndexEquiv]
+    simp [ComponentIdx.prod]
     simp [ComponentIdx.DropPairSection.ofFinEquiv, ComponentIdx.DropPairSection.ofFin]
     intro h
     change ¬ 0 = 0 at h
@@ -1291,14 +1290,14 @@ lemma gradKineticTerm_eq_distTensorDeriv {d} {𝓕 : FreeSpace}
   funext x
   fin_cases x
   · simp only [Function.comp_apply, Fin.cast_eq_self]
-    simp [ComponentIdx.prodEquiv, ComponentIdx.prodIndexEquiv]
+    simp [ComponentIdx.prod]
     simp [ComponentIdx.DropPairSection.ofFinEquiv, ComponentIdx.DropPairSection.ofFin]
     intro _ h
     apply False.elim
     apply h
     decide
   · simp only [Function.comp_apply, Fin.cast_eq_self]
-    simp [ComponentIdx.prodEquiv, ComponentIdx.prodIndexEquiv]
+    simp [ComponentIdx.prod]
     simp [ComponentIdx.DropPairSection.ofFinEquiv, ComponentIdx.DropPairSection.ofFin]
     split_ifs
     · rename_i h

--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -306,7 +306,7 @@ lemma deriv_eq_tensorDeriv {d} (A : ElectromagneticPotential d)
   rw [deriv, tensorDeriv_eq_sum_tensor_basis (by fun_prop)]
   /- Match the basis sum. -/
   let e :  ComponentIdx (Fin.append ![Color.down] ![Color.up])
-      ≃ (Fin 1 ⊕ Fin d) × (Fin 1 ⊕ Fin d) := ComponentIdx.prodEquiv.trans <|
+      ≃ (Fin 1 ⊕ Fin d) × (Fin 1 ⊕ Fin d) := ComponentIdx.prod.trans <|
     Lorentz.CoVector.indexEquiv.prodCongr Lorentz.Vector.indexEquiv
   rw [← e.symm.sum_comp, Fintype.sum_prod_type]
   /- Getting rid of the sums -/

--- a/Physlib/Relativity/Tensors/ComplexTensor/OfRat.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/OfRat.lean
@@ -111,8 +111,8 @@ lemma prodT_ofRat_ofRat {n n1 : ℕ} {c : Fin n → complexLorentzTensor.Color}
     {c1 : Fin n1 → complexLorentzTensor.Color}
     (f1 : (ComponentIdx c1) → RatComplexNum) :
     (prodT (ofRat f) (ofRat f1)) =
-    ((ofRat (fun b => f (ComponentIdx.prodEquiv b).1 *
-      f1 (ComponentIdx.prodEquiv b).2))) := by
+    ((ofRat (fun b => f (ComponentIdx.prod b).1 *
+      f1 (ComponentIdx.prod b).2))) := by
   apply (Tensor.basis _).repr.injective
   ext b
   rw [prodT_basis_repr_apply]

--- a/Physlib/Relativity/Tensors/Product.lean
+++ b/Physlib/Relativity/Tensors/Product.lean
@@ -35,9 +35,7 @@ The following results exist for both `prodP` and `prodT` :
 ## iii. Table of contents
 
 - A. Products of index components
-  - A.1. Indexing components by `Fin n1 ⊕ Fin n2` rather than `Fin (n1 + n2)`
-  - A.2. The product of two index components
-  - A.3. The product of component indices as an equivalence
+  - A.1. The product of component indices as an equivalence
 - B. Products of pure tensors
   - B.1. Indexing pure tensors by `Fin n1 ⊕ Fin n2` rather than `Fin (n1 + n2)`
   - B.2. The product of two pure tensors
@@ -95,82 +93,24 @@ variable {k C G : Type} [CommRing k] [Group G]
 
 /-!
 
-### A.1. Indexing components by `Fin n1 ⊕ Fin n2` rather than `Fin (n1 + n2)`
-
--/
-
-/-- The equivalence between `ComponentIdx (Fin.append c c1)` and
-  `Π (i : Fin n1 ⊕ Fin n2), Fin (S.repDim (Sum.elim c c1 i))`. -/
-def ComponentIdx.prodIndexEquiv {n1 n2 : ℕ} {c : Fin n1 → C} {c1 : Fin n2 → C} :
-    ComponentIdx (S := S) (Fin.append c c1) ≃
-    Π (i : Fin n1 ⊕ Fin n2), Fin (S.repDim (Sum.elim c c1 i)) :=
-  (Equiv.piCongr finSumFinEquiv (fun x => finCongr (by cases x <;> simp))).symm
-
-/-!
-
-### A.2. The product of two index components
-
--/
-/-- The product of two component indices. -/
-def ComponentIdx.prod {n1 n2 : ℕ} {c : Fin n1 → C} {c1 : Fin n2 → C}
-    (b : ComponentIdx (S := S) c) (b1 : ComponentIdx (S := S) c1) :
-    ComponentIdx (S := S) (Fin.append c c1) :=
-  ComponentIdx.prodIndexEquiv.symm fun | Sum.inl i => b i | Sum.inr i => b1 i
-
-lemma ComponentIdx.prod_apply_finSumFinEquiv {n1 n2 : ℕ} {c : Fin n1 → C} {c1 : Fin n2 → C}
-    (b : ComponentIdx c) (b1 : ComponentIdx (S := S) c1) (i : Fin n1 ⊕ Fin n2) :
-    ComponentIdx.prod b b1 (finSumFinEquiv i) =
-    match i with
-    | Sum.inl i => Fin.cast (by simp) (b i)
-    | Sum.inr i => Fin.cast (by simp) (b1 i) := by
-  rw [ComponentIdx.prod]
-  rw [ComponentIdx.prodIndexEquiv]
-  simp only [Equiv.symm_symm]
-  rw [Equiv.piCongr_apply_apply]
-  match i with
-  | Sum.inl i =>
-    rfl
-  | Sum.inr i =>
-    rfl
-
-/-!
-
-### A.3. The product of component indices as an equivalence
+### A.1 The product of component indices as an equivalence
 
 -/
 
 /-- The equivalence between `ComponentIdx (Fin.append c c1)` and
   `ComponentIdx c × ComponentIdx c1` formed by products. -/
-def ComponentIdx.prodEquiv {n1 n2 : ℕ} {c : Fin n1 → C} {c1 : Fin n2 → C} :
+def ComponentIdx.prod {n1 n2 : ℕ} {c : Fin n1 → C} {c1 : Fin n2 → C} :
     ComponentIdx (S := S) (Fin.append c c1) ≃
       ComponentIdx (S := S) c × ComponentIdx (S := S) c1 where
-  toFun p := (fun i => (ComponentIdx.prodIndexEquiv p) (Sum.inl i),
-    fun i => (ComponentIdx.prodIndexEquiv p) (Sum.inr i))
-  invFun p := ComponentIdx.prod (p.1) (p.2)
+  toFun p := (fun i => Fin.cast (by simp) (p (Fin.castAdd n2 i)),
+    fun i => Fin.cast (by simp) (p (Fin.natAdd n1 i)))
+  invFun p := Fin.addCases (fun i => Fin.cast (by simp) (p.1 i))
+    (fun i => Fin.cast (by simp) (p.2 i))
   left_inv p := by
-    simp only
-    funext i
-    obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
-    rw [prod_apply_finSumFinEquiv]
-    match i with
-    | Sum.inl i =>
-      rfl
-    | Sum.inr i =>
-      rfl
-  right_inv p := by
-    ext i
-    simp only
-    · rw [ComponentIdx.prodIndexEquiv]
-      rw [Equiv.piCongr_symm_apply]
-      simp only [Sum.elim_inl, finCongr_symm]
-      rw [prod_apply_finSumFinEquiv]
-      rfl
-    · rw [ComponentIdx.prodIndexEquiv]
-      simp only
-      erw [Equiv.piCongr_symm_apply]
-      simp only [Sum.elim_inr, finCongr_symm]
-      rw [prod_apply_finSumFinEquiv]
-      rfl
+    ext1 i
+    revert i
+    simp [Fin.forall_fin_add]
+  right_inv p := by simp
 
 /-!
 
@@ -259,7 +199,7 @@ lemma Pure.prodP_apply_natAdd {n1 n2} {c : Fin n1 → C} {c1 : Fin n2 → C}
 lemma Pure.prodP_basisVector {n n1 : ℕ} {c : Fin n → C} {c1 : Fin n1 → C}
     (b : ComponentIdx c) (b1 : ComponentIdx (S := S) c1) :
     Pure.prodP (Pure.basisVector c b) (Pure.basisVector c1 b1) =
-    Pure.basisVector _ (b.prod b1) := by
+    Pure.basisVector _ (ComponentIdx.prod.symm (b, b1)) := by
   ext i
   obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
   rw [Pure.prodP_apply_finSumFinEquiv]
@@ -273,12 +213,12 @@ lemma Pure.prodP_basisVector {n n1 : ℕ} {c : Fin n → C} {c1 : Fin n1 → C}
   | Sum.inl i =>
     simp only [basisVector]
     apply basis_congr
-    · rw [ComponentIdx.prod_apply_finSumFinEquiv]
+    · simp [ComponentIdx.prod]
     · simp
   | Sum.inr i =>
     simp only [basisVector]
     apply basis_congr
-    · rw [ComponentIdx.prod_apply_finSumFinEquiv]
+    · simp [ComponentIdx.prod]
     · simp
 
 /-!
@@ -290,8 +230,8 @@ lemma Pure.prodP_basisVector {n n1 : ℕ} {c : Fin n → C} {c1 : Fin n1 → C}
 lemma Pure.prodP_component {n m : ℕ} {c : Fin n → C} {c1 : Fin m → C}
     (p : Pure S c) (p1 : Pure S c1)
     (b : ComponentIdx (Fin.append c c1)) :
-    (p.prodP p1).component b = p.component (ComponentIdx.prodEquiv b).1 *
-    p1.component (ComponentIdx.prodEquiv b).2 := by
+    (p.prodP p1).component b = p.component (ComponentIdx.prod b).1 *
+    p1.component (ComponentIdx.prod b).2 := by
   simp only [component]
   rw [← finSumFinEquiv.prod_comp]
   conv_lhs =>
@@ -728,7 +668,7 @@ open TensorProduct
 lemma prodT_basis {n1 n2} {c : Fin n1 → C} {c1 : Fin n2 → C}
     (b : ComponentIdx c) (b1 : ComponentIdx (S := S) c1) :
     (basis c b).prodT (basis c1 b1) =
-    (Pure.basisVector _ (b.prod b1)).toTensor := by
+    (Pure.basisVector _ (ComponentIdx.prod.symm (b, b1))).toTensor := by
   rw [basis_apply, basis_apply, prodT_pure]
   congr
   rw [Pure.prodP_basisVector]
@@ -746,14 +686,14 @@ noncomputable def tensorEquivProd {n n2 : ℕ} {c : Fin n → C} {c1 : Fin n2 �
     S.Tensor c ⊗[k] S.Tensor c1 ≃ₗ[k] S.Tensor (Fin.append c c1) where
   toLinearMap := TensorProduct.lift prodT
   invFun := (Tensor.basis (Fin.append c c1)).constr k (fun b =>
-    (Tensor.basis c) (ComponentIdx.prodEquiv b).1 ⊗ₜ[k]
-    (Tensor.basis c1) (ComponentIdx.prodEquiv b).2)
+    (Tensor.basis c) (ComponentIdx.prod b).1 ⊗ₜ[k]
+    (Tensor.basis c1) (ComponentIdx.prod b).2)
   left_inv x := by
     let f : S.Tensor (Fin.append c c1) →ₗ[k]
       S.Tensor c ⊗[k] S.Tensor c1 :=
       (Tensor.basis (Fin.append c c1)).constr k (fun b =>
-        (Tensor.basis c) (ComponentIdx.prodEquiv b).1 ⊗ₜ[k]
-        (Tensor.basis c1) (ComponentIdx.prodEquiv b).2)
+        (Tensor.basis c) (ComponentIdx.prod b).1 ⊗ₜ[k]
+        (Tensor.basis c1) (ComponentIdx.prod b).2)
     let P (x : S.Tensor c ⊗[k] S.Tensor c1) := f (TensorProduct.lift prodT x) = x
     change P x
     apply TensorProduct.induction_on
@@ -766,11 +706,6 @@ noncomputable def tensorEquivProd {n n2 : ℕ} {c : Fin n → C} {c1 : Fin n2 �
           dsimp [P]
           rw [prodT_basis]
           simp [f]
-          congr
-          · change (ComponentIdx.prodEquiv (ComponentIdx.prodEquiv.symm (b1, b2))).1 = _
-            simp
-          · change (ComponentIdx.prodEquiv (ComponentIdx.prodEquiv.symm (b1, b2))).2 = _
-            simp
           · simp [P]
           · intro r t h
             simp [tmul_smul, P] at *
@@ -792,8 +727,8 @@ noncomputable def tensorEquivProd {n n2 : ℕ} {c : Fin n → C} {c1 : Fin n2 �
     let f : S.Tensor (Fin.append c c1) →ₗ[k]
       S.Tensor c ⊗[k] S.Tensor c1 :=
       (Tensor.basis (Fin.append c c1)).constr k (fun b =>
-        (Tensor.basis c) (ComponentIdx.prodEquiv b).1 ⊗ₜ[k]
-        (Tensor.basis c1) (ComponentIdx.prodEquiv b).2)
+        (Tensor.basis c) (ComponentIdx.prod b).1 ⊗ₜ[k]
+        (Tensor.basis c1) (ComponentIdx.prod b).2)
     let P (x : _) := (TensorProduct.lift prodT (f x)) = x
     change P x
     apply induction_on_basis (t := x)
@@ -803,7 +738,7 @@ noncomputable def tensorEquivProd {n n2 : ℕ} {c : Fin n → C} {c1 : Fin n2 �
       rw [prodT_basis]
       rw [basis_apply]
       congr
-      change (ComponentIdx.prodEquiv.symm (ComponentIdx.prodEquiv b)) = _
+      change (ComponentIdx.prod.symm (ComponentIdx.prod b)) = _
       simp
     · simp [P]
     · intro r t h
@@ -824,25 +759,25 @@ set_option backward.isDefEq.respectTransparency false in
 lemma basis_prod_eq {n1 n2} {c : Fin n1 → C} {c1 : Fin n2 → C} :
     basis (S := S) (Fin.append c c1) =
     (((Tensor.basis (S := S) c).tensorProduct (Tensor.basis (S := S) c1)).reindex
-    (ComponentIdx.prodEquiv.symm)).map tensorEquivProd := by
+    (ComponentIdx.prod.symm)).map tensorEquivProd := by
   ext b
-  simp [ComponentIdx.prodEquiv, tensorEquivProd]
+  simp [ComponentIdx.prod, tensorEquivProd]
   rw [prodT_basis]
   rw [← basis_apply]
   congr
   funext i
   obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
-  rw [ComponentIdx.prod_apply_finSumFinEquiv]
+  rw [ComponentIdx.prod]
   match i with
-  | Sum.inl i => rfl
-  | Sum.inr i => rfl
+  | Sum.inl i => simp
+  | Sum.inr i => simp
 
 lemma prodT_basis_repr_apply {n m : ℕ} {c : Fin n → C} {c1 : Fin m → C}
     (t : Tensor S c) (t1 : Tensor S c1)
     (b : ComponentIdx (Fin.append c c1)) :
     (basis (Fin.append c c1)).repr (prodT t t1) b =
-    (basis c).repr t (ComponentIdx.prodEquiv b).1 *
-    (basis c1).repr t1 (ComponentIdx.prodEquiv b).2 := by
+    (basis c).repr t (ComponentIdx.prod b).1 *
+    (basis c1).repr t1 (ComponentIdx.prod b).2 := by
   apply induction_on_pure (t := t)
   · apply induction_on_pure (t := t1)
     · intro p p1

--- a/Physlib/Relativity/Tensors/RealTensor/Derivative.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Derivative.lean
@@ -44,9 +44,9 @@ noncomputable def derivative {d n m : ℕ} {cm : Fin m → realLorentzTensor.Col
   /- evaluated at the point `y` in `ℝT(d, cm)` -/
     (Finsupp.equivFunOnFinite ((basis cm).repr y))
   /- In the direction of `(splitEquiv b).1` -/
-    (Finsupp.single (fun i => Fin.cast (by simp) ((ComponentIdx.prodEquiv b).1 i)) (1 : ℝ))
+    (Finsupp.single (fun i => Fin.cast (by simp) ((ComponentIdx.prod b).1 i)) (1 : ℝ))
   /- The `(splitEquiv b).2` component of that derivative. -/
-    (ComponentIdx.prodEquiv b).2
+    (ComponentIdx.prod b).2
 
 @[inherit_doc realLorentzTensor.derivative]
 scoped[realLorentzTensor] notation "∂" => realLorentzTensor.derivative
@@ -59,9 +59,9 @@ lemma derivative_repr {d n m : ℕ} {cm : Fin m → realLorentzTensor.Color}
     (h1 : DifferentiableAt ℝ (mapToBasis f)
       (Finsupp.equivFunOnFinite ((basis cm).repr y))) :
     (Tensor.basis _).repr (∂ f y) b =
-    fderiv ℝ (fun y => mapToBasis f y (ComponentIdx.prodEquiv b).2)
+    fderiv ℝ (fun y => mapToBasis f y (ComponentIdx.prod b).2)
       ((basis cm).repr y)
-      (Finsupp.single (fun i => Fin.cast (by simp) ((ComponentIdx.prodEquiv b).1 i)) (1 : ℝ)) := by
+      (Finsupp.single (fun i => Fin.cast (by simp) ((ComponentIdx.prod b).1 i)) (1 : ℝ)) := by
   simp [derivative]
   rw [fderiv_pi]
   · simp

--- a/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
@@ -667,42 +667,20 @@ lemma complexify_prod {n m : ℕ}
     {c : Fin n → realLorentzTensor.Color} {c1 : Fin m → realLorentzTensor.Color}
     (b : ComponentIdx (S := realLorentzTensor) c)
     (b1 : ComponentIdx (S := realLorentzTensor) c1) :
-    ComponentIdx.complexify (c := Fin.append c c1) (b.prod b1)
+    ComponentIdx.complexify (c := Fin.append c c1) (ComponentIdx.prod.symm (b, b1))
       =
     cast (congr_arg ComponentIdx (colorToComplex_append c c1).symm)
-      ((ComponentIdx.complexify (c := c) b).prod (ComponentIdx.complexify (c := c1) b1)) := by
+      (ComponentIdx.prod.symm (ComponentIdx.complexify (c := c) b,
+        ComponentIdx.complexify (c := c1) b1)) := by
   ext x
   obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective x
   cases i with
   | inl i =>
-    rw [ComponentIdx.complexify_apply, ComponentIdx.prod_apply_finSumFinEquiv b b1 (Sum.inl i)]
-    have cast_apply_rhs : (cast (congr_arg ComponentIdx (colorToComplex_append c c1).symm)
-        ((ComponentIdx.complexify b).prod (ComponentIdx.complexify b1)))
-          (finSumFinEquiv (Sum.inl i)) =
-          Fin.cast (congr_arg (fun c =>
-            complexLorentzTensor.repDim (c (finSumFinEquiv (Sum.inl i))))
-              (colorToComplex_append c c1).symm)
-            (((ComponentIdx.complexify b).prod (ComponentIdx.complexify b1))
-              (finSumFinEquiv (Sum.inl i))) :=
-      cast_componentIdx_apply (colorToComplex_append c c1).symm _ _
-    rw [cast_apply_rhs,
-      ComponentIdx.prod_apply_finSumFinEquiv (ComponentIdx.complexify b)
-        (ComponentIdx.complexify b1) (Sum.inl i)]
-    congr 1
+    rw [ComponentIdx.complexify_apply]
+    simp [ComponentIdx.prod]
   | inr j =>
-    rw [ComponentIdx.complexify_apply, ComponentIdx.prod_apply_finSumFinEquiv b b1 (Sum.inr j)]
-    have cast_apply_rhs : (cast (congr_arg ComponentIdx (colorToComplex_append c c1).symm)
-        ((ComponentIdx.complexify b).prod (ComponentIdx.complexify b1)))
-          (finSumFinEquiv (Sum.inr j)) =
-        Fin.cast (congr_arg (fun c => complexLorentzTensor.repDim
-          (c (finSumFinEquiv (Sum.inr j)))) (colorToComplex_append c c1).symm)
-          (((ComponentIdx.complexify b).prod (ComponentIdx.complexify b1))
-          (finSumFinEquiv (Sum.inr j))) :=
-      cast_componentIdx_apply (colorToComplex_append c c1).symm _ _
-    rw [cast_apply_rhs,
-      ComponentIdx.prod_apply_finSumFinEquiv (ComponentIdx.complexify b)
-        (ComponentIdx.complexify b1) (Sum.inr j)]
-    congr 1
+    rw [ComponentIdx.complexify_apply]
+    simp [ComponentIdx.prod]
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The map `toComplex` commutes with prodT. -/

--- a/Physlib/Relativity/Tensors/Tensorial.lean
+++ b/Physlib/Relativity/Tensors/Tensorial.lean
@@ -263,7 +263,7 @@ lemma smul_prod {n2 : ℕ} {c2 : Fin n2 → C} {M₂ : Type}
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
+open Tensor in
 lemma basis_map_prod {n2 : ℕ} {c2 : Fin n2 → C} {M₂ : Type}
     [Tensorial S c M] [AddCommMonoid M₂] [Module k M₂]
     [Tensorial S c2 M₂] :
@@ -271,10 +271,10 @@ lemma basis_map_prod {n2 : ℕ} {c2 : Fin n2 → C} {M₂ : Type}
       (toTensor (M := (M ⊗[k] M₂))).symm =
     (((Tensor.basis (S := S) c).map (toTensor (M := M)).symm).tensorProduct
     ((Tensor.basis (S := S) c2).map (toTensor (M := M₂)).symm)).reindex
-    (Tensor.ComponentIdx.prodEquiv.symm) := by
+    (ComponentIdx.prod.symm) := by
   rw [Tensor.basis_prod_eq]
   ext b
-  simp only [Tensor.ComponentIdx.prodEquiv, Module.Basis.map_apply, Module.Basis.coe_reindex,
+  simp only [ComponentIdx.prod, Module.Basis.map_apply, Module.Basis.coe_reindex,
     Equiv.symm_symm, Equiv.coe_fn_mk, Function.comp_apply, Module.Basis.tensorProduct_apply]
   apply toTensor.injective
   simp only [LinearEquiv.apply_symm_apply]

--- a/Physlib/SpaceAndTime/SpaceTime/Derivatives.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Derivatives.lean
@@ -436,24 +436,25 @@ lemma tensorDeriv_equivariant (f : SpaceTime d → M) (Λ : LorentzGroup d) (x :
   simp only [Nat.succ_eq_add_one, Nat.reduceAdd, map_sum]
   simp [TensorSpecies.Tensorial.smulLinearMap_apply]
 
-set_option backward.isDefEq.respectTransparency false in
+open TensorSpecies.Tensorial Lorentz Tensor
+
 lemma tensorDeriv_toTensor_basis_repr
     {f : SpaceTime d → M}
     (hf : Differentiable ℝ f) (x : SpaceTime d)
     (b : Tensor.ComponentIdx (Fin.append ![realLorentzTensor.Color.down] c)) :
     (Tensor.basis _).repr (Tensorial.toTensor (tensorDeriv f x)) b =
-    ∂_ (Lorentz.CoVector.indexEquiv (Tensor.ComponentIdx.prodEquiv b).1)
+    ∂_ (Lorentz.CoVector.indexEquiv (ComponentIdx.prod b).1)
       (fun x => (Tensor.basis _).repr (Tensorial.toTensor (f x))
-        (Tensor.ComponentIdx.prodEquiv b).2) x := by
+        (ComponentIdx.prod b).2) x := by
   simp [tensorDeriv]
   conv_lhs =>
     enter [2, μ]
     rw [Tensorial.toTensor_tprod, Tensor.prodT_basis_repr_apply]
     simp [Lorentz.CoVector.toTensor_basis_eq_tensor_basis, Finsupp.single_apply]
-  rw [Finset.sum_eq_single (Lorentz.CoVector.indexEquiv (Tensor.ComponentIdx.prodEquiv b).1)]
+  rw [Finset.sum_eq_single (Lorentz.CoVector.indexEquiv (ComponentIdx.prod b).1)]
   · simp
-    generalize (Lorentz.CoVector.indexEquiv (Tensor.ComponentIdx.prodEquiv b).1) = μ at *
-    generalize (Tensor.ComponentIdx.prodEquiv b).2 = ν at *
+    generalize (Lorentz.CoVector.indexEquiv (ComponentIdx.prod b).1) = μ at *
+    generalize (ComponentIdx.prod b).2 = ν at *
     have h1 (x : SpaceTime d) : ((Tensor.basis c).repr (Tensorial.toTensor (f x))) ν =
         (ContinuousLinearMap.proj ν ∘L ((Tensor.basis c).map
         (Tensorial.toTensor).symm).equivFunL.toContinuousLinearMap) (f x) := by
@@ -472,12 +473,11 @@ lemma tensorDeriv_toTensor_basis_repr
     grind
   · simp
 
-open TensorSpecies.Tensorial Lorentz Tensor
 /-- The expansion of `tensorDeriv` in terms of the tensor basis vector. -/
 lemma tensorDeriv_eq_sum_tensor_basis
     {f : SpaceTime d → M} (hf : Differentiable ℝ f) (x : SpaceTime d) :
-    tensorDeriv f x = ∑ b, ∂_ (CoVector.indexEquiv (ComponentIdx.prodEquiv b).1)
-      (fun x => (Tensor.basis _).repr (toTensor (f x)) (ComponentIdx.prodEquiv b).2) x •
+    tensorDeriv f x = ∑ b, ∂_ (CoVector.indexEquiv (ComponentIdx.prod b).1)
+      (fun x => (Tensor.basis _).repr (toTensor (f x)) (ComponentIdx.prod b).2) x •
     toTensor.symm (Tensor.basis _ b) := by
   apply Tensorial.toTensor.injective
   apply (Tensor.basis (Fin.append _ _)).repr.injective
@@ -561,14 +561,14 @@ lemma distTensorDeriv_toTensor_basis_repr {M : Type} [NormedAddCommGroup M]
     (b : Tensor.ComponentIdx (Fin.append ![realLorentzTensor.Color.down] c)) :
     (Tensor.basis _).repr (Tensorial.toTensor (distTensorDeriv f ε)) b =
     (Tensor.basis _).repr (Tensorial.toTensor
-    (distDeriv (Lorentz.CoVector.indexEquiv (Tensor.ComponentIdx.prodEquiv b).1) f ε))
-    (Tensor.ComponentIdx.prodEquiv b).2 := by
+    (distDeriv (Lorentz.CoVector.indexEquiv (ComponentIdx.prod b).1) f ε))
+    (ComponentIdx.prod b).2 := by
   simp [distTensorDeriv]
   conv_lhs =>
     enter [2, μ]
     rw [Tensorial.toTensor_tprod, Tensor.prodT_basis_repr_apply]
     simp [Lorentz.CoVector.toTensor_basis_eq_tensor_basis, Finsupp.single_apply]
-  rw [Finset.sum_eq_single (Lorentz.CoVector.indexEquiv (Tensor.ComponentIdx.prodEquiv b).1)]
+  rw [Finset.sum_eq_single (Lorentz.CoVector.indexEquiv (ComponentIdx.prod b).1)]
   · simp
   · intro b' _ hb
     simp only [ite_eq_right_iff]


### PR DESCRIPTION
I got rid of some unneeded definitions related to the product of tensor components, and simplified an existing definition. Ends up in shorter cleaner proofs. 