### PR TITLE
refactor: TODO item hashes

### DIFF
--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -66,17 +66,17 @@ open Real
 open ContDiff
 open Time
 
-TODO "DHO05" "Derive solutions for the underdamped case (oscillatory with exponential decay)."
+TODO "Derive solutions for the underdamped case (oscillatory with exponential decay)."
 
-TODO "DHO06" "Derive solutions for the critically damped case (fastest non-oscillatory return)."
+TODO "Derive solutions for the critically damped case (fastest non-oscillatory return)."
 
-TODO "DHO07" "Derive solutions for the overdamped case (slow non-oscillatory return)."
+TODO "Derive solutions for the overdamped case (slow non-oscillatory return)."
 
-TODO "DHO08" "Define and prove properties of the quality factor Q."
+TODO "Define and prove properties of the quality factor Q."
 
-TODO "DHO09" "Define and prove properties of the relaxation time τ."
+TODO "Define and prove properties of the relaxation time τ."
 
-TODO "DHO10" "Prove that the damped harmonic oscillator reduces to the undamped case when γ = 0."
+TODO "Prove that the damped harmonic oscillator reduces to the undamped case when γ = 0."
 
 /-!
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -95,9 +95,9 @@ open Real
 open Space
 open InnerProductSpace
 
-TODO "6VZHC" "Create a new folder for the damped harmonic oscillator, initially as a place-holder."
+TODO "Create a new folder for the damped harmonic oscillator, initially as a place-holder."
 
-TODO "4DK2M" "Create a new file for the geometric model which properly models the position as a
+TODO "Create a new file for the geometric model which properly models the position as a
     configuration space and velocity as its tangent space, then show explicitly how this
     coordinate model is a simplification of the geometric model.
     A nice reference for such an analysis is:

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/ConfigurationSpace.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/ConfigurationSpace.lean
@@ -20,10 +20,10 @@ namespace ClassicalMechanics
 
 namespace HarmonicOscillator
 
-TODO "4DLKC" "Configuration Space should be refactored to take `EuclideanSpace ℝ (Fin 1)`
+TODO "Configuration Space should be refactored to take `EuclideanSpace ℝ (Fin 1)`
     as its value."
 
-TODO "4DLL5" "The API around this should be improved to allow further development of a proper
+TODO "The API around this should be improved to allow further development of a proper
     geometric model of the Harmonic Oscillator (see TODO item 4DK2M)."
 
 /-- The configuration space of the harmonic oscillator. -/

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -854,7 +854,7 @@ lemma trajectory_velocity_eq_zero_iff (IC : InitialConditions) (t : Time) :
         _ = (1 / S.m) * (S.m * ‖IC.v₀‖ ^ 2 + S.k * ‖IC.x₀‖ ^ 2
           - S.k * ‖IC.x₀‖ ^ 2 - S.k * (‖IC.v₀‖ / S.ω) ^ 2) := by
           rw [mul_add S.k (‖IC.x₀‖ ^ 2) ((‖IC.v₀‖ /S.ω) ^2)]
