### PR TITLE
feat(Cosmology/FLRW): formalize Hubble/deceleration informal lemmas

### DIFF
--- a/Physlib/Cosmology/FLRW/Basic.lean
+++ b/Physlib/Cosmology/FLRW/Basic.lean
@@ -9,6 +9,7 @@ public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
 public import Physlib.Meta.Linters.Sorry
 public import Physlib.Meta.Informal.Basic
+public import Physlib.SpaceAndTime.Time.Derivatives
 /-!
 
 # The Friedmann-Lemaître-Robertson-Walker metric
@@ -110,11 +111,13 @@ namespace FLRW
 
 namespace FriedmannEquation
 
+open Time
+
 /--
 The first-order Friedmann equation.
 
-- `a : ℝ → ℝ` is the FLRW scale factor as a function of cosmic time `t`.
-- `ρ : ℝ → ℝ` is the total energy density as a function of cosmic time `t`.
+- `a : Time → ℝ` is the FLRW scale factor as a function of cosmic time `t`.
+- `ρ : Time → ℝ` is the total energy density as a function of cosmic time `t`.
 - `k : ℝ` is the spatial curvature parameter.
 - `Λ : ℝ` is the cosmological constant.
 - `G : ℝ` is Newton's constant.
@@ -126,8 +129,8 @@ At time `t` the equation reads:
 `(a'(t) / a(t))^2 = (8πG/3) ρ(t) − k c^2 / a(t)^2 + Λ c^2 / 3`.
 
 -/
