### PR TITLE
refactor(QuantumInfo): Some Line lengths

### DIFF
--- a/QuantumInfo/ClassicalInfo/Capacity.lean
+++ b/QuantumInfo/ClassicalInfo/Capacity.lean
@@ -22,7 +22,8 @@ variable (A I O : Type*)
  strings (`List`s) of any length over an alphabet `A`, and returns strings over `I`;
  the decoder takes `O` and gives back strings over `A`. The idea is that a channel
  would map from strings of `I` to `O`. Important special cases are where `I=O` (the channel doesn't
- change the symbol set), and `FixedLengthCode` where the output lengths only depend on input lengths. -/
+ change the symbol set), and `FixedLengthCode` where the output lengths only depend on input
+ lengths. -/
 structure Code where
   encoder : List A → List I
   decoder : List O → List A
@@ -38,8 +39,8 @@ structure FixedLengthCode extends Code A I O where
 /-- A `BlockCode` is a `FixedLengthCode` that (1) maps symbols in discrete blocks of fixed length,
  (2) the encoded alphabet `I` has a canonical injection into `O`, and (3) has encoder and decoders
  that are inverses of each other. This is well-suited to describing noise and erasure channels. If
- the channel merely "corrupts" the data then this `O = I`; the erasure channel might for instance take
- `O = I ⊕ Unit` or `Option I`.
+ the channel merely "corrupts" the data then this `O = I`; the erasure channel might for instance
+ take `O = I ⊕ Unit` or `Option I`.
 
  We define the behavior of a block code to "fail" if the input is not a multiple of the block size,
  by having it return an empty list. -/

--- a/QuantumInfo/ClassicalInfo/Channel.lean
+++ b/QuantumInfo/ClassicalInfo/Channel.lean
@@ -60,7 +60,8 @@ namespace DMChannel
 /-- Apply a discrete memoryless channel to an n-character string. -/
 def on_fin (C : DMChannel I O) {n : ℕ} (is : Fin n → I) : ProbDistribution (Fin n → O) :=
   ⟨fun os ↦ ∏ k, C.symb_dist (is k) (os k), by
-    -- change ∑ os in Fintype.piFinset fun x => (Finset.univ : Finset O), ∏ k : Fin n, ((C.symb_dist (is k)) (os k) : ℝ) = 1
+    -- change ∑ os in Fintype.piFinset fun x => (Finset.univ : Finset O),
+    --  ∏ k : Fin n, ((C.symb_dist (is k)) (os k) : ℝ) = 1
     -- have : ∀i, Finset.sum Finset.univ (C.symb_dist i) = 1 :=
     --   fun i ↦ Distribution.prop <| C.symb_dist i
     -- rw [Finset.sum_prod_piFinset]

--- a/QuantumInfo/ClassicalInfo/Distribution.lean
+++ b/QuantumInfo/ClassicalInfo/Distribution.lean
@@ -11,8 +11,10 @@ public import Mathlib.Analysis.Convex.Combination
 
 /-! # Distributions on finite sets
 
-We define the type `Distribution α` on a `Fintype α`. By restricting ourselves to distributoins on finite types,
-a lot of notation and casts are greatly simplified. This suffices for (most) finite-dimensional quantum theory.
+We define the type `Distribution α` on a `Fintype α`. By restricting ourselves to distributoins on
+finite types, a lot of notation and casts are greatly simplified.
+This suffices for (most) finite-dimensional quantum theory.
+
 -/
 
 @[expose] public section
@@ -101,7 +103,8 @@ theorem constant_def' (x y : α) : (constant x : α → Prob) y = if x = y then 
   <;> simp [h]
 
 /-- If a distribution has an element with probability 1, the distribution has a constant. -/
-theorem constant_of_exists_one {D : ProbDistribution α} {x : α} (h : D x = 1) : D = ProbDistribution.constant x := by
+theorem constant_of_exists_one {D : ProbDistribution α} {x : α} (h : D x = 1) :
+    D = ProbDistribution.constant x := by
   ext y
   by_cases h₂ : x = y
   · simp [h, ← h₂]
@@ -136,11 +139,13 @@ def prod (d1 : ProbDistribution α) (d2 : ProbDistribution β) : ProbDistributio
 theorem prod_def (x : α) (y : β) : prod d1 d2 ⟨x, y⟩ = (d1 x) * (d2 y) :=
   rfl
 
-/-- Given a distribution on α, extend it to a distribution on `Sum α β` by giving it no support on `β`. -/
+/-- Given a distribution on α, extend it to a distribution on `Sum α β` by
+  giving it no support on `β`. -/
 def extend_right (d : ProbDistribution α) : ProbDistribution (α ⊕ β) :=
   ⟨fun x ↦ Sum.casesOn x d.val (Function.const _ 0), by simp⟩
 
-/-- Given a distribution on α, extend it to a distribution on `Sum β α` by giving it no support on `β`. -/
+/-- Given a distribution on α, extend it to a distribution on `Sum β α` by
+  giving it no support on `β`. -/
 def extend_left (d : ProbDistribution α) : ProbDistribution (β ⊕ α) :=
   ⟨fun x ↦ Sum.casesOn x (Function.const _ 0) d.val, by simp⟩
 
@@ -157,7 +162,8 @@ def relabel (d : ProbDistribution α) (σ : β ≃ α) : ProbDistribution β :=
   ⟨fun b ↦ d (σ b),
    by rw [Equiv.sum_comp σ (fun a ↦ (d a : ℝ))]; exact d.prop⟩
 
