### PR TITLE
fix: Initial Commit for Orbital Mechanics, Vis Viva Version 2

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -10,6 +10,7 @@ public import Physlib.ClassicalMechanics.HarmonicOscillator.ConfigurationSpace
 public import Physlib.ClassicalMechanics.HarmonicOscillator.Solution
 public import Physlib.ClassicalMechanics.Lagrangian.TotalDerivativeEquivalence
 public import Physlib.ClassicalMechanics.Mass.MassUnit
+public import Physlib.ClassicalMechanics.OrbitalMechanics.VisViva
 public import Physlib.ClassicalMechanics.Pendulum.CoplanarDoublePendulum
 public import Physlib.ClassicalMechanics.Pendulum.MiscellaneousPendulumPivotMotions
 public import Physlib.ClassicalMechanics.Pendulum.SlidingPendulum

--- a/Physlib/ClassicalMechanics/OrbitalMechanics/VisViva.lean
+++ b/Physlib/ClassicalMechanics/OrbitalMechanics/VisViva.lean
@@ -42,8 +42,8 @@ noncomputable def speedCircular (sys : VisViva) (cfg : ConfigurationSpace) : ℝ
   Real.sqrt (sys.G * sys.M / cfg.r)
 
 /-- Lemma: the square of the circular orbit speed equals G M / r. -/
-lemma speedCircular_sq (sys : VisViva) (cfg : ConfigurationSpace) (hr : cfg.r > 0) (hG : sys.G > 0)
-    (hM : sys.M > 0) :
+lemma speedCircular_sq (sys : VisViva) (cfg : ConfigurationSpace) (hr : 0 < cfg.r) (hG : 0 < sys.G)
+    (hM : 0 < sys.M) :
     (speedCircular sys cfg)^2 = sys.G * sys.M / cfg.r := by
   simp [speedCircular]
   apply Real.sq_sqrt

--- a/Physlib/ClassicalMechanics/OrbitalMechanics/VisViva.lean
+++ b/Physlib/ClassicalMechanics/OrbitalMechanics/VisViva.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2026 Hannah Dawe. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Hannah Dawe
+-/
+
+module
+
+public import Mathlib.Data.Real.Basic
+public import Mathlib.Data.Real.Sqrt
+
+/-!
+# Circular Orbit Vis Viva
+Defines the orbital speed for a circular orbit (v^2 = G M / r).
+-/
+
+@[expose] public section
+
+namespace ClassicalMechanics
+
+structure VisViva where
+  G : ℝ      -- gravitational constant
+  M : ℝ      -- central mass body
+  m : ℝ      -- orbiting mass body # for later usage
+
+namespace VisViva
+
+structure ConfigurationSpace where
+  r : ℝ      -- radius
+
+/-- Orbital speed for a circular orbit. -/
+noncomputable def speedCircular (sys : VisViva) (cfg : ConfigurationSpace) : ℝ :=
+  Real.sqrt (sys.G * sys.M / cfg.r)
+
+/-- Lemma: the square of the circular orbit speed equals G M / r. -/
+lemma speedCircular_sq (sys : VisViva) (cfg : ConfigurationSpace) (hr : cfg.r > 0) (hG : sys.G > 0) (hM : sys.M > 0) :
+    (speedCircular sys cfg)^2 = sys.G * sys.M / cfg.r := by
+  simp [speedCircular]
+  apply Real.sq_sqrt
+  positivity
+
+end VisViva
+end ClassicalMechanics

--- a/Physlib/ClassicalMechanics/OrbitalMechanics/VisViva.lean
+++ b/Physlib/ClassicalMechanics/OrbitalMechanics/VisViva.lean
@@ -11,29 +11,39 @@ public import Mathlib.Data.Real.Sqrt
 
 /-!
 # Circular Orbit Vis Viva
-Defines the orbital speed for a circular orbit (v^2 = G M / r).
+The vis-viva equation relates the speed of an orbiting body to its position
+and the mass of the central body. This module defines a simplified version of the
+vis-viva equation that is restricted to circular orbits (v^2 = G M / r).
 -/
+
 
 @[expose] public section
 
 namespace ClassicalMechanics
 
+/-- System parameters for the vis-viva equation in circular orbital mechanics. -/
 structure VisViva where
-  G : ℝ      -- gravitational constant
-  M : ℝ      -- central mass body
-  m : ℝ      -- orbiting mass body # for later usage
+  /-- Gravitational constant. -/
+  G : ℝ
+  /-- Central mass body. -/
+  M : ℝ
+  /-- Orbiting mass body. -/
+  m : ℝ
 
 namespace VisViva
 
+/-- Configuration space for orbital mechanics, defining the orbital radius. -/
 structure ConfigurationSpace where
-  r : ℝ      -- radius
+  /-- Orbital radius. -/
+  r : ℝ
 
-/-- Orbital speed for a circular orbit. -/
+/-- The orbital speed required for a circular orbit at radius `r`. -/
 noncomputable def speedCircular (sys : VisViva) (cfg : ConfigurationSpace) : ℝ :=
   Real.sqrt (sys.G * sys.M / cfg.r)
 
 /-- Lemma: the square of the circular orbit speed equals G M / r. -/
-lemma speedCircular_sq (sys : VisViva) (cfg : ConfigurationSpace) (hr : cfg.r > 0) (hG : sys.G > 0) (hM : sys.M > 0) :
+lemma speedCircular_sq (sys : VisViva) (cfg : ConfigurationSpace) (hr : cfg.r > 0) (hG : sys.G > 0)
+    (hM : sys.M > 0) :
     (speedCircular sys cfg)^2 = sys.G * sys.M / cfg.r := by
   simp [speedCircular]
   apply Real.sq_sqrt


### PR DESCRIPTION
New PR for 'initial commit for orbital mechanics' since the large PhysLean to Physlib updates from March. Updated to reflect the new version of the project, and `lake build` compiles successfully. 