-def FirstOrderFriedmann (a ρ: ℝ → ℝ) (k Λ G c : ℝ) (t : ℝ) : Prop :=
-    ((deriv a t / a t)^2
+def FirstOrderFriedmann (a ρ : Time → ℝ) (k Λ G c : ℝ) (t : Time) : Prop :=
+    ((∂ₜ a t / a t)^2
       = ((8 * Real.pi * G) / 3) * ρ t - k * c^2 / (a t)^2 + Λ * c ^2/ 3)
 
 /--
@@ -135,9 +138,9 @@ The second-order Friedmann equation.
 Note: Other sources may call this the Raychaudhuri equation.
 We choose not to use that terminology to avoid the Raychaudhuri equation
 related to describing congruences of geodesics in general relativity.
-- `a : ℝ → ℝ` is the FLRW scale factor as a function of cosmic time `t`.
-- `ρ : ℝ → ℝ` is the total energy density as a function of cosmic time `t`.
-- `p : ℝ → ℝ` is the pressure. It is related to `ρ` via `p = w * ρ `
+- `a : Time → ℝ` is the FLRW scale factor as a function of cosmic time `t`.
+- `ρ : Time → ℝ` is the total energy density as a function of cosmic time `t`.
+- `p : Time → ℝ` is the pressure. It is related to `ρ` via `p = w * ρ `
 - `w` is the equation of state. We will introduce this later.
 - `Λ : ℝ` is the cosmological constant.
 - `G : ℝ` is Newton's constant.
@@ -149,8 +152,8 @@ At time `t` the equation reads:
 `(a''(t) / a (t)) = - (4πG/3) * (ρ(t) + 3 * p(t) / c^2) + Λ * c^2 / 3`.
 
 -/
-def SecondOrderFriedmann (a ρ p: ℝ → ℝ) (Λ G c : ℝ) (t : ℝ) : Prop :=
-    (deriv (deriv a) t) / a t = - (4 * Real.pi * G / 3) * (ρ t + 3 * p t / c^2) + Λ * c^2 / 3
+def SecondOrderFriedmann (a ρ p : Time → ℝ) (Λ G c : ℝ) (t : Time) : Prop :=
+    ∂ₜ (∂ₜ a) t / a t = - (4 * Real.pi * G / 3) * (ρ t + 3 * p t / c^2) + Λ * c^2 / 3
 
 /-- The hubble constant defined in terms of the scale factor
   as `(dₜ a) / a`.
@@ -159,8 +162,14 @@ def SecondOrderFriedmann (a ρ p: ℝ → ℝ) (Λ G c : ℝ) (t : ℝ) : Prop :
 
   Semiformal implementation note: Implement also scoped notation. -/
 
-noncomputable def hubbleConstant (a : ℝ → ℝ) (t : ℝ) : ℝ :=
-    deriv a t / a t
+noncomputable def hubbleConstant (a : Time → ℝ) (t : Time) : ℝ :=
+    ∂ₜ a t / a t
+
+/-- The Hubble constant is nonzero whenever `∂ₜ a t` and `a t` are both nonzero. -/
+lemma hubbleConstant_ne_zero {a : Time → ℝ} {t : Time}
+    (hd_az : ∂ₜ a t ≠ 0) (haz : a t ≠ 0) :
+    hubbleConstant a t ≠ 0 :=
+  div_ne_zero hd_az haz
 
 /-- The deceleration parameter defined in terms of the scale factor
   as `- (dₜdₜ a) a / (dₜ a)^2`.
@@ -169,61 +178,60 @@ noncomputable def hubbleConstant (a : ℝ → ℝ) (t : ℝ) : ℝ :=
 
   Semiformal implementation note: Implement also scoped notation. -/
 
-noncomputable def decelerationParameter (a : ℝ → ℝ) (t : ℝ) : ℝ :=
-    - (deriv (deriv a) t * a t) / (deriv a t)^2
+noncomputable def decelerationParameter (a : Time → ℝ) (t : Time) : ℝ :=
+    - (∂ₜ (∂ₜ a) t * a t) / (∂ₜ a t)^2
 
 /-- Quotient-rule expression for the time derivative of the Hubble constant:
   `dₜ H = (a'' a - (a')^2) / a^2`. -/
-lemma deriv_hubbleConstant {a : ℝ → ℝ} {t : ℝ}
-    (ha : DifferentiableAt ℝ a t) (hd_a : DifferentiableAt ℝ (deriv a) t)
+lemma deriv_hubbleConstant {a : Time → ℝ} {t : Time}
+    (ha : DifferentiableAt ℝ a t) (hd_a : DifferentiableAt ℝ (∂ₜ a) t)
     (haz : a t ≠ 0) :
-    deriv (hubbleConstant a) t =
-      (deriv (deriv a) t * a t - (deriv a t) ^ 2) / (a t) ^ 2 := by
-  change deriv (deriv a / a) t = _
-  rw [deriv_div hd_a ha haz]
+    ∂ₜ (hubbleConstant a) t =
+      (∂ₜ (∂ₜ a) t * a t - (∂ₜ a t) ^ 2) / (a t) ^ 2 := by
+  show ∂ₜ (fun s => ∂ₜ a s / a s) t = _
+  rw [Time.deriv_div hd_a ha haz]
   ring
 
 /-- The deceleration parameter is equal to `- (1 + (dₜ H)/H^2)`. -/
 lemma decelerationParameter_eq_one_plus_hubbleConstant
-    {a : ℝ → ℝ} {t : ℝ}
-    (ha : DifferentiableAt ℝ a t) (hd_a : DifferentiableAt ℝ (deriv a) t)
-    (haz : a t ≠ 0) (hd_az : deriv a t ≠ 0) :
+    {a : Time → ℝ} {t : Time}
+    (ha : DifferentiableAt ℝ a t) (hd_a : DifferentiableAt ℝ (∂ₜ a) t)
+    (haz : a t ≠ 0) (hd_az : ∂ₜ a t ≠ 0) :
     decelerationParameter a t =
-      -(1 + deriv (hubbleConstant a) t / (hubbleConstant a t) ^ 2) := by
+      -(1 + ∂ₜ (hubbleConstant a) t / (hubbleConstant a t) ^ 2) := by
   rw [deriv_hubbleConstant ha hd_a haz]
-  unfold decelerationParameter hubbleConstant
+  simp only [decelerationParameter, hubbleConstant]
   field_simp
   ring
 
-/-- The time evolution of the hubble parameter is equal to `dₜ H = - H^2 (1 + q)`. -/
-lemma time_evolution_hubbleConstant
-    {a : ℝ → ℝ} {t : ℝ}
-    (ha : DifferentiableAt ℝ a t) (hd_a : DifferentiableAt ℝ (deriv a) t)
-    (haz : a t ≠ 0) (hd_az : deriv a t ≠ 0) :
-    deriv (hubbleConstant a) t =
+/-- The time derivative of the Hubble constant equals `-H² (1 + q)`. -/
+lemma deriv_hubbleConstant_eq_neg_sq_mul
+    {a : Time → ℝ} {t : Time}
+    (ha : DifferentiableAt ℝ a t) (hd_a : DifferentiableAt ℝ (∂ₜ a) t)
+    (haz : a t ≠ 0) (hd_az : ∂ₜ a t ≠ 0) :
+    ∂ₜ (hubbleConstant a) t =
       -(hubbleConstant a t) ^ 2 * (1 + decelerationParameter a t) := by
   rw [deriv_hubbleConstant ha hd_a haz]
-  unfold hubbleConstant decelerationParameter
+  simp only [hubbleConstant, decelerationParameter]
   field_simp
   ring
 
-/-- There exists a time at which the Hubble constant is strictly decreasing if and only if
-  there exists a time where the deceleration parameter is greater than `-1`.
+/-- There exists a time at which `∂ₜ H < 0` iff there exists a time with `q > -1`.
 
   (The corresponding informal statement was written with `q < -1`. Since
   `dₜ H = -H² (1 + q)` and `H ≠ 0`, one has `dₜ H < 0 ↔ q > -1`, so the formal
   statement uses the corrected inequality `-1 < q`.) -/
-lemma hubbleConstant_decrease_iff
-    {a : ℝ → ℝ}
-    (ha : ∀ t, DifferentiableAt ℝ a t) (hd_a : ∀ t, DifferentiableAt ℝ (deriv a) t)
-    (haz : ∀ t, a t ≠ 0) (hd_az : ∀ t, deriv a t ≠ 0) :
-    (∃ t, deriv (hubbleConstant a) t < 0) ↔ (∃ t, -1 < decelerationParameter a t) := by
-  have key : ∀ t, deriv (hubbleConstant a) t < 0 ↔ -1 < decelerationParameter a t := by
+lemma deriv_hubbleConstant_neg_iff
+    {a : Time → ℝ}
+    (ha : ∀ t, DifferentiableAt ℝ a t) (hd_a : ∀ t, DifferentiableAt ℝ (∂ₜ a) t)
+    (haz : ∀ t, a t ≠ 0) (hd_az : ∀ t, ∂ₜ a t ≠ 0) :
+    (∃ t, ∂ₜ (hubbleConstant a) t < 0) ↔ (∃ t, -1 < decelerationParameter a t) := by
+  have key : ∀ t, ∂ₜ (hubbleConstant a) t < 0 ↔ -1 < decelerationParameter a t := by
     intro t
-    have hH : hubbleConstant a t ≠ 0 := div_ne_zero (hd_az t) (haz t)
+    have hH : hubbleConstant a t ≠ 0 := hubbleConstant_ne_zero (hd_az t) (haz t)
     have hHsq : 0 < (hubbleConstant a t) ^ 2 :=
       (sq_nonneg _).lt_of_ne (Ne.symm (pow_ne_zero _ hH))
-    rw [time_evolution_hubbleConstant (ha t) (hd_a t) (haz t) (hd_az t)]
+    rw [deriv_hubbleConstant_eq_neg_sq_mul (ha t) (hd_a t) (haz t) (hd_az t)]
     constructor <;> intro h <;> nlinarith
   exact ⟨fun ⟨t, ht⟩ => ⟨t, (key t).mp ht⟩, fun ⟨t, ht⟩ => ⟨t, (key t).mpr ht⟩⟩
 end FriedmannEquation

--- a/Physlib/Cosmology/FLRW/Basic.lean
+++ b/Physlib/Cosmology/FLRW/Basic.lean
@@ -216,24 +216,31 @@ lemma deriv_hubbleConstant_eq_neg_sq_mul
   field_simp
   ring
 
+/-- Pointwise: `∂ₜ H t < 0` iff `-1 < q t` (assuming `a` is twice differentiable at `t`
+  and both `a t` and `∂ₜ a t` are nonzero). -/
+lemma deriv_hubbleConstant_neg_iff
+    {a : Time → ℝ} {t : Time}
+    (ha : DifferentiableAt ℝ a t) (hd_a : DifferentiableAt ℝ (∂ₜ a) t)
+    (haz : a t ≠ 0) (hd_az : ∂ₜ a t ≠ 0) :
+    ∂ₜ (hubbleConstant a) t < 0 ↔ -1 < decelerationParameter a t := by
+  have hH : hubbleConstant a t ≠ 0 := hubbleConstant_ne_zero hd_az haz
+  have hHsq : 0 < (hubbleConstant a t) ^ 2 :=
+    (sq_nonneg _).lt_of_ne (Ne.symm (pow_ne_zero _ hH))
+  rw [deriv_hubbleConstant_eq_neg_sq_mul ha hd_a haz hd_az]
+  constructor <;> intro h <;> nlinarith
+
 /-- There exists a time at which `∂ₜ H < 0` iff there exists a time with `q > -1`.
 
   (The corresponding informal statement was written with `q < -1`. Since
   `dₜ H = -H² (1 + q)` and `H ≠ 0`, one has `dₜ H < 0 ↔ q > -1`, so the formal
   statement uses the corrected inequality `-1 < q`.) -/
-lemma deriv_hubbleConstant_neg_iff
+lemma exists_deriv_hubbleConstant_neg_iff
     {a : Time → ℝ}
     (ha : ∀ t, DifferentiableAt ℝ a t) (hd_a : ∀ t, DifferentiableAt ℝ (∂ₜ a) t)
     (haz : ∀ t, a t ≠ 0) (hd_az : ∀ t, ∂ₜ a t ≠ 0) :
-    (∃ t, ∂ₜ (hubbleConstant a) t < 0) ↔ (∃ t, -1 < decelerationParameter a t) := by
-  have key : ∀ t, ∂ₜ (hubbleConstant a) t < 0 ↔ -1 < decelerationParameter a t := by
-    intro t
-    have hH : hubbleConstant a t ≠ 0 := hubbleConstant_ne_zero (hd_az t) (haz t)
-    have hHsq : 0 < (hubbleConstant a t) ^ 2 :=
-      (sq_nonneg _).lt_of_ne (Ne.symm (pow_ne_zero _ hH))
-    rw [deriv_hubbleConstant_eq_neg_sq_mul (ha t) (hd_a t) (haz t) (hd_az t)]
-    constructor <;> intro h <;> nlinarith
-  exact ⟨fun ⟨t, ht⟩ => ⟨t, (key t).mp ht⟩, fun ⟨t, ht⟩ => ⟨t, (key t).mpr ht⟩⟩
+    (∃ t, ∂ₜ (hubbleConstant a) t < 0) ↔ (∃ t, -1 < decelerationParameter a t) :=
+  ⟨fun ⟨t, ht⟩ => ⟨t, (deriv_hubbleConstant_neg_iff (ha t) (hd_a t) (haz t) (hd_az t)).mp ht⟩,
+   fun ⟨t, ht⟩ => ⟨t, (deriv_hubbleConstant_neg_iff (ha t) (hd_a t) (haz t) (hd_az t)).mpr ht⟩⟩
 end FriedmannEquation
 end FLRW
 

--- a/Physlib/Cosmology/FLRW/Basic.lean
+++ b/Physlib/Cosmology/FLRW/Basic.lean
@@ -175,22 +175,22 @@ noncomputable def decelerationParameter (a : ℝ → ℝ) (t : ℝ) : ℝ :=
 /-- Quotient-rule expression for the time derivative of the Hubble constant:
   `dₜ H = (a'' a - (a')^2) / a^2`. -/
 lemma deriv_hubbleConstant {a : ℝ → ℝ} {t : ℝ}
-    (ha : DifferentiableAt ℝ a t) (hda : DifferentiableAt ℝ (deriv a) t)
+    (ha : DifferentiableAt ℝ a t) (hd_a : DifferentiableAt ℝ (deriv a) t)
     (haz : a t ≠ 0) :
     deriv (hubbleConstant a) t =
       (deriv (deriv a) t * a t - (deriv a t) ^ 2) / (a t) ^ 2 := by
   change deriv (deriv a / a) t = _
-  rw [deriv_div hda ha haz]
+  rw [deriv_div hd_a ha haz]
   ring
 
 /-- The deceleration parameter is equal to `- (1 + (dₜ H)/H^2)`. -/
 lemma decelerationParameter_eq_one_plus_hubbleConstant
     {a : ℝ → ℝ} {t : ℝ}
-    (ha : DifferentiableAt ℝ a t) (hda : DifferentiableAt ℝ (deriv a) t)
-    (haz : a t ≠ 0) (hdaz : deriv a t ≠ 0) :
+    (ha : DifferentiableAt ℝ a t) (hd_a : DifferentiableAt ℝ (deriv a) t)
+    (haz : a t ≠ 0) (hd_az : deriv a t ≠ 0) :
     decelerationParameter a t =
       -(1 + deriv (hubbleConstant a) t / (hubbleConstant a t) ^ 2) := by
-  rw [deriv_hubbleConstant ha hda haz]
+  rw [deriv_hubbleConstant ha hd_a haz]
   unfold decelerationParameter hubbleConstant
   field_simp
   ring
@@ -198,11 +198,11 @@ lemma decelerationParameter_eq_one_plus_hubbleConstant
 /-- The time evolution of the hubble parameter is equal to `dₜ H = - H^2 (1 + q)`. -/
 lemma time_evolution_hubbleConstant
     {a : ℝ → ℝ} {t : ℝ}
-    (ha : DifferentiableAt ℝ a t) (hda : DifferentiableAt ℝ (deriv a) t)
-    (haz : a t ≠ 0) (hdaz : deriv a t ≠ 0) :
+    (ha : DifferentiableAt ℝ a t) (hd_a : DifferentiableAt ℝ (deriv a) t)
+    (haz : a t ≠ 0) (hd_az : deriv a t ≠ 0) :
     deriv (hubbleConstant a) t =
       -(hubbleConstant a t) ^ 2 * (1 + decelerationParameter a t) := by
-  rw [deriv_hubbleConstant ha hda haz]
+  rw [deriv_hubbleConstant ha hd_a haz]
   unfold hubbleConstant decelerationParameter
   field_simp
   ring
@@ -215,15 +215,15 @@ lemma time_evolution_hubbleConstant
   statement uses the corrected inequality `-1 < q`.) -/
 lemma hubbleConstant_decrease_iff
     {a : ℝ → ℝ}
