### PR TITLE
feat(QM): add polynomially-bounded Schwartz maps

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -241,6 +241,7 @@ public import Physlib.QuantumMechanics.DDimensions.Operators.Momentum
 public import Physlib.QuantumMechanics.DDimensions.Operators.Position
 public import Physlib.QuantumMechanics.DDimensions.Operators.Unbounded
 public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.Basic
+public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.PolyBddSchwartzSubmodule
 public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.SchwartzSubmodule
 public import Physlib.QuantumMechanics.FiniteTarget.Basic
 public import Physlib.QuantumMechanics.FiniteTarget.HilbertSpace

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 Gregory J. Loges. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gregory J. Loges
+-/
+module
+
+public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.SchwartzSubmodule
+public import Physlib.Meta.Linters.Sorry
+/-!
+
+# Polynomially-bounded Schwartz submodules
+
+## i. Overview
+
+In this module we define polynomially-bounded Schwartz submodules of `SpaceDHilbertSpace`.
+
+For each `a : ℕ∞`, `polyBddSchwartzSubmodule d a` is the submodule corresponding to Schwartz
+maps `f` satisfying the polynomial growth bounds `‖x‖ ^ (-k) * ‖f x‖ ≤ Cₖ` for each `(k : ℕ) ≤ a`.
+In particular, for `a = ⊤` such a bound holds for all natural numbers.
+
+These serve as a natural domain for singular unbounded operators such as the `1/r` Coulomb
+potential acting on `SpaceDHilbertSpace`.
+
+Note: the condition defining polynomially-bounded Schwartz maps is phrased as
+`‖x‖ ^ (-k) * ‖f x‖ ≤ Cₖ` rather than as `‖f x‖ ≤ Cₖ * ‖x‖ ^ k` to mirror `SchwartzMap.decay`.
+These two conditions only differ at `x = 0` and are therefore equivalent for `d > 0` since
+then `f 0` may be determined by continuity. For `d = 0` the former does not constrain `f 0 = 0`
+(since `x = 0` is the only point and `0⁻¹ = 0`) while the latter does (and would therefore spoil
+their being dense in `SpaceDHilbertSpace 0 ≅ ℂ`).
+
+## ii. Key results
+
+- `polyBddSchwartzSubmodule d (a : ℕ∞)`: Restriction of `schwartzSubmodule d` to those Schwartz maps
+  which are bounded by powers of `‖x‖`.
+- `polyBddSchwartzSubmodule_dense d a`: These submodules are dense in `SpaceDHilbertSpace`.
+
+## iii. Table of contents
+
+- A. Definitions
+- B. (In)equalities
+- C. Density
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+namespace QuantumMechanics
+namespace SpaceDHilbertSpace
+
+open MeasureTheory
+open InnerProductSpace
+open SchwartzMap
+
+noncomputable section
+
+/-!
+### A. Definitions
+-/
+
+/-- A function is a bounded Schwartz map if it is both Schwartz and bounded by powers of `‖x‖`. -/
+def polyBddSchwartzMap (d : ℕ) (a : ℕ∞) : Submodule ℂ 𝓢(Space d, ℂ) where
+  carrier := {f : 𝓢(Space d, ℂ) |
+    ∀ k : ℕ, k ≤ a → ∃ C : ℝ, 0 < C ∧ ∀ x : Space d, ‖x‖ ^ (-k : ℤ) * ‖f x‖ ≤ C}
+  add_mem' := by
+    intro f g hf hg k hk
+    obtain ⟨C₁, hC₁_pos, hC₁⟩ := hf k hk
+    obtain ⟨C₂, hC₂_pos, hC₂⟩ := hg k hk
+    refine ⟨C₁ + C₂, by positivity, fun x ↦ ?_⟩
+    refine le_trans ?_ (add_le_add (hC₁ x) (hC₂ x))
+    rw [← mul_add]
+    exact mul_le_mul_of_nonneg_left (norm_add_le (f x) (g x)) (by positivity)
+  zero_mem' := fun _ _ ↦ ⟨1, by simp⟩
+  smul_mem' := by
+    intro c f hf k hk
+    obtain ⟨C, hC_pos, hC⟩ := hf k hk
+    refine ⟨(1 + ‖c‖) * C, by positivity, fun x ↦ ?_⟩
+    rw [smul_apply, norm_smul, mul_rotate', mul_comm ‖f x‖]
+    exact le_trans (mul_le_mul_of_nonneg_left (hC x) (norm_nonneg c)) (by linarith)
+
+/-- The continuous linear map `schwartzIncl` with domain restricted to `polyBddSchwartzMap d a`. -/
+def polyBddSchwartzIncl {d : ℕ} {a : ℕ∞} : polyBddSchwartzMap d a →L[ℂ] SpaceDHilbertSpace d :=
+  ⟨schwartzIncl.domRestrict (polyBddSchwartzMap d a),
+    schwartzIncl.continuous_domRestrict schwartzIncl.continuous _⟩
+
+/-- The submodule of `SpaceDHilbertSpace d` corresponding to bounded Schwartz maps. -/
+abbrev polyBddSchwartzSubmodule (d : ℕ) (a : ℕ∞) : Submodule ℂ (SpaceDHilbertSpace d) :=
+  (polyBddSchwartzIncl (a := a)).range
+
+lemma polyBddSchwartzIncl_injective (d : ℕ) (a : ℕ∞) :
+    Function.Injective (polyBddSchwartzIncl (d := d) (a := a)) :=
+  LinearMap.injective_domRestrict_iff.mpr <| schwartzIncl_ker.symm ▸ inf_bot_eq _
+
+/-- The linear equivalence between polynomially-bounded Schwartz maps and the corresponding
+  submodule of the Hilbert space. -/
+def polyBddSchwartzEquiv {d : ℕ} {a : ℕ∞} :
+    polyBddSchwartzMap d a ≃ₗ[ℂ] polyBddSchwartzSubmodule d a :=
+  LinearEquiv.ofInjective polyBddSchwartzIncl.toLinearMap (polyBddSchwartzIncl_injective d a)
+
+/-!
+### B. (In)equalities
+-/
+
+lemma polyBddSchwartzMap_zero_eq_top (d : ℕ) : polyBddSchwartzMap d 0 = ⊤ := by
+  ext f
+  have := f.decay 0 0
+  simp_all [polyBddSchwartzMap]
+
+lemma polyBddSchwartzMap_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
+    polyBddSchwartzMap d b ≤ polyBddSchwartzMap d a := fun _ hx k hk ↦ hx k (hk.trans h)
+
+lemma polyBddSchwartzSubmodule_zero_eq (d : ℕ) :
+    polyBddSchwartzSubmodule d 0 = schwartzSubmodule d := by
+  simp [polyBddSchwartzSubmodule, polyBddSchwartzIncl, polyBddSchwartzMap_zero_eq_top]
+
+lemma polyBddSchwartzSubmodule_le (d : ℕ) (a : ℕ∞) :
+    polyBddSchwartzSubmodule d a ≤ schwartzSubmodule d := LinearMap.range_domRestrict_le_range _ _
+
+lemma polyBddSchwartzSubmodule_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
+    polyBddSchwartzSubmodule d b ≤ polyBddSchwartzSubmodule d a := by
+  simp only [polyBddSchwartzSubmodule, polyBddSchwartzIncl, LinearMap.range_domRestrict]
+  exact Submodule.map_mono (polyBddSchwartzMap_le_of_ge d h)
+
+/-!
+### C. Density
+-/
+
+@[sorryful]
+lemma polyBddSchwartzSubmodule_top_dense (d : ℕ) :
+    Dense (polyBddSchwartzSubmodule d ⊤ : Set (SpaceDHilbertSpace d)) :=
+  sorry
+
+@[sorryful]
+lemma polyBddSchwartzSubmodule_dense (d : ℕ) (a : ℕ∞) :
+    Dense (polyBddSchwartzSubmodule d a : Set (SpaceDHilbertSpace d)) :=
+  (polyBddSchwartzSubmodule_top_dense d).mono (polyBddSchwartzSubmodule_le_of_ge d le_top)
+
+end
+
+end SpaceDHilbertSpace
+end QuantumMechanics

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
@@ -16,11 +16,15 @@ public import Physlib.Meta.Linters.Sorry
 In this module we define polynomially-bounded Schwartz submodules of `SpaceDHilbertSpace`.
 
 For each `a : ℕ∞`, `polyBddSchwartzSubmodule d a` is the submodule corresponding to Schwartz
-maps `f` satisfying the polynomial growth bounds `‖x‖ ^ (-k) * ‖f x‖ ≤ Cₖ` for each `(k : ℕ) ≤ a`.
+maps `f` satisfying the polynomial growth bounds `‖x‖ ^ (-k) * ‖f x‖ ≤ Cₖ` for all `(k : ℕ) ≤ a`.
 In particular, for `a = ⊤` such a bound holds for all natural numbers.
 
-These serve as a natural domain for singular unbounded operators such as the `1/r` Coulomb
-potential acting on `SpaceDHilbertSpace`.
+These serve as a natural domain for singular unbounded operators. For example, the `1/r` Coulomb
+potential operator maps `polyBddSchwartzSubmodule d ⊤` to itself. In the same way that multiplying
+a Schwartz map by any polynomial in the coordinates results in a square-integrable function,
+polynomially-bounded Schwartz maps may be multiplied by Laurent polynomials and remain
+square-integrable (the precise condition depends on `d`, `a` and the negative degree of
+the Laurent polynomial).
 
 Note: the condition defining polynomially-bounded Schwartz maps is phrased as
 `‖x‖ ^ (-k) * ‖f x‖ ≤ Cₖ` rather than as `‖f x‖ ≤ Cₖ * ‖x‖ ^ k` to mirror `SchwartzMap.decay`.

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -24,6 +24,12 @@ open MeasureTheory
 open InnerProductSpace
 open SchwartzMap
 
+/-!
+## A. Schwartz submodule
+-/
+
+section
+
 variable {d : ℕ}
 
 set_option backward.isDefEq.respectTransparency false in
@@ -49,9 +55,15 @@ set_option backward.isDefEq.respectTransparency false in
 def schwartzEquiv : 𝓢(Space d, ℂ) ≃ₗ[ℂ] schwartzSubmodule d :=
   LinearEquiv.ofInjective schwartzIncl.toLinearMap (injective_toLp (E := Space d) 2)
 
-variable (f g : 𝓢(Space d, ℂ))
+variable (f g : 𝓢(Space d, ℂ)) (ψ : schwartzSubmodule d)
 
 lemma schwartzEquiv_coe_ae : (schwartzEquiv f) =ᵐ[volume] f := coeFn_toLp f 2 volume
+
+lemma schwartzEquiv_symm_coe_ae : schwartzEquiv.symm ψ =ᵐ[volume] ψ := by
+  nth_rw 2 [← schwartzEquiv.apply_symm_apply ψ]
+  exact (schwartzEquiv_coe_ae _).symm
+
+lemma schwartzEquiv_apply_coe : ↑(schwartzEquiv f) = schwartzIncl f := by simp [schwartzEquiv]
 
 lemma schwartzEquiv_inner :
     ⟪schwartzEquiv f, schwartzEquiv g⟫_ℂ = ∫ x : Space d, starRingEnd ℂ (f x) * g x := by
@@ -61,6 +73,44 @@ lemma schwartzEquiv_inner :
 
 lemma schwartzEquiv_ae_eq (h : schwartzEquiv f =ᵐ[volume] schwartzEquiv g) : f = g :=
   (EmbeddingLike.apply_eq_iff_eq _).mp (SetLike.coe_eq_coe.mp (ext_iff.mpr h))
+
+end
+
+/-!
+## B. Bounded Schwartz submodule
+-/
+
+section
+
+/-- The submodule of Schwartz maps which are bounded by `Cₖ‖x‖ᵏ` for all `(k : ℕ) ≤ a`. -/
+def bddSchwartzMap (d : ℕ) (a : ℕ∞) : Submodule ℂ 𝓢(Space d, ℂ) where
+  carrier := {f : 𝓢(Space d, ℂ) |
+    ∀ k : ℕ, k ≤ a → ∃ C : ℝ, 0 < C ∧ ∀ x : Space d, ‖x‖ ^ (-k : ℤ) * ‖f x‖ ≤ C}
+  add_mem' := by
+    intro f g hf hg k hk
+    obtain ⟨C₁, hC₁_pos, hC₁⟩ := hf k hk
+    obtain ⟨C₂, hC₂_pos, hC₂⟩ := hg k hk
+    refine ⟨C₁ + C₂, by positivity, fun x ↦ ?_⟩
+    refine le_trans ?_ (add_le_add (hC₁ x) (hC₂ x))
+    rw [← mul_add]
+    exact mul_le_mul_of_nonneg_left (norm_add_le (f x) (g x)) (by positivity)
+  zero_mem' := fun _ _ ↦ ⟨1, by simp⟩
+  smul_mem' := by
+    intro c f hf k hk
+    obtain ⟨C, hC_pos, hC⟩ := hf k hk
+    refine ⟨(1 + ‖c‖) * C, by positivity, fun x ↦ ?_⟩
+    rw [smul_apply, norm_smul, mul_rotate', mul_comm ‖f x‖]
+    exact le_trans (mul_le_mul_of_nonneg_left (hC x) (norm_nonneg c)) (by linarith)
+
+lemma bddSchwartzMap_zero_eq_top (d : ℕ) : bddSchwartzMap d 0 = ⊤ := by
+  ext f
+  have := f.decay 0 0
+  simp_all [bddSchwartzMap]
+
+lemma bddSchwartzMap_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
+    bddSchwartzMap d b ≤ bddSchwartzMap d a := fun _ hx k hk ↦ hx k (hk.trans h)
+
+end
 
 end
 end SpaceDHilbertSpace

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -7,41 +7,20 @@ module
 
 public import Mathlib.Analysis.Distribution.SchwartzSpace.Basic
 public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.Basic
-public import Physlib.Meta.Linters.Sorry
 /-!
 
-# Schwartz submodules
+# Schwartz submodule
 
 ## i. Overview
 
 In this module we define the Schwartz submodule of `SpaceDHilbertSpace`.
 
-We also define, for each `a : ℕ∞`, a variant corresponding to Schwartz maps `f` satisfying
-the polynomial growth bounds `‖x‖ ^ (-k) * ‖f x‖ ≤ Cₖ` for each `(k : ℕ) ≤ a`. In particular,
-for `a = ⊤` such a bound holds for all natural numbers. These serve as a natural domain
-for singular unbounded operators such as the `1/r` Coulomb potential acting on `SpaceDHilbertSpace`.
-
-Note: the condition defining polynomially-bounded Schwartz maps is phrased as
-`‖x‖ ^ (-k) * ‖f x‖ ≤ Cₖ` rather than as `‖f x‖ ≤ Cₖ * ‖x‖ ^ k` to mirror `SchwartzMap.decay`.
-These two conditions only differ at `x = 0` and are therefore equivalent for `d > 0` since
-then `f 0` may be determined by continuity. For `d = 0` the former does not constrain `f 0 = 0`
-(since `x = 0` is the only point and `0⁻¹ = 0`) while the latter does (and would therefore spoil
-their being dense in `SpaceDHilbertSpace 0 ≅ ℂ`).
-
 ## ii. Key results
 
 - `schwartzSubmodule d`: Submodule of `SpaceDHilbertSpace d` consisting of the L² equivalence
   classes of Schwartz maps `𝓢(Space d, ℂ)`.
-- `polyBddSchwartzSubmodule d (a : ℕ∞)`: Restriction of `schwartzSubmodule d` to those Schwartz maps
-  which are bounded by powers of `‖x‖`.
 
 ## iii. Table of contents
-
-- A. Schwartz submodule
-- B. Polynomially-bounded Schwartz submodule
-  - B.1. Definitions
-  - B.2. (In)equalities
-  - B.3. Density
 
 ## iv. References
 
@@ -108,95 +87,6 @@ lemma schwartzEquiv_ae_eq (h : schwartzEquiv f =ᵐ[volume] schwartzEquiv g) : f
 
 lemma schwartzIncl_ker : schwartzIncl.ker = (⊥ : Submodule ℂ 𝓢(Space d, ℂ)) := by
   ext; simp [← schwartzEquiv_apply_coe]
-
-end
-
-/-!
-## B. Polynomially-bounded Schwartz submodule
--/
-
-noncomputable section
-
-/-!
-### B.1. Definitions
--/
-
-/-- A function is a bounded Schwartz map if it is both Schwartz and bounded by powers of `‖x‖`. -/
-def polyBddSchwartzMap (d : ℕ) (a : ℕ∞) : Submodule ℂ 𝓢(Space d, ℂ) where
-  carrier := {f : 𝓢(Space d, ℂ) |
-    ∀ k : ℕ, k ≤ a → ∃ C : ℝ, 0 < C ∧ ∀ x : Space d, ‖x‖ ^ (-k : ℤ) * ‖f x‖ ≤ C}
-  add_mem' := by
-    intro f g hf hg k hk
-    obtain ⟨C₁, hC₁_pos, hC₁⟩ := hf k hk
-    obtain ⟨C₂, hC₂_pos, hC₂⟩ := hg k hk
-    refine ⟨C₁ + C₂, by positivity, fun x ↦ ?_⟩
-    refine le_trans ?_ (add_le_add (hC₁ x) (hC₂ x))
-    rw [← mul_add]
-    exact mul_le_mul_of_nonneg_left (norm_add_le (f x) (g x)) (by positivity)
-  zero_mem' := fun _ _ ↦ ⟨1, by simp⟩
-  smul_mem' := by
-    intro c f hf k hk
-    obtain ⟨C, hC_pos, hC⟩ := hf k hk
-    refine ⟨(1 + ‖c‖) * C, by positivity, fun x ↦ ?_⟩
-    rw [smul_apply, norm_smul, mul_rotate', mul_comm ‖f x‖]
-    exact le_trans (mul_le_mul_of_nonneg_left (hC x) (norm_nonneg c)) (by linarith)
-
-/-- The continuous linear map `schwartzIncl` with domain restricted to `polyBddSchwartzMap d a`. -/
-def polyBddSchwartzIncl {d : ℕ} {a : ℕ∞} : polyBddSchwartzMap d a →L[ℂ] SpaceDHilbertSpace d :=
-  ⟨schwartzIncl.domRestrict (polyBddSchwartzMap d a),
-    schwartzIncl.continuous_domRestrict schwartzIncl.continuous _⟩
-
-/-- The submodule of `SpaceDHilbertSpace d` corresponding to bounded Schwartz maps. -/
-abbrev polyBddSchwartzSubmodule (d : ℕ) (a : ℕ∞) : Submodule ℂ (SpaceDHilbertSpace d) :=
-  (polyBddSchwartzIncl (a := a)).range
-
-lemma polyBddSchwartzIncl_injective (d : ℕ) (a : ℕ∞) :
-    Function.Injective (polyBddSchwartzIncl (d := d) (a := a)) :=
-  LinearMap.injective_domRestrict_iff.mpr <| schwartzIncl_ker.symm ▸ inf_bot_eq _
-
-/-- The linear equivalence between polynomially-bounded Schwartz maps and the corresponding
-  submodule of the Hilbert space. -/
-def polyBddSchwartzEquiv {d : ℕ} {a : ℕ∞} :
-    polyBddSchwartzMap d a ≃ₗ[ℂ] polyBddSchwartzSubmodule d a :=
-  LinearEquiv.ofInjective polyBddSchwartzIncl.toLinearMap (polyBddSchwartzIncl_injective d a)
-
-/-!
-### B.2. (In)equalities
--/
-
-lemma polyBddSchwartzMap_zero_eq_top (d : ℕ) : polyBddSchwartzMap d 0 = ⊤ := by
-  ext f
-  have := f.decay 0 0
-  simp_all [polyBddSchwartzMap]
-
-lemma polyBddSchwartzMap_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
-    polyBddSchwartzMap d b ≤ polyBddSchwartzMap d a := fun _ hx k hk ↦ hx k (hk.trans h)
-
-lemma polyBddSchwartzSubmodule_zero_eq (d : ℕ) :
-    polyBddSchwartzSubmodule d 0 = schwartzSubmodule d := by
-  simp [polyBddSchwartzSubmodule, polyBddSchwartzIncl, polyBddSchwartzMap_zero_eq_top]
-
-lemma polyBddSchwartzSubmodule_le (d : ℕ) (a : ℕ∞) :
-    polyBddSchwartzSubmodule d a ≤ schwartzSubmodule d := LinearMap.range_domRestrict_le_range _ _
-
-lemma polyBddSchwartzSubmodule_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
-    polyBddSchwartzSubmodule d b ≤ polyBddSchwartzSubmodule d a := by
-  simp only [polyBddSchwartzSubmodule, polyBddSchwartzIncl, LinearMap.range_domRestrict]
-  exact Submodule.map_mono (polyBddSchwartzMap_le_of_ge d h)
-
-/-!
-### B.3. Density
--/
-
-@[sorryful]
-lemma polyBddSchwartzSubmodule_top_dense (d : ℕ) :
-    Dense (polyBddSchwartzSubmodule d ⊤ : Set (SpaceDHilbertSpace d)) :=
-  sorry
-
-@[sorryful]
-lemma polyBddSchwartzSubmodule_dense (d : ℕ) (a : ℕ∞) :
-    Dense (polyBddSchwartzSubmodule d a : Set (SpaceDHilbertSpace d)) :=
-  (polyBddSchwartzSubmodule_top_dense d).mono (polyBddSchwartzSubmodule_le_of_ge d le_top)
 
 end
 

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -141,9 +141,10 @@ def polyBddSchwartzMap (d : ℕ) (a : ℕ∞) : Submodule ℂ 𝓢(Space d, ℂ)
     rw [smul_apply, norm_smul, mul_rotate', mul_comm ‖f x‖]
     exact le_trans (mul_le_mul_of_nonneg_left (hC x) (norm_nonneg c)) (by linarith)
 
-/-- The linear map `schwartzIncl` with domain restricted to `polyBddSchwartzMap d a`. -/
-def polyBddSchwartzIncl {d : ℕ} {a : ℕ∞} : polyBddSchwartzMap d a →ₗ[ℂ] SpaceDHilbertSpace d :=
-  schwartzIncl.domRestrict (polyBddSchwartzMap d a)
+/-- The continuous linear map `schwartzIncl` with domain restricted to `polyBddSchwartzMap d a`. -/
+def polyBddSchwartzIncl {d : ℕ} {a : ℕ∞} : polyBddSchwartzMap d a →L[ℂ] SpaceDHilbertSpace d :=
+  ⟨schwartzIncl.domRestrict (polyBddSchwartzMap d a),
+    schwartzIncl.continuous_domRestrict schwartzIncl.continuous _⟩
 
 /-- The submodule of `SpaceDHilbertSpace d` corresponding to bounded Schwartz maps. -/
 abbrev polyBddSchwartzSubmodule (d : ℕ) (a : ℕ∞) : Submodule ℂ (SpaceDHilbertSpace d) :=
@@ -157,7 +158,7 @@ lemma polyBddSchwartzIncl_injective (d : ℕ) (a : ℕ∞) :
   submodule of the Hilbert space. -/
 def polyBddSchwartzEquiv {d : ℕ} {a : ℕ∞} :
     polyBddSchwartzMap d a ≃ₗ[ℂ] polyBddSchwartzSubmodule d a :=
-  LinearEquiv.ofInjective polyBddSchwartzIncl (polyBddSchwartzIncl_injective d a)
+  LinearEquiv.ofInjective polyBddSchwartzIncl.toLinearMap (polyBddSchwartzIncl_injective d a)
 
 /-!
 ### B.2. (In)equalities

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Distribution.SchwartzSpace.Basic
 public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.Basic
+public import Physlib.Meta.Linters.Sorry
 /-!
 
 # Schwartz submodules
@@ -186,10 +187,12 @@ lemma polyBddSchwartzSubmodule_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
 ### B.3. Density
 -/
 
+@[sorryful]
 lemma polyBddSchwartzSubmodule_top_dense (d : ℕ) :
     Dense (polyBddSchwartzSubmodule d ⊤ : Set (SpaceDHilbertSpace d)) :=
   sorry
 
+@[sorryful]
 lemma polyBddSchwartzSubmodule_dense (d : ℕ) (a : ℕ∞) :
     Dense (polyBddSchwartzSubmodule d a : Set (SpaceDHilbertSpace d)) :=
   (polyBddSchwartzSubmodule_top_dense d).mono (polyBddSchwartzSubmodule_le_of_ge d le_top)

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -9,7 +9,40 @@ public import Mathlib.Analysis.Distribution.SchwartzSpace.Basic
 public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.Basic
 /-!
 
-# Schwartz submodule of the Hilbert space
+# Schwartz submodules
+
+## i. Overview
+
+In this module we define the Schwartz submodule of `SpaceDHilbertSpace`.
+
+We also define, for each `a : ℕ∞`, a variant corresponding to Schwartz maps `f` satisfying
+the polynomial growth bounds `‖x‖ ^ (-k) * ‖f x‖ ≤ Cₖ` for each `(k : ℕ) ≤ a`. In particular,
+for `a = ⊤` such a bound holds for all natural numbers. These serve as a natural domain
+for singular unbounded operators such as the `1/r` Coulomb potential acting on `SpaceDHilbertSpace`.
+
+Note: the condition defining polynomially-bounded Schwartz maps is phrased as
+`‖x‖ ^ (-k) * ‖f x‖ ≤ Cₖ` rather than as `‖f x‖ ≤ Cₖ * ‖x‖ ^ k` to mirror `SchwartzMap.decay`.
+These two conditions only differ at `x = 0` and are therefore equivalent for `d > 0` since
+then `f 0` may be determined by continuity. For `d = 0` the former does not constrain `f 0 = 0`
+(since `x = 0` is the only point and `0⁻¹ = 0`) while the latter does (and would therefore spoil
+their being dense in `SpaceDHilbertSpace 0 ≅ ℂ`).
+
+## ii. Key results
+
+- `schwartzSubmodule d`: Submodule of `SpaceDHilbertSpace d` consisting of the L² equivalence
+  classes of Schwartz maps `𝓢(Space d, ℂ)`.
+- `polyBddSchwartzSubmodule d (a : ℕ∞)`: Restriction of `schwartzSubmodule d` to those Schwartz maps
+  which are bounded by powers of `‖x‖`.
+
+## iii. Table of contents
+
+- A. Schwartz submodule
+- B. Polynomially-bounded Schwartz submodule
+  - B.1. Definitions
+  - B.2. (In)equalities
+  - B.3. Density
+
+## iv. References
 
 -/
 
@@ -17,8 +50,6 @@ public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.Basic
 
 namespace QuantumMechanics
 namespace SpaceDHilbertSpace
-
-noncomputable section
 
 open MeasureTheory
 open InnerProductSpace
@@ -28,16 +59,16 @@ open SchwartzMap
 ## A. Schwartz submodule
 -/
 
-section
+noncomputable section
 
 variable {d : ℕ}
 
 set_option backward.isDefEq.respectTransparency false in
-/-- The continuous linear map including Schwartz functions into `SpaceDHilbertSpace d`. -/
+/-- The continuous linear map including Schwartz maps into `SpaceDHilbertSpace d`. -/
 def schwartzIncl : 𝓢(Space d, ℂ) →L[ℂ] SpaceDHilbertSpace d := toLpCLM ℂ (E := Space d) ℂ 2
 
 set_option backward.isDefEq.respectTransparency false in
-/-- The submodule of `SpaceDHilbertSpace d` consisting of Schwartz functions. -/
+/-- The submodule of `SpaceDHilbertSpace d` corresponding to Schwartz maps. -/
 abbrev schwartzSubmodule (d : ℕ) := (schwartzIncl (d := d)).range
 
 instance : CoeFun (schwartzSubmodule d) fun _ ↦ Space d → ℂ := ⟨fun ψ ↦ ψ.val⟩
@@ -50,8 +81,8 @@ lemma schwartzSubmodule_dense (d : ℕ) :
   denseRange_toLpCLM ENNReal.top_ne_ofNat.symm
 
 set_option backward.isDefEq.respectTransparency false in
-/-- The linear equivalence between the Schwartz functions `𝓢(Space d, ℂ)`
-  and the Schwartz submodule of `SpaceDHilbertSpace d`. -/
+/-- The linear equivalence between the Schwartz maps `𝓢(Space d, ℂ)` and the Schwartz submodule
+  of `SpaceDHilbertSpace d`. -/
 def schwartzEquiv : 𝓢(Space d, ℂ) ≃ₗ[ℂ] schwartzSubmodule d :=
   LinearEquiv.ofInjective schwartzIncl.toLinearMap (injective_toLp (E := Space d) 2)
 
@@ -74,20 +105,23 @@ lemma schwartzEquiv_inner :
 lemma schwartzEquiv_ae_eq (h : schwartzEquiv f =ᵐ[volume] schwartzEquiv g) : f = g :=
   (EmbeddingLike.apply_eq_iff_eq _).mp (SetLike.coe_eq_coe.mp (ext_iff.mpr h))
 
+lemma schwartzIncl_ker : schwartzIncl.ker = (⊥ : Submodule ℂ 𝓢(Space d, ℂ)) := by
+  ext; simp [← schwartzEquiv_apply_coe]
+
 end
 
 /-!
-## B. Bounded Schwartz submodule
+## B. Polynomially-bounded Schwartz submodule
 -/
 
-section
+noncomputable section
 
 /-!
 ### B.1. Definitions
 -/
 
-/-- The submodule of Schwartz maps which are bounded by `Cₖ‖x‖ᵏ` for all `(k : ℕ) ≤ a`. -/
-def bddSchwartzMap (d : ℕ) (a : ℕ∞) : Submodule ℂ 𝓢(Space d, ℂ) where
+/-- A function is a bounded Schwartz map if it is both Schwartz and bounded by powers of `‖x‖`. -/
+def polyBddSchwartzMap (d : ℕ) (a : ℕ∞) : Submodule ℂ 𝓢(Space d, ℂ) where
   carrier := {f : 𝓢(Space d, ℂ) |
     ∀ k : ℕ, k ≤ a → ∃ C : ℝ, 0 < C ∧ ∀ x : Space d, ‖x‖ ^ (-k : ℤ) * ‖f x‖ ≤ C}
   add_mem' := by
@@ -106,50 +140,52 @@ def bddSchwartzMap (d : ℕ) (a : ℕ∞) : Submodule ℂ 𝓢(Space d, ℂ) whe
     rw [smul_apply, norm_smul, mul_rotate', mul_comm ‖f x‖]
     exact le_trans (mul_le_mul_of_nonneg_left (hC x) (norm_nonneg c)) (by linarith)
 
-lemma bddSchwartzMap_zero_eq_top (d : ℕ) : bddSchwartzMap d 0 = ⊤ := by
-  ext f
-  have := f.decay 0 0
-  simp_all [bddSchwartzMap]
+/-- The linear map `schwartzIncl` with domain restricted to `polyBddSchwartzMap d a`. -/
+def polyBddSchwartzIncl {d : ℕ} {a : ℕ∞} : polyBddSchwartzMap d a →ₗ[ℂ] SpaceDHilbertSpace d :=
+  schwartzIncl.domRestrict (polyBddSchwartzMap d a)
 
-lemma bddSchwartzMap_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
-    bddSchwartzMap d b ≤ bddSchwartzMap d a := fun _ hx k hk ↦ hx k (hk.trans h)
+/-- The submodule of `SpaceDHilbertSpace d` corresponding to bounded Schwartz maps. -/
+abbrev polyBddSchwartzSubmodule (d : ℕ) (a : ℕ∞) : Submodule ℂ (SpaceDHilbertSpace d) :=
+  (polyBddSchwartzIncl (a := a)).range
 
-/-- The linear map including `bddSchwartzMap d a` into the Hilbert space. -/
-def bddSchwartzIncl (d : ℕ) (a : ℕ∞) : bddSchwartzMap d a →ₗ[ℂ] SpaceDHilbertSpace d :=
-  schwartzIncl.domRestrict (bddSchwartzMap d a)
+lemma polyBddSchwartzIncl_injective (d : ℕ) (a : ℕ∞) :
+    Function.Injective (polyBddSchwartzIncl (d := d) (a := a)) :=
+  LinearMap.injective_domRestrict_iff.mpr <| schwartzIncl_ker.symm ▸ inf_bot_eq _
 
-/-- The submodule of `SpaceDHilbertSpace d` consisting of Schwartz functions which are bounded
-  by `Cₖ‖x‖ᵏ` for all `(k : ℕ) ≤ a`. -/
-abbrev bddSchwartzSubmodule (d : ℕ) (a : ℕ∞) : Submodule ℂ (SpaceDHilbertSpace d) :=
-  (bddSchwartzIncl d a).range
-
-lemma bddSchwartzIncl_injective (d : ℕ) (a : ℕ∞) : Function.Injective (bddSchwartzIncl d a) := by
-  apply LinearMap.injective_domRestrict_iff.mpr
-  have h : (schwartzIncl (d := d)).toLinearMap.ker = ⊥ := by ext; simp [← schwartzEquiv_apply_coe]
-  exact h.symm ▸ inf_bot_eq _
-
-/-- The linear equivalence between `bddSchwartzMap d a` and the bounded Schwartz submodule
-  of `SpaceDHilbertSpace d`. -/
-def bddSchwartzEquiv {d : ℕ} {a : ℕ∞} : bddSchwartzMap d a ≃ₗ[ℂ] bddSchwartzSubmodule d a :=
-  LinearEquiv.ofInjective (bddSchwartzIncl d a) (bddSchwartzIncl_injective d a)
+/-- The linear equivalence between polynomially-bounded Schwartz maps and the corresponding
+  submodule of the Hilbert space. -/
+def polyBddSchwartzEquiv {d : ℕ} {a : ℕ∞} :
+    polyBddSchwartzMap d a ≃ₗ[ℂ] polyBddSchwartzSubmodule d a :=
+  LinearEquiv.ofInjective polyBddSchwartzIncl (polyBddSchwartzIncl_injective d a)
 
 /-!
 ### B.2. (In)equalities
 -/
 
-lemma bddSchwartzSubmodule_zero_eq (d : ℕ) : bddSchwartzSubmodule d 0 = schwartzSubmodule d := by
-  simp [bddSchwartzSubmodule, bddSchwartzIncl, bddSchwartzMap_zero_eq_top d]
+lemma polyBddSchwartzMap_zero_eq_top (d : ℕ) : polyBddSchwartzMap d 0 = ⊤ := by
+  ext f
+  have := f.decay 0 0
+  simp_all [polyBddSchwartzMap]
 
-lemma bddSchwartzSubmodule_le (d : ℕ) (a : ℕ∞) : bddSchwartzSubmodule d a ≤ schwartzSubmodule d :=
-  LinearMap.range_domRestrict_le_range _ _
+lemma polyBddSchwartzMap_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
+    polyBddSchwartzMap d b ≤ polyBddSchwartzMap d a := fun _ hx k hk ↦ hx k (hk.trans h)
 
-lemma bddSchwartzSubmodule_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
-    bddSchwartzSubmodule d b ≤ bddSchwartzSubmodule d a := by
-  simp only [bddSchwartzSubmodule, bddSchwartzIncl, LinearMap.range_domRestrict]
-  exact Submodule.map_mono (bddSchwartzMap_le_of_ge d h)
+lemma polyBddSchwartzSubmodule_zero_eq (d : ℕ) :
+    polyBddSchwartzSubmodule d 0 = schwartzSubmodule d := by
+  simp [polyBddSchwartzSubmodule, polyBddSchwartzIncl, polyBddSchwartzMap_zero_eq_top]
+
+lemma polyBddSchwartzSubmodule_le (d : ℕ) (a : ℕ∞) :
+    polyBddSchwartzSubmodule d a ≤ schwartzSubmodule d := LinearMap.range_domRestrict_le_range _ _
+
+lemma polyBddSchwartzSubmodule_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
+    polyBddSchwartzSubmodule d b ≤ polyBddSchwartzSubmodule d a := by
+  simp only [polyBddSchwartzSubmodule, polyBddSchwartzIncl, LinearMap.range_domRestrict]
+  exact Submodule.map_mono (polyBddSchwartzMap_le_of_ge d h)
 
 end
 
 end
+end
+
 end SpaceDHilbertSpace
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -82,6 +82,10 @@ end
 
 section
 
+/-!
+### B.1. Definitions
+-/
+
 /-- The submodule of Schwartz maps which are bounded by `Cₖ‖x‖ᵏ` for all `(k : ℕ) ≤ a`. -/
 def bddSchwartzMap (d : ℕ) (a : ℕ∞) : Submodule ℂ 𝓢(Space d, ℂ) where
   carrier := {f : 𝓢(Space d, ℂ) |
@@ -109,6 +113,25 @@ lemma bddSchwartzMap_zero_eq_top (d : ℕ) : bddSchwartzMap d 0 = ⊤ := by
 
 lemma bddSchwartzMap_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
     bddSchwartzMap d b ≤ bddSchwartzMap d a := fun _ hx k hk ↦ hx k (hk.trans h)
+
+/-- The linear map including `bddSchwartzMap d a` into the Hilbert space. -/
+def bddSchwartzIncl (d : ℕ) (a : ℕ∞) : bddSchwartzMap d a →ₗ[ℂ] SpaceDHilbertSpace d :=
+  schwartzIncl.domRestrict (bddSchwartzMap d a)
+
+/-- The submodule of `SpaceDHilbertSpace d` consisting of Schwartz functions which are bounded
+  by `Cₖ‖x‖ᵏ` for all `(k : ℕ) ≤ a`. -/
+abbrev bddSchwartzSubmodule (d : ℕ) (a : ℕ∞) : Submodule ℂ (SpaceDHilbertSpace d) :=
+  (bddSchwartzIncl d a).range
+
+lemma bddSchwartzIncl_injective (d : ℕ) (a : ℕ∞) : Function.Injective (bddSchwartzIncl d a) := by
+  apply LinearMap.injective_domRestrict_iff.mpr
+  have h : (schwartzIncl (d := d)).toLinearMap.ker = ⊥ := by ext; simp [← schwartzEquiv_apply_coe]
+  exact h.symm ▸ inf_bot_eq _
+
+/-- The linear equivalence between `bddSchwartzMap d a` and the bounded Schwartz submodule
+  of `SpaceDHilbertSpace d`. -/
+def bddSchwartzEquiv {d : ℕ} {a : ℕ∞} : bddSchwartzMap d a ≃ₗ[ℂ] bddSchwartzSubmodule d a :=
+  LinearEquiv.ofInjective (bddSchwartzIncl d a) (bddSchwartzIncl_injective d a)
 
 end
 

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -133,6 +133,21 @@ lemma bddSchwartzIncl_injective (d : ℕ) (a : ℕ∞) : Function.Injective (bdd
 def bddSchwartzEquiv {d : ℕ} {a : ℕ∞} : bddSchwartzMap d a ≃ₗ[ℂ] bddSchwartzSubmodule d a :=
   LinearEquiv.ofInjective (bddSchwartzIncl d a) (bddSchwartzIncl_injective d a)
 
+/-!
+### B.2. (In)equalities
+-/
+
+lemma bddSchwartzSubmodule_zero_eq (d : ℕ) : bddSchwartzSubmodule d 0 = schwartzSubmodule d := by
+  simp [bddSchwartzSubmodule, bddSchwartzIncl, bddSchwartzMap_zero_eq_top d]
+
+lemma bddSchwartzSubmodule_le (d : ℕ) (a : ℕ∞) : bddSchwartzSubmodule d a ≤ schwartzSubmodule d :=
+  LinearMap.range_domRestrict_le_range _ _
+
+lemma bddSchwartzSubmodule_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
+    bddSchwartzSubmodule d b ≤ bddSchwartzSubmodule d a := by
+  simp only [bddSchwartzSubmodule, bddSchwartzIncl, LinearMap.range_domRestrict]
+  exact Submodule.map_mono (bddSchwartzMap_le_of_ge d h)
+
 end
 
 end

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -182,9 +182,18 @@ lemma polyBddSchwartzSubmodule_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
   simp only [polyBddSchwartzSubmodule, polyBddSchwartzIncl, LinearMap.range_domRestrict]
   exact Submodule.map_mono (polyBddSchwartzMap_le_of_ge d h)
 
-end
+/-!
+### B.3. Density
+-/
 
-end
+lemma polyBddSchwartzSubmodule_top_dense (d : ℕ) :
+    Dense (polyBddSchwartzSubmodule d ⊤ : Set (SpaceDHilbertSpace d)) :=
+  sorry
+
+lemma polyBddSchwartzSubmodule_dense (d : ℕ) (a : ℕ∞) :
+    Dense (polyBddSchwartzSubmodule d a : Set (SpaceDHilbertSpace d)) :=
+  (polyBddSchwartzSubmodule_top_dense d).mono (polyBddSchwartzSubmodule_le_of_ge d le_top)
+
 end
 
 end SpaceDHilbertSpace


### PR DESCRIPTION
Defines polynomially-bounded Schwartz maps and the corresponding submodule in the Hilbert space.
These are Schwartz maps with the decay bounds `‖x‖ ^ k * ‖f x‖ ≤ C` extended to negative values for `k` (up to some threshold), although phrased in terms of (extended) natural numbers rather than integers.

The proof that these submodules are dense in `SpaceDHilbertSpace` is a bit involved and I have split it off into a separate PR.