-          rw [←sub_sub_sub_eq (S.m * ‖IC.v₀‖ ^ 2) (S.k * ‖IC.x₀‖ ^ 2)
+          rw [← sub_sub_sub_eq (S.m * ‖IC.v₀‖ ^ 2) (S.k * ‖IC.x₀‖ ^ 2)
           (S.k * (‖IC.v₀‖ / S.ω) ^ 2) (S.k * ‖IC.x₀‖ ^ 2)]
           simp only [one_div, sub_sub_sub_cancel_right, add_sub_cancel_right]
         _ = (1 / S.m) * (S.m * ‖IC.v₀‖ ^ 2 - S.k * (‖IC.v₀‖ / S.ω) ^ 2) := by simp

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -209,7 +209,7 @@ The correctness proofs showing that the conversion produces the expected traject
 are given later in section D.1, after the trajectory machinery has been defined.
 -/
 
-TODO "6VZME" "Implement other initial conditions (deferred to future PRs). For example:
+TODO "Implement other initial conditions (deferred to future PRs). For example:
 - Two positions at different times.
 - Two velocities at different times.
 And convert them into the type `InitialConditions` above."
@@ -880,10 +880,10 @@ We give some open TODOs for the classical harmonic oscillator.
 
 -/
 
-TODO "6VZI3" "For the classical harmonic oscillator find the time for which it returns to
+TODO "For the classical harmonic oscillator find the time for which it returns to
   it's initial position and velocity."
 
-TODO "6VZJB" "For the classical harmonic oscillator find the times for
+TODO "For the classical harmonic oscillator find the times for
   which it passes through zero."
 
 end InitialConditions

--- a/Physlib/ClassicalMechanics/RigidBody/Basic.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Basic.lean
@@ -28,7 +28,7 @@ In this module we will define the basic properties of a rigid body, including
 
 open Manifold
 
-TODO "MEX5S" "The definition of a rigid body is currently defined via linear maps
+TODO "The definition of a rigid body is currently defined via linear maps
   from the space of smooth functions to ℝ. When possible, it should be change
   to *continuous* linear maps. "
 

--- a/Physlib/ClassicalMechanics/Scattering/RigidSphere.lean
+++ b/Physlib/ClassicalMechanics/Scattering/RigidSphere.lean
@@ -17,4 +17,4 @@ public import Physlib.Meta.TODO.Basic
 
 @[expose] public section
 
-TODO "L7OTP" "Derive the scattering cross section of a perfectly rigid sphere."
+TODO "Derive the scattering cross section of a perfectly rigid sphere."

--- a/Physlib/ClassicalMechanics/Vibrations/LinearTriatomic.lean
+++ b/Physlib/ClassicalMechanics/Vibrations/LinearTriatomic.lean
@@ -17,4 +17,4 @@ public import Physlib.Meta.TODO.Basic
 
 @[expose] public section
 
-TODO "L7O4I" "Derive the frequencies of vibaration of a symmetric linear triatomic molecule."
+TODO "Derive the frequencies of vibaration of a symmetric linear triatomic molecule."

--- a/Physlib/ClassicalMechanics/WaveEquation/HarmonicWave.lean
+++ b/Physlib/ClassicalMechanics/WaveEquation/HarmonicWave.lean
@@ -38,7 +38,7 @@ noncomputable def harmonicWave (a g : ℝ → Space d → ℝ) (ω : WaveVector 
     Time → Space d → ℝ :=
     fun t r => a (ω k) r * Real.cos (ω k * t - g (ω k) r)
 
-TODO "EGQUA" "Show that the wave equation is invariant under rotations and any direction `s`
+TODO "Show that the wave equation is invariant under rotations and any direction `s`
     can be rotated to `EuclideanSpace.single 2 1` if only one wave is concerned."
 open InnerProductSpace
 set_option linter.unusedVariables false in
@@ -75,7 +75,7 @@ lemma transverseHarmonicPlaneWave_eq_planeWave {c : ℝ} {k : WaveVector} {f₀x
   ring_nf
   simp [ne_of_gt, hc_ge_zero, hω_ge_zero, mul_comm ω, mul_assoc, basis_repr_inner_eq]
 
-TODO "EGU3E" "Show that any disturbance (subject to certain conditions) can be expressed
+TODO "Show that any disturbance (subject to certain conditions) can be expressed
     as a superposition of harmonic plane waves via Fourier integral."
 
 end ClassicalMechanics

--- a/Physlib/Electromagnetism/Basic.lean
+++ b/Physlib/Electromagnetism/Basic.lean
@@ -41,7 +41,7 @@ structure EMSystem where
   /-- The permeability of free space. -/
   μ₀ : ℝ
 
-TODO "6V2UZ" "Charge density and current density should be generalized to signed measures,
+TODO "Charge density and current density should be generalized to signed measures,
   in such a way
   that they are still easy to work with and can be integrated with with tensor notation.
   See here:

--- a/Physlib/Electromagnetism/Current/CircularCoil.lean
+++ b/Physlib/Electromagnetism/Current/CircularCoil.lean
@@ -29,7 +29,7 @@ electromagnetic potentials and fields around a circular coil.
 
 @[expose] public section
 
-TODO "TCGIW" "Copying the structure of the electrostatics of an infinite wire,
+TODO "Copying the structure of the electrostatics of an infinite wire,
   complete the definitions and proofs for a circular coil carrying a steady current."
 
 namespace Electromagnetism

--- a/Physlib/Mathematics/Distribution/Basic.lean
+++ b/Physlib/Mathematics/Distribution/Basic.lean
@@ -242,7 +242,7 @@ lemma fderivD_apply [FiniteDimensional ℝ E] (u : E →d[𝕜] F) (η : 𝓢(E,
     fderivD 𝕜 u η v = - u (SchwartzMap.evalCLM (𝕜 := 𝕜) E 𝕜 v (SchwartzMap.fderivCLM 𝕜 E 𝕜 η)) := by
   rfl
 
-TODO "01-09-25-JTS" "For distributions, prove that the derivative fderivD commutes with
+TODO "For distributions, prove that the derivative fderivD commutes with
   integrals and sums. This may require defining the integral of families of distributions
   although it is expected this will follow from the definition of a distribution."
 

--- a/Physlib/Mathematics/LinearMaps.lean
+++ b/Physlib/Mathematics/LinearMaps.lean
@@ -18,7 +18,7 @@ quadratic and cubic equations.
 -/
 
 @[expose] public section
-TODO "6VZLZ" "Replace the definitions in this file with Mathlib definitions."
+TODO "Replace the definitions in this file with Mathlib definitions."
 
 /-- The structure defining a homogeneous quadratic equation. -/
 @[simp]

--- a/Physlib/Meta/TODO/Basic.lean
+++ b/Physlib/Meta/TODO/Basic.lean
@@ -37,15 +37,15 @@ meta initialize todoExtension : SimplePersistentEnvExtension todoInfo (Array tod
   }
 
 /-- Syntax for the `TODO ...` command. -/
-syntax (name := todo_comment) "TODO " str str : command
+syntax (name := todo_comment) "TODO " str : command
 
 /-- Elaborator for the `TODO ...` command -/
 @[command_elab todo_comment]
 meta def elabTODO : Elab.Command.CommandElab := fun stx =>
   match stx with
-  | `(TODO $t $s) => do
+  | `(TODO $s) => do
     let str : String := s.getString
-    let tag : String := t.getString
+    let tag : String := toString (String.hash str)
     let pos := stx.getPos?
     match pos with
     | some pos => do
@@ -56,6 +56,8 @@ meta def elabTODO : Elab.Command.CommandElab := fun stx =>
       let modName := env.mainModule
       let todoInfo : todoInfo := { content := str, fileName := modName, line := line, tag := tag }
       modifyEnv fun env => todoExtension.addEntry env todoInfo
+      Elab.Command.liftTermElabM <| Lean.Elab.Term.addTermInfo' s
+        (Lean.mkStrLit s!"TODO tag: {tag}") (expectedType? := none)
     | none => throwError "Invalid syntax for `TODO` command"
   | _ => throwError "Invalid syntax for `TODO` command"
 

--- a/Physlib/Meta/TransverseTactics.lean
+++ b/Physlib/Meta/TransverseTactics.lean
@@ -79,7 +79,7 @@ def traverseForest (file : FilePath)
 
 end transverseTactics
 
-TODO "6VZEW" "Find a way to free the environment `env` in `transverseTactics`.
+TODO "Find a way to free the environment `env` in `transverseTactics`.
   This leads to memory problems when using `transverseTactics` directly in loops."
 
 open transverseTactics in

--- a/Physlib/Particles/BeyondTheStandardModel/RHN/AnomalyCancellation/Ordinary/DimSevenPlane.lean
+++ b/Physlib/Particles/BeyondTheStandardModel/RHN/AnomalyCancellation/Ordinary/DimSevenPlane.lean
@@ -152,7 +152,7 @@ lemma B₆_cubic (S T : (SM 3).Charges) : cubeTriLin B₆ S T =
     Nat.reduceAdd, one_mul, neg_mul, mul_neg]
   ring_nf
 
-TODO "7SQUT" "Remove the definitions of elements `(SM 3).Charges` B₀, B₁ etc, here are
+TODO "Remove the definitions of elements `(SM 3).Charges` B₀, B₁ etc, here are
   use only `B : Fin 7 → (SM 3).Charges`. "
 /-- The charge assignments forming a basis of the plane. -/
 @[simp]

--- a/Physlib/Particles/StandardModel/Basic.lean
+++ b/Physlib/Particles/StandardModel/Basic.lean
@@ -15,7 +15,7 @@ This file defines the basic properties of the standard model in particle physics
 -/
 
 @[expose] public section
-TODO "6V2FP" "Redefine the gauge group as a quotient of SU(3) x SU(2) x U(1) by a subgroup of ℤ₆."
+TODO "Redefine the gauge group as a quotient of SU(3) x SU(2) x U(1) by a subgroup of ℤ₆."
 
 namespace StandardModel
 

--- a/Physlib/Particles/StandardModel/HiggsBoson/Basic.lean
+++ b/Physlib/Particles/StandardModel/HiggsBoson/Basic.lean
@@ -461,7 +461,7 @@ We define the Higgs bundle.
 
 -/
 
-TODO "6V2IS" "Make `HiggsBundle` an associated bundle."
+TODO "Make `HiggsBundle` an associated bundle."
 
 /-- The `HiggsBundle` is defined as the trivial vector bundle with base `SpaceTime` and
   fiber `HiggsVec`. Thus as a manifold it corresponds to `ℝ⁴ × ℂ²`. -/
@@ -815,9 +815,9 @@ lemma const_normSq (φ : HiggsVec) (x : SpaceTime) :
 The results in this section are currently informal.
 -/
 
-TODO "6V2MV" "Define the global gauge action on HiggsField."
-TODO "6V2M3" "Prove `⟪φ1, φ2⟫_H` invariant under the global gauge action. (norm_map_of_mem_unitary)"
-TODO "6V2NA" "Prove invariance of potential under global gauge action."
+TODO "Define the global gauge action on HiggsField."
+TODO "Prove `⟪φ1, φ2⟫_H` invariant under the global gauge action. (norm_map_of_mem_unitary)"
+TODO "Prove invariance of potential under global gauge action."
 
 /-- The action of `gaugeTransformI` on `HiggsField` acting pointwise through `HiggsVec.rep`. -/
 informal_definition gaugeAction where

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/PhenoClosed.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/PhenoClosed.lean
@@ -386,7 +386,7 @@ lemma completeness_of_isPhenoClosedQ5_isPhenoClosedQ10
 
 -/
 
-TODO "JGVOQ" "Make the result `viableChargesMultiset` a safe definition, that is to
+TODO "Make the result `viableChargesMultiset` a safe definition, that is to
   say proof that the recursion terminates."
 
 /-- All charges, for a given `S5 S10 : Finset 𝓩`,

--- a/Physlib/QFT/AnomalyCancellation/Basic.lean
+++ b/Physlib/QFT/AnomalyCancellation/Basic.lean
@@ -109,7 +109,7 @@ We provide a constructor `ACCSystemChargesMk` for `ACCSystemCharges` given the n
 
 -/
 
-TODO "NCRC5" "Replace `ACCSystemChargesMk` with `⟨n⟩` notation everywhere. "
+TODO "Replace `ACCSystemChargesMk` with `⟨n⟩` notation everywhere. "
 /--
   Creates an `ACCSystemCharges` object with the specified number of charges.
 -/
@@ -595,9 +595,9 @@ formalize this derivation in Lean, and instead take the resulting homogeneous fo
 
 -/
 
-TODO "6VZMW" "Anomaly cancellation conditions can be derived formally from the gauge group
+TODO "Anomaly cancellation conditions can be derived formally from the gauge group
   and fermionic representations using e.g. topological invariants. Include such a
   definition."
 
-TODO "6VZM3" "Anomaly cancellation conditions can be defined using algebraic varieties.
+TODO "Anomaly cancellation conditions can be defined using algebraic varieties.
   Link such an approach to the approach here."

--- a/Physlib/QFT/PerturbationTheory/FieldOpFreeAlgebra/NormalOrder.lean
+++ b/Physlib/QFT/PerturbationTheory/FieldOpFreeAlgebra/NormalOrder.lean
@@ -400,7 +400,7 @@ lemma normalOrderF_ofFieldOpF_mul_ofFieldOpF (φ φ' : 𝓕.FieldOp) :
 
 -/
 
-TODO "6V2JJ" "Split the following two lemmas up into smaller parts."
+TODO "Split the following two lemmas up into smaller parts."
 
 set_option backward.isDefEq.respectTransparency false in
 lemma normalOrderF_superCommuteF_ofCrAnListF_create_create_ofCrAnListF

--- a/Physlib/QFT/PerturbationTheory/WickAlgebra/Basic.lean
+++ b/Physlib/QFT/PerturbationTheory/WickAlgebra/Basic.lean
@@ -291,7 +291,7 @@ lemma fermionicProjF_mem_fieldOpIdealSet_or_zero (x : FieldOpFreeAlgebra 𝓕)
       rw [fermionicProjF_of_mem_fermionic _ h]
       simpa using hx'
 
-TODO "7ERJ3" "The lemma `bosonicProjF_mem_ideal` has a proof which is really long.
+TODO "The lemma `bosonicProjF_mem_ideal` has a proof which is really long.
   We should either 1) split it up into smaller lemmas or 2) Put more comments into the proof."
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Physlib/QFT/QED/AnomalyCancellation/Basic.lean
+++ b/Physlib/QFT/QED/AnomalyCancellation/Basic.lean
@@ -31,7 +31,7 @@ open Finset
 namespace PureU1
 open BigOperators
 
-TODO "K3HYF" "The implementation of pure U(1) anomaly cancellation conditions is done
+TODO "The implementation of pure U(1) anomaly cancellation conditions is done
   currently through the type `ACCSystemCharges`. This whole directory could be
   simplified by refactoring to remove `ACCSystemCharges` defining `PureU1Charges` as
   `Fin n → ℚ` directly, or this space quotiented by permutations and overall factors."

--- a/Physlib/QFT/QED/AnomalyCancellation/BasisLinear.lean
+++ b/Physlib/QFT/QED/AnomalyCancellation/BasisLinear.lean
@@ -80,7 +80,7 @@ lemma sum_of_vectors {n : ℕ} (f : Fin k → (PureU1 n).LinSols) (j : Fin n) :
     (∑ i : Fin k, (f i)).1 j = (∑ i : Fin k, (f i).1 j) :=
   sum_of_anomaly_free_linear (fun i => f i) j
 
-TODO "6VZO6" "The definition of `coordinateMap` here may be improved by replacing
+TODO "The definition of `coordinateMap` here may be improved by replacing
   `Finsupp.equivFunOnFinite` with `Finsupp.linearEquivFunOnFinite`. Investigate this."
 /-- The coordinate map for the basis. -/
 noncomputable

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -95,7 +95,7 @@ lemma positionOperator_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) : 𝐱 i ψ
 /-!
 ### A.2. Radius powers (regularized)
 -/
-TODO "ZGCNP" "Incorporate normRegularizedPow into Space.Norm"
+TODO "Incorporate normRegularizedPow into Space.Norm"
 
 /-- Power of regularized norm, `(‖x‖² + ε²)^(s/2)`. -/
 def normRegularizedPow (d : ℕ) (ε s : ℝ) : Space d → ℝ :=

--- a/Physlib/QuantumMechanics/FiniteTarget/Basic.lean
+++ b/Physlib/QuantumMechanics/FiniteTarget/Basic.lean
@@ -65,7 +65,7 @@ noncomputable def timeEvolutionMatrixStandard (t : ℝ) :
     let b : Basis (Fin n) ℂ H := Module.finBasisOfFinrankEq ℂ H A.hdim
     (timeEvolutionMatrix A t b)
 
-TODO "6VZGG" "Define a smooth structure on `FiniteTarget`."
+TODO "Define a smooth structure on `FiniteTarget`."
 
 end FiniteTarget
 

--- a/Physlib/Relativity/CliffordAlgebra.lean
+++ b/Physlib/Relativity/CliffordAlgebra.lean
@@ -35,7 +35,7 @@ This file defines the Gamma matrices and their relationship to the Clifford alge
 -/
 
 @[expose] public section
-TODO "6VZF2" "Prove injectivity of ofCliffordAlgebra and construct the full isomorphism."
+TODO "Prove injectivity of ofCliffordAlgebra and construct the full isomorphism."
 namespace spaceTime
 open Complex
 

--- a/Physlib/Relativity/LorentzAlgebra/Basis.lean
+++ b/Physlib/Relativity/LorentzAlgebra/Basis.lean
@@ -39,7 +39,7 @@ block, while rotation generators are antisymmetric matrices acting only on spati
 
 ## Future Work
 
-TODO "6VZKA" can be completed by proving linear independence and spanning of these
+TODO can be completed by proving linear independence and spanning of these
 6 generators, then constructing a formal `Basis (Fin 2 × Fin 3) ℝ lorentzAlgebra`.
 
 -/
@@ -152,16 +152,16 @@ The following properties are documented in the docstrings but not yet formally p
 These should be established in future PRs to complete the characterization of the generators.
 -/
 
-TODO "BOOST_SYM" "Prove that boost generators are symmetric: \
+TODO "Prove that boost generators are symmetric: \
   (boostGenerator i)ᵀ = boostGenerator i"
 
-TODO "BOOST_TRACE" "Prove that boost generators are traceless: \
+TODO "Prove that boost generators are traceless: \
   Matrix.trace (boostGenerator i) = 0"
 
-TODO "ROT_ANTISYM" "Prove that rotation generators are antisymmetric: \
+TODO "Prove that rotation generators are antisymmetric: \
   (rotationGenerator i)ᵀ = -(rotationGenerator i)"
 
-TODO "ROT_TRACE" "Prove that rotation generators are traceless: \
+TODO "Prove that rotation generators are traceless: \
   Matrix.trace (rotationGenerator i) = 0"
 
 end lorentzAlgebra

--- a/Physlib/Relativity/LorentzGroup/Basic.lean
+++ b/Physlib/Relativity/LorentzGroup/Basic.lean
@@ -22,7 +22,7 @@ We define the Lorentz group.
 -/
 
 @[expose] public section
-TODO "6VZHM" "Define the Lie group structure on the Lorentz group."
+TODO "Define the Lie group structure on the Lorentz group."
 
 noncomputable section
 

--- a/Physlib/Relativity/LorentzGroup/Orthochronous/Basic.lean
+++ b/Physlib/Relativity/LorentzGroup/Orthochronous/Basic.lean
@@ -17,7 +17,7 @@ matrices.
 -/
 
 @[expose] public section
-TODO "6VZLO" "Prove topological properties of the Orthochronous Lorentz Group."
+TODO "Prove topological properties of the Orthochronous Lorentz Group."
 
 noncomputable section
 

--- a/Physlib/Relativity/LorentzGroup/Restricted/Basic.lean
+++ b/Physlib/Relativity/LorentzGroup/Restricted/Basic.lean
@@ -16,7 +16,7 @@ This file is currently a stub.
 
 @[expose] public section
 
-TODO "6VZNP" "Prove that every member of the restricted Lorentz group is
+TODO "Prove that every member of the restricted Lorentz group is
   combination of a boost and a rotation."
 
 namespace LorentzGroup

--- a/Physlib/Relativity/Special/TwinParadox/Basic.lean
+++ b/Physlib/Relativity/Special/TwinParadox/Basic.lean
@@ -65,7 +65,7 @@ def properTimeTwinB : ℝ := SpaceTime.properTime T.startPoint T.twinBMid +
 /-- The proper time of twin A minus the proper time of twin B. -/
 def ageGap : ℝ := T.properTimeTwinA - T.properTimeTwinB
 
-TODO "6V2UQ" "Find the conditions for which the age gap for the twin paradox is zero."
+TODO "Find the conditions for which the age gap for the twin paradox is zero."
 
 /-- In the twin paradox with instantaneous acceleration, Twin A is always older
   then Twin B. -/
@@ -141,7 +141,7 @@ lemma example1_ageGap : example1.ageGap = 6 := by
 
 end InstantaneousTwinParadox
 
-TODO "7ROQ4" "Do the twin paradox with a non-instantaneous acceleration. This should be done
+TODO "Do the twin paradox with a non-instantaneous acceleration. This should be done
   in a different module."
 
 end SpecialRelativity

--- a/Physlib/Relativity/Tensors/Basic.lean
+++ b/Physlib/Relativity/Tensors/Basic.lean
@@ -637,7 +637,7 @@ lemma PermCond.comp {n n1 n2 : ℕ} {c : Fin n → C} {c1 : Fin n1 → C}
     simp only [Function.comp_apply]
     rw [h.2, h2.2]
 
-TODO "6VZ3C" "Prove that if `σ` satisfies `PermCond c c1 σ` then `PermCond.inv σ h`
+TODO "Prove that if `σ` satisfies `PermCond c c1 σ` then `PermCond.inv σ h`
   satisfies `PermCond c1 c (PermCond.inv σ h)`."
 
 lemma fin_cast_permCond (n n1 : ℕ) {c : Fin n → C} (h : n1 = n) :

--- a/Physlib/Relativity/Tensors/Contraction/Pure.lean
+++ b/Physlib/Relativity/Tensors/Contraction/Pure.lean
@@ -584,7 +584,7 @@ lemma dropPair_update_dropPairEmb {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))
     · simp [h]
     · simp [h]
 
-TODO "63B7X" "Prove lemmas relating to the commutation rules of `dropPair` and `prodP`."
+TODO "Prove lemmas relating to the commutation rules of `dropPair` and `prodP`."
 
 @[simp]
 lemma dropPair_permP {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}

--- a/Physlib/Relativity/Tensors/Evaluation.lean
+++ b/Physlib/Relativity/Tensors/Evaluation.lean
@@ -135,7 +135,7 @@ lemma evalT_pure {n : ℕ} {c : Fin (n + 1) → C} (i : Fin (n + 1))
   conv_rhs => rw [← PiTensorProduct.lift.tprod]
   rfl
 
-TODO "6VZ6G" "Add lemmas related to the interaction of evalT and permT, prodT and contrT."
+TODO "Add lemmas related to the interaction of evalT and permT, prodT and contrT."
 
 end Tensor
 

--- a/Physlib/SpaceAndTime/Space/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Basic.lean
@@ -76,10 +76,10 @@ the `VAdd (EuclideanSpace ℝ (Fin d)) (Space d)` instance instead.
 
 -/
 
-TODO "HB6RR" "In the above documentation describe the notion of a type, and
+TODO "In the above documentation describe the notion of a type, and
   introduce the type `Space d`."
 
-TODO "HB6VC" "Convert `Space` from an `abbrev` to a `def`."
+TODO "Convert `Space` from an `abbrev` to a `def`."
 
 /-- The type `Space d` is the world-volume which corresponds to
 `d` dimensional (flat) Euclidean space with a given (but arbitrary)

--- a/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
@@ -119,7 +119,7 @@ lemma mdifferentiable_manifoldStructure_iff_differentiable {M d} [NormedAddCommG
     apply (mdifferentiableAt_iff_differentiableAt.mpr h).comp (I' := 𝓘(ℝ, Space d))
     exact (modelDiffeo.mdifferentiable (WithTop.top_ne_zero)).mdifferentiableAt
 
-TODO "3XMN6" "Make the version of the derivative described through
+TODO "Make the version of the derivative described through
   `deriv_eq_mfderiv_manifoldStructure` the definition of `deriv` and prove the
   equivalence with the current definition, under suitable conditions."
 

--- a/Physlib/SpaceAndTime/Space/DistOfFunction.lean
+++ b/Physlib/SpaceAndTime/Space/DistOfFunction.lean
@@ -145,7 +145,7 @@ lemma distOfFunction_inner {d n : ℕ} (f : Space d → EuclideanSpace ℝ (Fin 
   rw [integral_inner, real_inner_comm]
   fun_prop
 
-TODO "LV5RM" "Add a general lemma specifying the derivative of
+TODO "Add a general lemma specifying the derivative of
   functions from distributions."
 
 /-!

--- a/Physlib/SpaceAndTime/Space/LengthUnit.lean
+++ b/Physlib/SpaceAndTime/Space/LengthUnit.lean
@@ -201,7 +201,7 @@ set_option backward.isDefEq.respectTransparency false in
 noncomputable def parsecs : LengthUnit := scale (648000/Real.pi) astronomicalUnits
   (by norm_num; exact Real.pi_pos)
 
-TODO "ITXJV" "For each unit of charge give the reference the literature where it's definition
+TODO "For each unit of charge give the reference the literature where it's definition
   is defined."
 
 /-!

--- a/Physlib/SpaceAndTime/Space/Module.lean
+++ b/Physlib/SpaceAndTime/Space/Module.lean
@@ -290,10 +290,10 @@ noncomputable instance {d : ℕ} : MeasurableSpace (Space d) := borel (Space d)
 instance {d : ℕ} : BorelSpace (Space d) where
   measurable_eq := by rfl
 
-TODO "HB6YZ" "In the above documentation describe what an instance is, and why
+TODO "In the above documentation describe what an instance is, and why
   it is useful to have instances for `Space d`."
 
-TODO "HB6WN" "After TODO 'HB6VC', give `Space d` the necessary instances
+TODO "After TODO 'HB6VC', give `Space d` the necessary instances
   using `inferInstanceAs`."
 /-!
 
@@ -331,7 +331,7 @@ lemma sum_apply {ι : Type} [Fintype ι] (f : ι → Space d) (i : Fin d) :
 
 -/
 
-TODO "HB6Z4" "In the above documentation describe the notion of a basis
+TODO "In the above documentation describe the notion of a basis
   in Lean."
 
 /-- The standard basis of Space based on `Fin d`. -/

--- a/Physlib/SpaceAndTime/SpaceTime/Basic.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Basic.lean
@@ -73,7 +73,7 @@ noncomputable section
 
 -/
 
-TODO "6V2DR" "SpaceTime should be refactored into a structure, or similar, to prevent casting."
+TODO "SpaceTime should be refactored into a structure, or similar, to prevent casting."
 
 /-- `SpaceTime d` corresponds to `d+1` dimensional space-time.
   This is equipped with an instance of the action of a Lorentz group,

--- a/Physlib/StringTheory/FTheory/SU5/Charges/OfRationalSection.lean
+++ b/Physlib/StringTheory/FTheory/SU5/Charges/OfRationalSection.lean
@@ -57,7 +57,7 @@ F-theory and All Things Rational: Surveying U(1) Symmetries with Rational Sectio
 
 @[expose] public section
 
-TODO "AETF6" "The results in this file are currently stated, but not proved.
+TODO "The results in this file are currently stated, but not proved.
   They should should be proved following e.g. https://arxiv.org/pdf/1504.05593.
   This is a large project."
 

--- a/Physlib/Units/Basic.lean
+++ b/Physlib/Units/Basic.lean
@@ -199,7 +199,7 @@ lemma dimScale_pos (u1 u2 : UnitChoices) (d : Dimension) :
   · simp
   · exact Ne.symm (dimScale_ne_zero u1 u2 d)
 
-TODO "LCSAY" "Make SI : UnitChoices computable, probably by
+TODO "Make SI : UnitChoices computable, probably by
   replacing the axioms defining the units. See here:
   https://leanprover.zulipchat.com/#narrow/channel/479953-Physlib/topic/physical.20units/near/534914807"
 /-- The choice of units corresponding to SI units, that is

--- a/Physlib/Units/Examples.lean
+++ b/Physlib/Units/Examples.lean
@@ -225,5 +225,5 @@ lemma cosDim_isDimensionallyCorrect : IsDimensionallyCorrect CosDim := by
 
 -/
 
-TODO "LCR7N" "Add an example involving derivatives."
+TODO "Add an example involving derivatives."
 end UnitExamples

--- a/Physlib/Units/WithDim/Basic.lean
+++ b/Physlib/Units/WithDim/Basic.lean
@@ -157,6 +157,6 @@ lemma cast_scaleUnit {d d2 : Dimension} {M : Type} [MulAction ℝ≥0 M] (m : Wi
   subst h
   simp
 
-TODO "LPWE4" "Induce instances on `WithDim d M` from instances on `M`."
+TODO "Induce instances on `WithDim d M` from instances on `M`."
 
 end WithDim


### PR DESCRIPTION
Replace the TODO item tags with hashes based on String.hash, making it easier for users to write TODO items without having to worry about the unique tag. 