-    (ha : ∀ t, DifferentiableAt ℝ a t) (hda : ∀ t, DifferentiableAt ℝ (deriv a) t)
-    (haz : ∀ t, a t ≠ 0) (hdaz : ∀ t, deriv a t ≠ 0) :
+    (ha : ∀ t, DifferentiableAt ℝ a t) (hd_a : ∀ t, DifferentiableAt ℝ (deriv a) t)
+    (haz : ∀ t, a t ≠ 0) (hd_az : ∀ t, deriv a t ≠ 0) :
     (∃ t, deriv (hubbleConstant a) t < 0) ↔ (∃ t, -1 < decelerationParameter a t) := by
   have key : ∀ t, deriv (hubbleConstant a) t < 0 ↔ -1 < decelerationParameter a t := by
     intro t
-    have hH : hubbleConstant a t ≠ 0 := div_ne_zero (hdaz t) (haz t)
+    have hH : hubbleConstant a t ≠ 0 := div_ne_zero (hd_az t) (haz t)
     have hHsq : 0 < (hubbleConstant a t) ^ 2 :=
       (sq_nonneg _).lt_of_ne (Ne.symm (pow_ne_zero _ hH))
-    rw [time_evolution_hubbleConstant (ha t) (hda t) (haz t) (hdaz t)]
+    rw [time_evolution_hubbleConstant (ha t) (hd_a t) (haz t) (hd_az t)]
     constructor <;> intro h <;> nlinarith
   exact ⟨fun ⟨t, ht⟩ => ⟨t, (key t).mp ht⟩, fun ⟨t, ht⟩ => ⟨t, (key t).mpr ht⟩⟩
 end FriedmannEquation