--- The two properties below (and congrRandVar) follow from the fact that Distribution is a contravariant functor.
+-- The two properties below (and congrRandVar) follow from the fact that Distribution is a
+-- contravariant functor.
 -- However, mathlib does not seem to support that outside of the CategoryTheory namespace
 /-- ProbDistribution on α and β are equivalent for equivalent types α ≃ β. -/
 def congr (σ : α ≃ β) : ProbDistribution α ≃ ProbDistribution β := by
@@ -181,10 +187,12 @@ theorem congr_apply (σ : α ≃ β) (d : ProbDistribution α) (j : β): (congr 
 
 /-- The inverse and congruence operations for distributions commute -/
 @[simp]
-theorem congr_symm_apply (σ : α ≃ β) : (ProbDistribution.congr σ).symm = ProbDistribution.congr σ.symm := by
+theorem congr_symm_apply (σ : α ≃ β) :
+    (ProbDistribution.congr σ).symm = ProbDistribution.congr σ.symm := by
   rfl
 
-/-- The distribution on Fin 2 corresponding to a coin with probability p. Chance p of 1, 1-p of 0. -/
+/-- The distribution on Fin 2 corresponding to a coin with probability p.
+  Chance p of 1, 1-p of 0. -/
 def coin (p : Prob) : ProbDistribution (Fin 2) :=
   ⟨(if · = 0 then p else 1 - p), by simp⟩
 
@@ -233,24 +241,27 @@ instance instLawfulFunctor : LawfulFunctor (RandVar α) where
 variable {T U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T]
 
 /-- `Distribution.exp_val` is the expectation value of a random variable `X`. Under the hood,
-it is the "convex combination over a finite family" on the type `T`, afforded by the `Mixable` instance,
-with the probability distribution of `X` as weights. -/
+it is the "convex combination over a finite family" on the type `T`, afforded by
+the `Mixable` instance, with the probability distribution of `X` as weights. -/
 def expect_val (X : RandVar α T) : T := by
   let u : U := ∑ i ∈ Finset.univ, (X.distr i : ℝ) • (inst.to_U (X.var i))
   have ht : ∃ t : T, inst.to_U t = u := by
     have h₀ : ∀ i ∈ Finset.univ, 0 ≤ ↑(X.distr i) := by simp
     have h₁ : ∑ i ∈ Finset.univ, (X.distr i : ℝ) = 1 := by simp
-    have hz : ∀ i ∈ Finset.univ, inst.to_U (X.var i) ∈ Set.range inst.to_U := by simp [Finset.mem_univ]
+    have hz : ∀ i ∈ Finset.univ, inst.to_U (X.var i) ∈ Set.range inst.to_U := by
+      simp [Finset.mem_univ]
     exact Set.mem_range.mp (inst.convex.sum_mem h₀ h₁ hz)
   exact (inst.mkT ht).1
 
 /-- The expectation value of a random variable over `α = Fin 2` is the same as `Mixable.mix`
 with probabiliy weight `X.distr 0` -/
-theorem expect_val_eq_mixable_mix (d : ProbDistribution (Fin 2)) (x₁ x₂ : T) : expect_val ⟨![x₁, x₂], d⟩ = Mixable.mix (d 0) x₁ x₂ := by
+theorem expect_val_eq_mixable_mix (d : ProbDistribution (Fin 2)) (x₁ x₂ : T) :
+    expect_val ⟨![x₁, x₂], d⟩ = Mixable.mix (d 0) x₁ x₂ := by
   apply Mixable.to_U_inj
   simp only [Mixable.mix, expect_val, DFunLike.coe, Mixable.to_U_of_mkT]
   calc
-    ∑ i : Fin (Nat.succ 0).succ, (d i : ℝ) • Mixable.to_U (![x₁, x₂] i) = ∑ i, (d i : ℝ) • Mixable.to_U (![x₁, x₂] i) := by
+    ∑ i : Fin (Nat.succ 0).succ, (d i : ℝ) • Mixable.to_U (![x₁, x₂] i) =
+        ∑ i, (d i : ℝ) • Mixable.to_U (![x₁, x₂] i) := by
       simp
     _ = (d 0 : ℝ) • Mixable.to_U (![x₁, x₂] 0) + (d 1 : ℝ) • Mixable.to_U (![x₁, x₂] 1) := by
       simp
@@ -259,14 +270,16 @@ theorem expect_val_eq_mixable_mix (d : ProbDistribution (Fin 2)) (x₁ x₂ : T)
       simpa only [Subtype.ext_iff, Prob.coe_one_minus, eq_sub_iff_add_eq, add_comm,
         fun_eq_val, Fin.sum_univ_two] using d.property
 
-/-- The expectation value of a random variable with constant probability distribution `constant x` is its value at `x` -/
+/-- The expectation value of a random variable with constant probability distribution
+  `constant x` is its value at `x` -/
 theorem expect_val_constant (x : α) (f : α → T) : expect_val ⟨f, (constant x)⟩ = f x := by
   apply Mixable.to_U_inj
   simp only [expect_val, constant, DFunLike.coe, Mixable.to_U_of_mkT, apply_ite, Prob.coe_one,
     Prob.coe_zero, ite_smul, one_smul, zero_smul, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte]
 
 /-- The expectation value of a nonnegative real random variable is also nonnegative -/
-theorem zero_le_expect_val (d : ProbDistribution α) (f : α → ℝ) (hpos : 0 ≤ f) : 0 ≤ expect_val ⟨f, d⟩ := by
+theorem zero_le_expect_val (d : ProbDistribution α) (f : α → ℝ) (hpos : 0 ≤ f) :
+    0 ≤ expect_val ⟨f, d⟩ := by
   simp only [expect_val, Mixable.mkT, Mixable.to_U, id]
   apply Fintype.sum_nonneg
   intro x
@@ -291,13 +304,15 @@ def congrRandVar (σ : α ≃ β) : RandVar α T ≃ RandVar β T := by
     · simp [Function.comp_assoc]
     · rw [← ProbDistribution.congr_symm_apply, Equiv.apply_symm_apply]
 
-/-- Given a `T`-valued random variable `X` over `α`, mapping over `T` commutes with the equivalence over `α` -/
+/-- Given a `T`-valued random variable `X` over `α`, mapping over `T` commutes
+  with the equivalence over `α` -/
 def map_congr_eq_congr_map {S : Type _} [Mixable U S] (f : T → S) (σ : α ≃ β) (X : RandVar α T) :
   f <$> congrRandVar σ X = congrRandVar σ (f <$> X) := by rfl
 
 /-- The expectation value is invariant under equivalence of random variables -/
 @[simp]
-theorem expect_val_congr_eq_expect_val (σ : α ≃ β) (X : RandVar α T) : expect_val (congrRandVar σ X) = expect_val X := by
+theorem expect_val_congr_eq_expect_val (σ : α ≃ β) (X : RandVar α T) :
+    expect_val (congrRandVar σ X) = expect_val X := by
   apply Mixable.to_U_inj
   simp only [expect_val, congrRandVar, Equiv.coe_fn_mk, Function.comp_apply, Mixable.to_U_of_mkT,
     congr_apply]

--- a/QuantumInfo/ClassicalInfo/Entropy.lean
+++ b/QuantumInfo/ClassicalInfo/Entropy.lean
@@ -96,7 +96,8 @@ theorem Hₛ_le_log_d (d : ProbDistribution α) : Hₛ d ≤ Real.log (Fintype.c
   --Thanks Aristotle
   by_cases h : Fintype.card α = 0
   · simp_all [Hₛ, Fintype.card_eq_zero_iff.mp h]
-  -- Since the sum of the probabilities is 1, we can apply Jensen's inequality for the convex function -x log x.
+  -- Since the sum of the probabilities is 1, we can apply Jensen's inequality for the
+    -- convex function -x log x.
   have h_jensen {p : α → ℝ} (hsum : ∑ i, p i = 1) (hp : ∀ i, 0 ≤ p i ∧ p i ≤ 1) :
       -∑ i, p i * (p i).log ≤ Real.log (Fintype.card α) := by
     have h_jensen : (∑ i, (Fintype.card α : ℝ)⁻¹ * p i) * (∑ i, (Fintype.card α : ℝ)⁻¹ * p i).log ≤

--- a/QuantumInfo/ClassicalInfo/Prob.lean
+++ b/QuantumInfo/ClassicalInfo/Prob.lean
@@ -15,12 +15,13 @@ public import Mathlib.Topology.UnitInterval
 
 /-! # Probabilities
 
-This defines a type `Prob`, which is simply any real number in the interval O to 1. This then comes with
-additional statements such as its application to convex sets, and it makes useful type alias for
-functions that only make sense on probabilities.
+This defines a type `Prob`, which is simply any real number in the interval O to 1.
+This then comes with additional statements such as its application to convex sets, and
+it makes useful type alias for functions that only make sense on probabilities.
 
-A significant application is in the `Mixable` typeclass, also in this file, which is a general notion
-of convex combination that applies to types as opposed to sets; elements are `Mixable.mix`ed using `Prob`s.
+A significant application is in the `Mixable` typeclass, also in this file, which is a
+general notion of convex combination that applies to types as opposed to sets;
+elements are `Mixable.mix`ed using `Prob`s.
 -/
 
 @[expose] public section
@@ -221,21 +222,24 @@ theorem mul_eq_one_iff (p q : Prob) : p * q = 1 ↔ p = 1 ∧ q = 1 := by
 
 end Prob
 
-/-- A `Mixable T` typeclass instance gives a compact way of talking about the action of probabilities
-  for forming linear combinations in convex spaces. The notation `p [ x₁ ↔ x₂ ]` means to take a convex
+/-- A `Mixable T` typeclass instance gives a compact way of talking about the
+  action of probabilities for forming linear combinations in convex spaces.
+  The notation `p [ x₁ ↔ x₂ ]` means to take a convex
   combination, equal to `x₁` if `p=1` and to `x₂` if `p=0`.
 
-  Mixable is defined by an "underlying" data type `U` with addition and scalar multiplication, and a
-  bijection between the `T` and a convex set of `U`. For instance, in `Mixable (Distribution (Fin n))`,
-  `U` is `n`-element vectors (which form the probability simplex, degenerate in one dimension). For
-  `QuantumInfo.Finite.MState` density matrices in quantum mechanics, which are PSD matrices of trace 1,
-  `U` is the underlying matrix.
+  Mixable is defined by an "underlying" data type `U` with addition and scalar
+  multiplication, and a bijection between the `T` and a convex set of `U`.
+  For instance, in `Mixable (Distribution (Fin n))`, `U` is `n`-element vectors
+  (which form the probability simplex, degenerate in one dimension). For
+  `QuantumInfo.Finite.MState` density matrices in quantum mechanics, which are
+  PSD matrices of trace 1, `U` is the underlying matrix.
 
-  Why not just stick with existing notions of `Convex`? `Convex` requires that the type already forms an
-  `AddCommMonoid` and `Module ℝ`. But many types, such as `Distribution`, are not: there is no good notion of
-  "multiplying a probability distribution by 0.3" to get another distribution. We can coerce the distribution
-  into, say, a vector or a function, but then we are not doing arithmetic with distributions. Accordingly,
-  the expression `0.3 * distA + 0.7 * distB` cannot represent a distribution on its own. -/
+  Why not just stick with existing notions of `Convex`? `Convex` requires that
+  the type already forms an `AddCommMonoid` and `Module ℝ`. But many types, such as `Distribution`,
+  are not: there is no good notion of "multiplying a probability distribution by 0.3" to get another
+  distribution. We can coerce the distribution nto, say, a vector or a function, but then we are not
+  doing arithmetic with distributions. Accordingly, the expression `0.3 * distA + 0.7 * distB`
+  cannot represent a distribution on its own. -/
 class Mixable (U : outParam (Type u)) (T : Type v) [AddCommMonoid U] [Module ℝ U] where
   /-- Getter for the underlying data -/
   to_U : T → U
@@ -257,8 +261,9 @@ def mix_ab [inst : Mixable U T] {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hab :
     (y := to_U x₂) (exists_apply_eq_apply _ _)
     ha hb hab
 
-/-- `Mixable.mix` represents the notion of "convex combination" on the type `T`, afforded by the `Mixable`
-instance. It takes a `Prob`, that is, a `Real` between 0 and 1. For working directly with a Real, use `mix_ab`. -/
+/-- `Mixable.mix` represents the notion of "convex combination" on the type `T`, afforded by the
+  `Mixable` instance. It takes a `Prob`, that is, a `Real` between 0 and 1. For working directly
+  with a Real, use `mix_ab`. -/
 def mix [inst : Mixable U T] (p : Prob) (x₁ x₂ : T) : T :=
   inst.mix_ab p.zero_le_coe (1 - p).zero_le_coe p.add_one_minus x₁ x₂
 
@@ -285,7 +290,8 @@ instance instUniv [AddCommMonoid T] [Module ℝ T] : Mixable T T where
   mkT := fun _ ↦ ⟨_, rfl⟩
 
 @[simp]
-theorem mkT_instUniv [AddCommMonoid T] [Module ℝ T] {t : T} (h : ∃ t', to_U t' = t) : instUniv.mkT h = ⟨t, rfl⟩ :=
+theorem mkT_instUniv [AddCommMonoid T] [Module ℝ T] {t : T} (h : ∃ t', to_U t' = t) :
+    instUniv.mkT h = ⟨t, rfl⟩ :=
   rfl
 
 @[simp]
@@ -294,13 +300,16 @@ theorem to_U_instUniv [AddCommMonoid T] [Module ℝ T] {t : T} : instUniv.to_U t
 
 section pi
 
-theorem instPi.lem_1 {D : Type*} {T U : D → Type*} [∀i, AddCommMonoid (U i)] [∀ i, Module ℝ (U i)] [inst : ∀i, Mixable (U i) (T i)]
-    {u : (i : D) → U i} (h : ∃ (t : (i : D) → T i), (fun d => to_U (t d)) = u) (d : D) : ∃ (t : T d), to_U t = u d := by
+theorem instPi.lem_1 {D : Type*} {T U : D → Type*} [∀i, AddCommMonoid (U i)] [∀ i, Module ℝ (U i)]
+    [inst : ∀i, Mixable (U i) (T i)]
+    {u : (i : D) → U i} (h : ∃ (t : (i : D) → T i), (fun d => to_U (t d)) = u) (d : D) :
+    ∃ (t : T d), to_U t = u d := by
   obtain ⟨t, h⟩ := h
   use t d
   exact congrFun h d
 
-variable {D : Type*} {T U : D → Type*} [∀i, AddCommMonoid (U i)] [∀ i, Module ℝ (U i)] [inst : ∀i, Mixable (U i) (T i)] in
+variable {D : Type*} {T U : D → Type*} [∀i, AddCommMonoid (U i)] [∀ i, Module ℝ (U i)]
+  [inst : ∀i, Mixable (U i) (T i)] in
 /-- Mixable instance on Pi types. -/
 instance instPi : Mixable ((i:D) → U i) ((i:D) → T i) where
   to_U x := fun d ↦ (inst d).to_U (x d)
@@ -315,12 +324,13 @@ instance instPi : Mixable ((i:D) → U i) ((i:D) → T i) where
     simp only [to_U_of_mkT, Pi.add_apply, Pi.smul_apply]
 
 @[simp]
-theorem val_mkT_instPi (D : Type*) [inst : Mixable U T] {u : D → U} (h : ∃ t, to_U t = u) : (instPi.mkT h).val =
-    fun d ↦ (inst.mkT (instPi.lem_1 h d)).val :=
+theorem val_mkT_instPi (D : Type*) [inst : Mixable U T] {u : D → U} (h : ∃ t, to_U t = u) :
+    (instPi.mkT h).val = fun d ↦ (inst.mkT (instPi.lem_1 h d)).val :=
   rfl
 
 @[simp]
-theorem to_U_instPi (D : Type*) [inst : Mixable U T] {t : D → T} : (instPi).to_U t = fun d ↦ inst.to_U (t d) :=
+theorem to_U_instPi (D : Type*) [inst : Mixable U T] {t : D → T} :
+    (instPi).to_U t = fun d ↦ inst.to_U (t d) :=
   rfl
 
 end pi
@@ -379,13 +389,14 @@ theorem mkT_mixable (u : ℝ) (h : ∃ t : Prob, Mixable.to_U t = u) : Mixable.m
 
 /-- `Prob.mix` is an alias of `Mixable.mix` so it can be accessed from a probability with
 dot notation, e.g. `p.mix x y`. -/
-abbrev mix [AddCommMonoid U] [Module ℝ U] [inst : Mixable U T] (p : Prob) (x₁ x₂ : T) := inst.mix p x₁ x₂
+abbrev mix [AddCommMonoid U] [Module ℝ U] [inst : Mixable U T]
+    (p : Prob) (x₁ x₂ : T) := inst.mix p x₁ x₂
 
 section negLog
 open ENNReal
 
-/-- Map a probability [0,1] to [0,+∞] with -log p. Special case that 0 maps to +∞ (not 0, as Real.log
-does). This makes it `Antitone`.
+/-- Map a probability [0,1] to [0,+∞] with -log p. Special case that 0 maps to +∞ (not 0, as
+  Real.log does). This makes it `Antitone`.
 -/
 noncomputable def negLog : Prob → ENNReal :=
   fun p ↦ if p = 0 then ∞ else .ofNNReal ⟨-Real.log p,

--- a/QuantumInfo/Finite/CPTPMap/CPTP.lean
+++ b/QuantumInfo/Finite/CPTPMap/CPTP.lean
@@ -10,10 +10,11 @@ public import QuantumInfo.Finite.Unitary
 
 /-! # Completely Positive Trace Preserving maps
 
-A `CPTPMap` is a `ℂ`-linear map between matrices (`MatrixMap` is an alias), bundled with the facts that it
-`IsCompletelyPositive` and `IsTracePreserving`. CPTP maps are typically regarded as the "most general
-quantum operation", as they map density matrices (`MState`s) to density matrices. The type `PTPMap`,
-for maps that are positive (but not necessarily completely positive) is also declared.
+A `CPTPMap` is a `ℂ`-linear map between matrices (`MatrixMap` is an alias), bundled with the facts
+that it `IsCompletelyPositive` and `IsTracePreserving`. CPTP maps are typically regarded as the
+"most general quantum operation", as they map density matrices (`MState`s) to density matrices. The
+type `PTPMap`, for maps that are positive (but not necessarily completely positive) is also
+declared.
 
 A large portion of the theory is in terms of the Choi matrix (`MatrixMap.choi_matrix`), as the
 positive-definiteness of this matrix corresponds to being a CP map. This is
@@ -32,8 +33,8 @@ This file also defines several important examples of, classes of, and operations
  * `IsEntanglementBreaking`, `IsDegradable`, `IsAntidegradable`: Entanglement breaking, degradable
     and antidegradable channels.
  * `SWAP`, `assoc`, `assoc'`, `traceLeft`, `traceRight`: The CPTP maps corresponding to important
-    operations on states. These correspond directly to `MState.SWAP`, `MState.assoc`, `MState.assoc'`,
-    `MState.traceLeft`, and `MState.traceRight`.
+    operations on states. These correspond directly to `MState.SWAP`, `MState.assoc`,
+    `MState.assoc'`, `MState.traceLeft`, and `MState.traceRight`.
 -/
 
 @[expose] public section
@@ -455,16 +456,14 @@ variable [DecidableEq dOut] [Inhabited dOut]
 --PULLOUT
 omit [DecidableEq dOut] [Inhabited dOut] in
 /-
-PROBLEM
-If a MatrixMap of_kraus K K is trace-preserving, then Σ_k K_k† K_k = 1.
+PROBLEM If a MatrixMap of_kraus K K is trace-preserving, then Σ_k K_k† K_k = 1.
 
-PROVIDED SOLUTION
-The TP condition says for all X, trace((of_kraus K K) X) = trace(X).
-Unfolding of_kraus: trace(Σ_k K_k X K_k†) = Σ_k trace(K_k† K_k X) (by cycle) = trace((Σ_k K_k† K_k) X).
-So trace(A X) = trace(X) for all X where A = Σ_k K_k† K_k, which means A = 1.
-Use `Matrix.eq_of_trace_mul_eq` or the fact that trace is a faithful pairing on matrices
-to conclude A = 1. The TP condition `Λ.TP` gives us `∀ x, (Λ.map x).trace = x.trace`, and
-since `Λ.map = of_kraus K K`, we substitute and simplify.
+PROVIDED SOLUTION The TP condition says for all X, trace((of_kraus K K) X) = trace(X). Unfolding
+of_kraus: trace(Σ_k K_k X K_k†) = Σ_k trace(K_k† K_k X) (by cycle) = trace((Σ_k K_k† K_k) X). So
+trace(A X) = trace(X) for all X where A = Σ_k K_k† K_k, which means A = 1. Use
+`Matrix.eq_of_trace_mul_eq` or the fact that trace is a faithful pairing on matrices to conclude A =
+1. The TP condition `Λ.TP` gives us `∀ x, (Λ.map x).trace = x.trace`, and since `Λ.map = of_kraus K
+K`, we substitute and simplify.
 -/
 private lemma kraus_sum_eq_one_of_TP
     {κ : Type*} [Fintype κ]

--- a/QuantumInfo/Finite/CPTPMap/Dual.lean
+++ b/QuantumInfo/Finite/CPTPMap/Dual.lean
@@ -110,7 +110,8 @@ If two matrix maps satisfy the trace duality property, they are equal.
 lemma dual_unique
     (M : MatrixMap dIn dOut 𝕜) (M' : MatrixMap dOut dIn 𝕜)
     (h : ∀ A B, (M A * B).trace = (A * M' B).trace) : M.dual = M' := by
-  -- By definition of dual, we know that for any A and B, the trace of (M A) * B equals the trace of A * (M.dual B).
+  -- By definition of dual, we know that for any A and B, the trace of (M A) * B equals the trace of
+  -- A * (M.dual B).
   have h_dual : ∀ A : Matrix dIn dIn 𝕜, ∀ B : Matrix dOut dOut 𝕜, (M A * B).trace = (A * M.dual B).trace := by
     exact fun A B => Dual.trace_eq M A B;
   -- Since these two linear maps agree on all bases, they must be equal.
@@ -124,7 +125,8 @@ The Choi matrix of the dual map is the transpose of the reindexed Choi matrix of
 -/
 lemma dual_choi_matrix (M : MatrixMap dIn dOut 𝕜) :
     M.dual.choi_matrix = (M.choi_matrix.transpose).reindex (Equiv.prodComm dOut dIn) (Equiv.prodComm dOut dIn) := by
-  -- By definition of dual, we know that $(M.dual (single j₁ j₂ 1)) i₁ i₂ = (M (single i₂ i₁ 1)) j₂ j₁$.
+  -- By definition of dual, we know that
+  -- $(M.dual (single j₁ j₂ 1)) i₁ i₂ = (M (single i₂ i₁ 1)) j₂ j₁$.
   have h_dual_def : ∀ (i₁ : dIn) (j₁ : dOut) (i₂ : dIn) (j₂ : dOut), (M.dual (Matrix.single j₁ j₂ 1)) i₁ i₂ = (M (Matrix.single i₂ i₁ 1)) j₂ j₁ := by
     intro i₁ j₁ i₂ j₂
     have h_dual_def : (M.dual (Matrix.single j₁ j₂ 1)) i₁ i₂ = Matrix.trace (Matrix.single i₂ i₁ 1 * M.dual (Matrix.single j₁ j₂ 1)) := by
@@ -141,7 +143,8 @@ lemma dual_choi_matrix (M : MatrixMap dIn dOut 𝕜) :
   aesop
 
 /--
-If the Choi matrix of a map is positive semidefinite, then the Choi matrix of its dual is also positive semidefinite.
+If the Choi matrix of a map is positive semidefinite, then the Choi matrix of its dual is also
+positive semidefinite.
 -/
 lemma dual_choi_matrix_posSemidef_of_posSemidef (M : MatrixMap dIn dOut 𝕜) (h : M.choi_matrix.PosSemidef) :
     M.dual.choi_matrix.PosSemidef := by
@@ -227,7 +230,8 @@ theorem IsCompletelyPositive.dual (h : M.IsCompletelyPositive) : M.dual.IsComple
   rw [ h_dual_kron, dual_id ]
 
 /--
-The composition of the dual of the inverse of the dual basis isomorphism with the dual basis isomorphism is the evaluation map.
+The composition of the dual of the inverse of the dual basis isomorphism with the dual basis
+isomorphism is the evaluation map.
 -/
 lemma Module.Basis.dualMap_toDualEquiv_symm_comp_toDualEquiv {ι R M : Type*} [Fintype ι] [DecidableEq ι] [CommRing R] [AddCommGroup M] [Module R M] [Module.IsReflexive R M] (b : Module.Basis ι R M) :
     b.toDualEquiv.symm.toLinearMap.dualMap ∘ₗ b.toDualEquiv.toLinearMap = (Module.evalEquiv R M).toLinearMap := by
@@ -241,7 +245,8 @@ lemma Module.Basis.dualMap_toDualEquiv_symm_comp_toDualEquiv {ι R M : Type*} [F
   ac_rfl
 
 /--
-The composition of the inverse of the dual basis isomorphism with the dual of the dual basis isomorphism is the inverse of the evaluation map.
+The composition of the inverse of the dual basis isomorphism with the dual of the dual basis
+isomorphism is the inverse of the evaluation map.
 -/
 lemma Module.Basis.toDualEquiv_symm_comp_dualMap_toDualEquiv {ι R M : Type*} [Fintype ι] [DecidableEq ι] [CommRing R] [AddCommGroup M] [Module R M] [Module.IsReflexive R M] (b : Module.Basis ι R M) :
     b.toDualEquiv.symm.toLinearMap ∘ₗ b.toDualEquiv.toLinearMap.dualMap = (Module.evalEquiv R M).symm.toLinearMap := by
@@ -402,9 +407,9 @@ theorem HPMap.ofHermitianMat_linearMap (f : HPMap dIn dOut ℂ) :
 
 variable (f : HPMap dIn dOut) (A : HermitianMat dIn ℂ)
 
---Can define one for HPMap's that has 'easier' definitional properties, uses the inner product structure,
---doesn't go through Module.Basis the same way. Requires the equivalence between ℝ-linear maps of HermitianMats
---and ℂ-linear maps of matrices.
+--Can define one for HPMap's that has 'easier' definitional properties, uses the inner product
+--structure, doesn't go through Module.Basis the same way. Requires the equivalence between ℝ-linear
+--maps of HermitianMats and ℂ-linear maps of matrices.
 def HPMap.hermDual : HPMap dOut dIn :=
   HPMap.ofHermitianMat (LinearMapClass.linearMap f).adjoint
 

--- a/QuantumInfo/Finite/CPTPMap/MatrixMap.lean
+++ b/QuantumInfo/Finite/CPTPMap/MatrixMap.lean
@@ -19,13 +19,14 @@ This file works with `MatrixMap`s, that is, linear maps from square matrices to 
 Although this is just a shorthand for `Matrix A A R →ₗ[R] Matrix B B R`, there are several
 concepts that specifically make sense in this context.
 
- * `toMatrix` is the rectangular "transfer matrix", where matrix multiplication commutes with map composition.
+ * `toMatrix` is the rectangular "transfer matrix", where matrix multiplication commutes with map
+   composition.
  * `choi_matrix` is the square "Choi matrix", see `MatrixMap.choi_PSD_iff_CP_map` for example usage
  * `kron` is the Kronecker product of matrix maps
  * `IsTracePreserving` states the trace of the output is always equal to the trace of the input.
 
-We provide simp lemmas for relating these facts, prove basic facts e.g. composition and identity, and some facts
-about `IsTracePreserving` maps.
+We provide simp lemmas for relating these facts, prove basic facts e.g. composition and identity,
+and some facts about `IsTracePreserving` maps.
 -/
 
 @[expose] public section
@@ -69,7 +70,8 @@ theorem map_choi_inv (M : Matrix (B × A) (B × A) R) : choi_matrix (of_choi_mat
 /-- Proves that `MatrixMap.choi_matrix` and `MatrixMap.of_choi_matrix` inverses. -/
 @[simp]
 theorem choi_map_inv (M : MatrixMap A B R) : of_choi_matrix (choi_matrix M) = M := by
-  -- By definition of `MatrixMap.of_choi_matrix`, we know that applying it to the Choi matrix of `M` reconstructs `M`.
+  -- By definition of `MatrixMap.of_choi_matrix`, we know that applying it to the Choi matrix of `M`
+  -- reconstructs `M`.
   ext X b₁ b₂; simp [MatrixMap.of_choi_matrix, MatrixMap.choi_matrix];
   -- By linearity of $M$, we can distribute $M$ over the sum.
   have h_linear : M X = ∑ x : A, ∑ x_1 : A, X x x_1 • M (Matrix.single x x_1 1) := by
@@ -158,8 +160,8 @@ open Kronecker
 variable {A B C D R : Type*} [Fintype A] [Fintype B] [Fintype C] [Fintype D]
 variable [DecidableEq A] [DecidableEq C]
 
-/-- The Kronecker product of MatrixMaps. Defined here using `TensorProduct.map M₁ M₂`, with appropriate
-reindexing operations and `LinearMap.toMatrix`/`Matrix.toLin`. Notation `⊗ₖₘ`. -/
+/-- The Kronecker product of MatrixMaps. Defined here using `TensorProduct.map M₁ M₂`, with
+  appropriate reindexing operations and `LinearMap.toMatrix`/`Matrix.toLin`. Notation `⊗ₖₘ`. -/
 noncomputable def kron [CommSemiring R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D R) : MatrixMap (A × C) (B × D) R :=
   let h₁ := (LinearMap.toMatrix (Module.Basis.tensorProduct  (Matrix.stdBasis R A A) (Matrix.stdBasis R C C))
       (Module.Basis.tensorProduct  (Matrix.stdBasis R B B) (Matrix.stdBasis R D D)))
@@ -174,7 +176,8 @@ scoped[MatrixMap] infixl:100 " ⊗ₖₘ " => MatrixMap.kron
 set_option maxHeartbeats 800000 in
 set_option synthInstance.maxHeartbeats 60000 in
 set_option backward.isDefEq.respectTransparency false in
-/-- The extensional definition of the Kronecker product `MatrixMap.kron`, in terms of the entries of its image. -/
+/-- The extensional definition of the Kronecker product `MatrixMap.kron`, in terms of the entries of
+  its image. -/
 theorem kron_def [CommSemiring R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D R) (M : Matrix (A × C) (A × C) R) :
     (M₁ ⊗ₖₘ M₂) M (b₁, d₁) (b₂, d₂) = ∑ a₁, ∑ a₂, ∑ c₁, ∑ c₂,
       (M₁ (Matrix.single a₁ a₂ 1) b₁ b₂) * (M₂ (Matrix.single c₁ c₂ 1) d₁ d₂) * (M (a₁, c₁) (a₂, c₂)) := by
@@ -273,12 +276,12 @@ end kron_lemmas
 -- /-- The canonical tensor product on linear maps between matrices, where a map from
 --   M[A,B] to M[C,D] is given by M[A×C,B×D]. This tensor product acts independently on
 --   Kronecker products and gives Kronecker products as outputs. -/
--- def matrixMap_kron (M₁ : Matrix (A₁ × B₁) (C₁ × D₁) R) (M₂ : Matrix (A₂ × B₂) (C₂ × D₂) R) : Matrix ((A₁ × A₂) × (B₁ × B₂)) ((C₁ × C₂) × (D₁ × D₂)) R :=
---   Matrix.of fun ((a₁, a₂), (b₁, b₂)) ((c₁, c₂), (d₁, d₂)) ↦
---     (M₁ (a₁, b₁) (c₁, d₁)) * (M₂ (a₂, b₂) (c₂, d₂))
+--   def matrixMap_kron (M₁ : Matrix (A₁ × B₁) (C₁ × D₁) R) (M₂ : Matrix (A₂ × B₂) (C₂ × D₂) R) :
+--   Matrix ((A₁ × A₂) × (B₁ × B₂)) ((C₁ × C₂) × (D₁ × D₂)) R := Matrix.of fun ((a₁, a₂), (b₁, b₂))
+--   ((c₁, c₂), (d₁, d₂)) ↦ (M₁ (a₁, b₁) (c₁, d₁)) * (M₂ (a₂, b₂) (c₂, d₂))
 
-/-- The operational definition of the Kronecker product `MatrixMap.kron`, that it maps a Kronecker product of
-inputs to the Kronecker product of outputs. It is the unique bilinear map doing so. -/
+/-- The operational definition of the Kronecker product `MatrixMap.kron`, that it maps a Kronecker
+  product of inputs to the Kronecker product of outputs. It is the unique bilinear map doing so. -/
 theorem kron_map_of_kron_state [CommRing R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D R) (MA : Matrix A A R) (MC : Matrix C C R) : (M₁ ⊗ₖₘ M₂) (MA ⊗ₖ MC) = (M₁ MA) ⊗ₖ (M₂ MC) := by
   ext bd₁ bd₂
   let (b₁, d₁) := bd₁
@@ -379,8 +382,8 @@ variable {ι : Type u} [DecidableEq ι] [fι : Fintype ι]
 variable {dI : ι → Type v} [∀i, Fintype (dI i)] [∀i, DecidableEq (dI i)]
 variable {dO : ι → Type w} [∀i, Fintype (dO i)] [∀i, DecidableEq (dO i)]
 
-/-- Finite Pi-type tensor product of MatrixMaps. Defined as `PiTensorProduct.tprod` of the underlying
-Linear maps. Notation `⨂ₜₘ[R] i, f i`, eventually. -/
+/-- Finite Pi-type tensor product of MatrixMaps. Defined as `PiTensorProduct.tprod` of the
+  underlying Linear maps. Notation `⨂ₜₘ[R] i, f i`, eventually. -/
 noncomputable def piProd (Λi : ∀ i, MatrixMap (dI i) (dO i) R) : MatrixMap (∀i, dI i) (∀i, dO i) R :=
   let map₁ := PiTensorProduct.map Λi;
   let map₂ := LinearMap.toMatrix

--- a/QuantumInfo/Finite/CPTPMap/Unbundled.lean
+++ b/QuantumInfo/Finite/CPTPMap/Unbundled.lean
@@ -62,7 +62,8 @@ theorem IsTracePreserving_iff_trace_choi [DecidableEq A] (M : MatrixMap A B R) :
 
 namespace IsTracePreserving
 
-/-- Simp lemma: the trace of the image of a IsTracePreserving map is the same as the original trace. -/
+/-- Simp lemma: the trace of the image of a IsTracePreserving map is the same as the original
+trace. -/
 @[simp]
 theorem apply_trace (h : M.IsTracePreserving) (ρ : Matrix A A R)
     : (M ρ).trace = ρ.trace :=
@@ -354,12 +355,14 @@ variable {d : Type*} [Fintype d]
 open MatrixOrder
 
 set_option backward.isDefEq.respectTransparency false in
-/-- The map that takes M and returns M ⊗ₖ C, where C is positive semidefinite, is a completely positive map. -/
+/-- The map that takes M and returns M ⊗ₖ C, where C is positive semidefinite, is a completely
+  positive map. -/
 theorem kron_kronecker_const {C : Matrix d d R} (h : C.PosSemidef) {h₁ h₂ : _} : IsCompletelyPositive
     (⟨⟨fun M => M ⊗ₖ C, h₁⟩, h₂⟩ : MatrixMap A (A × d) R) := by
   intros n x hx
   have h_kronecker_pos : (x ⊗ₖ C).PosSemidef := by
-    -- Since $x$ and $C$ are positive semidefinite, there exist matrices $U$ and $V$ such that $x = U^*U$ and $C = V^*V$.
+    -- Since $x$ and $C$ are positive semidefinite, there exist matrices $U$ and $V$ such that
+    -- $x = U^*U$ and $C = V^*V$.
     obtain ⟨U, hU⟩ : ∃ U : Matrix (A × Fin n) (A × Fin n) R, x = star U * U := by
       classical
       apply CStarAlgebra.nonneg_iff_eq_star_mul_self.mp

--- a/QuantumInfo/Finite/Channel/DegradableOrder.lean
+++ b/QuantumInfo/Finite/Channel/DegradableOrder.lean
@@ -9,24 +9,24 @@ public import QuantumInfo.Finite.CPTPMap
 
 /-! # The Degradable Order
 
-We define the "degradable order" on channels, where M ≤ N if N can be degraded to M.
-This is a scoped instance, because there are other reasonable orders on channels.
+We define the "degradable order" on channels, where M ≤ N if N can be degraded to M. This is a
+scoped instance, because there are other reasonable orders on channels.
 
-The degradable order is actually only a preorder, because channels that are degradable to
-each other are not necessarily equal. (For instance, unitary channels are degradable to
-the identity and vice versa.) It can compare channels of different output dimensions, but
-they must have the same input dimension. For this reason the `DegradablePreorder` is parameterized
-by the channel input type.
+The degradable order is actually only a preorder, because channels that are degradable to each other
+are not necessarily equal. (For instance, unitary channels are degradable to the identity and vice
+versa.) It can compare channels of different output dimensions, but they must have the same input
+dimension. For this reason the `DegradablePreorder` is parameterized by the channel input type.
 
 One might hope that if this was defined on the quotient type of "channels up to unitary equivalence"
 that it would become an order; but this is not the case. That is, there are channels `A → B` that
-are degradable to each other, but cannot be degraded to each other by unitary operations. For instance,
-let A be the replacement channel that goes to a mixed state, and B be a replacement channel that goes
-to a pure state.
+are degradable to each other, but cannot be degraded to each other by unitary operations. For
+instance, let A be the replacement channel that goes to a mixed state, and B be a replacement
+channel that goes to a pure state.
 
-Technical notes: to model "channels of different output types", the preorder is on the Sigma
-type of channels parameterized by their output type. And since the output type needs to be a
-Fintype and DecidableEq, the argument is also a Sigma to bring this along.
+Technical notes: to model "channels of different output types", the preorder is on the Sigma type of
+channels parameterized by their output type. And since the output type needs to be a Fintype and
+DecidableEq, the argument is also a Sigma to bring this along.
+
 -/
 
 @[expose] public section

--- a/QuantumInfo/Finite/Distance/Fidelity.lean
+++ b/QuantumInfo/Finite/Distance/Fidelity.lean
@@ -20,7 +20,8 @@ variable {d d₂ : Type*} [Fintype d] [DecidableEq d] [Fintype d₂] (ρ σ : MS
 
 namespace MState
 
-/-- The fidelity of two quantum states. This is the quantum version of the Bhattacharyya coefficient. -/
+/-- The fidelity of two quantum states. This is the quantum version of the Bhattacharyya
+  coefficient. -/
 def fidelity (ρ σ : MState d) : ℝ :=
   (σ.M.conj ρ.M.sqrt.mat).sqrt.trace
 


### PR DESCRIPTION
Starting the process of reducing the line lengths of some of the results in QuantumInfo. With the help of the VS-code extension`Rewrap`