--- a/Physlib/Cosmology/FLRW/Basic.lean
+++ b/Physlib/Cosmology/FLRW/Basic.lean
@@ -239,8 +239,7 @@ lemma exists_deriv_hubbleConstant_neg_iff
     (ha : ∀ t, DifferentiableAt ℝ a t) (hd_a : ∀ t, DifferentiableAt ℝ (∂ₜ a) t)
     (haz : ∀ t, a t ≠ 0) (hd_az : ∀ t, ∂ₜ a t ≠ 0) :
     (∃ t, ∂ₜ (hubbleConstant a) t < 0) ↔ (∃ t, -1 < decelerationParameter a t) :=
-  ⟨fun ⟨t, ht⟩ => ⟨t, (deriv_hubbleConstant_neg_iff (ha t) (hd_a t) (haz t) (hd_az t)).mp ht⟩,
-   fun ⟨t, ht⟩ => ⟨t, (deriv_hubbleConstant_neg_iff (ha t) (hd_a t) (haz t) (hd_az t)).mpr ht⟩⟩
+  exists_congr fun t => deriv_hubbleConstant_neg_iff (ha t) (hd_a t) (haz t) (hd_az t)
 end FriedmannEquation
 end FLRW
 

--- a/Physlib/Cosmology/FLRW/Basic.lean
+++ b/Physlib/Cosmology/FLRW/Basic.lean
@@ -172,21 +172,60 @@ noncomputable def hubbleConstant (a : ℝ → ℝ) (t : ℝ) : ℝ :=
 noncomputable def decelerationParameter (a : ℝ → ℝ) (t : ℝ) : ℝ :=
     - (deriv (deriv a) t * a t) / (deriv a t)^2
 
+/-- Quotient-rule expression for the time derivative of the Hubble constant:
+  `dₜ H = (a'' a - (a')^2) / a^2`. -/
+lemma deriv_hubbleConstant {a : ℝ → ℝ} {t : ℝ}
+    (ha : DifferentiableAt ℝ a t) (hda : DifferentiableAt ℝ (deriv a) t)
+    (haz : a t ≠ 0) :
+    deriv (hubbleConstant a) t =
+      (deriv (deriv a) t * a t - (deriv a t) ^ 2) / (a t) ^ 2 := by
+  change deriv (deriv a / a) t = _
+  rw [deriv_div hda ha haz]
+  ring
+
 /-- The deceleration parameter is equal to `- (1 + (dₜ H)/H^2)`. -/
-informal_lemma decelerationParameter_eq_one_plus_hubbleConstant where
-  deps := []
-  tag := "6Z23H"
+lemma decelerationParameter_eq_one_plus_hubbleConstant
+    {a : ℝ → ℝ} {t : ℝ}
+    (ha : DifferentiableAt ℝ a t) (hda : DifferentiableAt ℝ (deriv a) t)
+    (haz : a t ≠ 0) (hdaz : deriv a t ≠ 0) :
+    decelerationParameter a t =
+      -(1 + deriv (hubbleConstant a) t / (hubbleConstant a t) ^ 2) := by
+  rw [deriv_hubbleConstant ha hda haz]
+  unfold decelerationParameter hubbleConstant
+  field_simp
+  ring
 
 /-- The time evolution of the hubble parameter is equal to `dₜ H = - H^2 (1 + q)`. -/
-informal_lemma time_evolution_hubbleConstant where
-  deps := []
-  tag := "6Z3BS"
+lemma time_evolution_hubbleConstant
+    {a : ℝ → ℝ} {t : ℝ}
+    (ha : DifferentiableAt ℝ a t) (hda : DifferentiableAt ℝ (deriv a) t)
+    (haz : a t ≠ 0) (hdaz : deriv a t ≠ 0) :
+    deriv (hubbleConstant a) t =
+      -(hubbleConstant a t) ^ 2 * (1 + decelerationParameter a t) := by
+  rw [deriv_hubbleConstant ha hda haz]
+  unfold hubbleConstant decelerationParameter
+  field_simp
+  ring
 
-/-- There exists a time at which the hubble constant decreases if and only if
-  there exists a time where the deceleration parameter is less then `-1`. -/
-informal_lemma hubbleConstant_decrease_iff where
-  deps := []
-  tag := "6Z3FS"
+/-- There exists a time at which the Hubble constant is strictly decreasing if and only if
+  there exists a time where the deceleration parameter is greater than `-1`.
+
+  (The corresponding informal statement was written with `q < -1`. Since
+  `dₜ H = -H² (1 + q)` and `H ≠ 0`, one has `dₜ H < 0 ↔ q > -1`, so the formal
+  statement uses the corrected inequality `-1 < q`.) -/
+lemma hubbleConstant_decrease_iff
+    {a : ℝ → ℝ}
+    (ha : ∀ t, DifferentiableAt ℝ a t) (hda : ∀ t, DifferentiableAt ℝ (deriv a) t)
+    (haz : ∀ t, a t ≠ 0) (hdaz : ∀ t, deriv a t ≠ 0) :
+    (∃ t, deriv (hubbleConstant a) t < 0) ↔ (∃ t, -1 < decelerationParameter a t) := by
+  have key : ∀ t, deriv (hubbleConstant a) t < 0 ↔ -1 < decelerationParameter a t := by
+    intro t
+    have hH : hubbleConstant a t ≠ 0 := div_ne_zero (hdaz t) (haz t)
+    have hHsq : 0 < (hubbleConstant a t) ^ 2 :=
+      (sq_nonneg _).lt_of_ne (Ne.symm (pow_ne_zero _ hH))
+    rw [time_evolution_hubbleConstant (ha t) (hda t) (haz t) (hdaz t)]
+    constructor <;> intro h <;> nlinarith
+  exact ⟨fun ⟨t, ht⟩ => ⟨t, (key t).mp ht⟩, fun ⟨t, ht⟩ => ⟨t, (key t).mpr ht⟩⟩
 end FriedmannEquation
 end FLRW
 

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -72,6 +72,29 @@ lemma deriv_neg [NormedAddCommGroup M] [NormedSpace ℝ M] (f : Time → M) :
   rw [deriv, fderiv_neg]
   rfl
 
+/-- Quotient rule for `Time.deriv` on real-valued functions: if `c` and `g` are
+  differentiable at `t` and `g t ≠ 0`, then
+  `∂ₜ (c / g) t = (∂ₜ c t * g t - c t * ∂ₜ g t) / (g t)^2`. -/
+lemma deriv_div {c g : Time → ℝ}
+    (hc : DifferentiableAt ℝ c t) (hg : DifferentiableAt ℝ g t) (hgz : g t ≠ 0) :
+    ∂ₜ (fun s => c s / g s) t =
+      (∂ₜ c t * g t - c t * ∂ₜ g t) / (g t) ^ 2 := by
+  have h_inv : DifferentiableAt ℝ (fun s => (g s)⁻¹) t := hg.inv hgz
+  have h_eq : (fun s : Time => c s / g s) = (fun s => c s * (g s)⁻¹) := by
+    funext; rw [div_eq_mul_inv]
+  have h_inv_fderiv : fderiv ℝ (fun s : Time => (g s)⁻¹) t =
+      (fderiv ℝ (Inv.inv : ℝ → ℝ) (g t)).comp (fderiv ℝ g t) := by
+    change fderiv ℝ (Inv.inv ∘ g) t = _
+    exact fderiv_comp t (differentiableAt_inv hgz) hg
+  rw [h_eq, Time.deriv_eq, fderiv_fun_mul hc h_inv]
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply, smul_eq_mul]
+  rw [h_inv_fderiv, fderiv_inv' hgz]
+  simp only [ContinuousLinearMap.coe_comp', Function.comp_apply,
+    ContinuousLinearMap.neg_apply, ContinuousLinearMap.mulLeftRight_apply]
+  rw [← Time.deriv_eq c t, ← Time.deriv_eq g t]
+  field_simp
+  ring
+
 /-!
 
 ## C. Derivative of constant functions

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -79,21 +79,11 @@ lemma deriv_div {c g : Time → ℝ}
     (hc : DifferentiableAt ℝ c t) (hg : DifferentiableAt ℝ g t) (hgz : g t ≠ 0) :
     ∂ₜ (fun s => c s / g s) t =
       (∂ₜ c t * g t - c t * ∂ₜ g t) / (g t) ^ 2 := by
-  have h_inv : DifferentiableAt ℝ (fun s => (g s)⁻¹) t := hg.inv hgz
-  have h_eq : (fun s : Time => c s / g s) = (fun s => c s * (g s)⁻¹) := by
-    funext; rw [div_eq_mul_inv]
-  have h_inv_fderiv : fderiv ℝ (fun s : Time => (g s)⁻¹) t =
-      (fderiv ℝ (Inv.inv : ℝ → ℝ) (g t)).comp (fderiv ℝ g t) := by
-    change fderiv ℝ (Inv.inv ∘ g) t = _
-    exact fderiv_comp t (differentiableAt_inv hgz) hg
-  rw [h_eq, Time.deriv_eq, fderiv_fun_mul hc h_inv]
-  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply, smul_eq_mul]
-  rw [h_inv_fderiv, fderiv_inv' hgz]
-  simp only [ContinuousLinearMap.coe_comp', Function.comp_apply,
-    ContinuousLinearMap.neg_apply, ContinuousLinearMap.mulLeftRight_apply]
-  rw [← Time.deriv_eq c t, ← Time.deriv_eq g t]
-  field_simp
-  ring
+  repeat rw [Time.deriv_eq]
+  ring_nf
+  simp [fderiv_fun_mul hc (DifferentiableAt.fun_inv (by fun_prop) hgz),
+    fderiv_comp' t (differentiableAt_inv hgz) hg]
+  grind 
 
 /-!
 

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -83,7 +83,7 @@ lemma deriv_div {c g : Time → ℝ}
   ring_nf
   simp [fderiv_fun_mul hc (DifferentiableAt.fun_inv (by fun_prop) hgz),
     fderiv_comp' t (differentiableAt_inv hgz) hg]
-  grind 
+  grind
 
 /-!
 


### PR DESCRIPTION
## Summary
- Formalize three informal lemmas in `Physlib/Cosmology/FLRW/Basic.lean` (tags `6Z23H`, `6Z3BS`, `6Z3FS`):
  - `decelerationParameter_eq_one_plus_hubbleConstant`: `q = -(1 + dₜH/H²)`
  - `time_evolution_hubbleConstant`: `dₜH = -H² (1 + q)`
  - `hubbleConstant_decrease_iff`: `(∃ t, dₜH t < 0) ↔ (∃ t, q t > -1)`
- Add a small helper `deriv_hubbleConstant` deriving the quotient-rule form `dₜH = (a''·a − (a')²)/a²` via `deriv_div`, used by both equality lemmas.

### Note on `hubbleConstant_decrease_iff`
The informal statement was written as `q < -1`, but this is physically reversed. From `dₜH = -H²(1+q)` with `H ≠ 0`:
- `q > -1` ↔ `dₜH < 0` (H **decreases** — matter, radiation, ΛCDM, the actual history of our universe).
- `q < -1` ↔ `dₜH > 0` (H **grows** — phantom dark energy, Big Rip; not observed).

The formal lemma uses the corrected inequality `-1 < q`, with the docstring documenting the change.

### TODO list
These three tags will drop off https://physlib.io/TODOList on the next regeneration of `docs/_data/TODO.yml` (auto-generated by `lake exe TODO_to_yml mkFile`); no extra changes needed.

## Test plan
- [x] `lake build Physlib.Cosmology.FLRW.Basic` clean (0 errors, 0 warnings).
- [ ] Maintainer to confirm the corrected sign in `hubbleConstant_decrease_iff` is acceptable.