### PR TITLE
feat(QM) : Add `polyBddSchwartzSubmodule` coercions

### DIFF
--- a/Physlib/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -79,7 +79,9 @@ lemma momentumOperator_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) : 𝐩 i ψ
 
 -/
 
-open SpaceDHilbertSpace MeasureTheory
+open MeasureTheory
+open SpaceDHilbertSpace
+open SchwartzSubmodule
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The momentum operators defined on the Schwartz submodule. -/
@@ -115,7 +117,7 @@ lemma momentumOperatorSchwartz_isSymmetric :
   submodule of the Hilbert space. -/
 def momentumUnboundedOperator :
     UnboundedOperator (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) :=
-  UnboundedOperator.ofSymmetric (schwartzSubmodule_dense d)
+  UnboundedOperator.ofSymmetric (SchwartzSubmodule.dense d)
     (momentumOperatorSchwartz_isSymmetric i)
 
 end

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -364,6 +364,7 @@ end
 noncomputable section
 
 open SpaceDHilbertSpace
+open SchwartzSubmodule
 
 /-!
 ### B.1. Position vector
@@ -389,7 +390,7 @@ lemma positionOperatorSchwartz_isSymmetric : (positionOperatorSchwartz i).IsSymm
 /-- The symmetric position unbounded operators with domain the Schwartz submodule
   of the Hilbert space. -/
 def positionUnboundedOperator : UnboundedOperator (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) :=
-  UnboundedOperator.ofSymmetric (schwartzSubmodule_dense d) (positionOperatorSchwartz_isSymmetric i)
+  UnboundedOperator.ofSymmetric (SchwartzSubmodule.dense d) (positionOperatorSchwartz_isSymmetric i)
 
 /-!
 ### B.2. Radius powers (regularized)
@@ -418,7 +419,7 @@ lemma radiusRegPowOperatorSchwartz_isSymmetric {d : ℕ} (ε : ℝˣ) (s : ℝ) 
   of the Hilbert space. -/
 def radiusRegPowUnboundedOperator {d : ℕ} (ε : ℝˣ) (s : ℝ) :
     UnboundedOperator (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) :=
-  UnboundedOperator.ofSymmetric (schwartzSubmodule_dense d)
+  UnboundedOperator.ofSymmetric (SchwartzSubmodule.dense d)
     (radiusRegPowOperatorSchwartz_isSymmetric ε s)
 
 end

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
@@ -152,7 +152,6 @@ lemma mk_eq_iff {f g : Space d → ℂ} {hf : MemHS f} {hg : MemHS g} :
 lemma ext_iff {f g : SpaceDHilbertSpace d} :
     f = g ↔ (f : Space d → ℂ) =ᵐ[volume] (g : Space d → ℂ) := Lp.ext_iff
 
-
 /-!
 ## Limits
 -/

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
@@ -152,6 +152,24 @@ lemma mk_eq_iff {f g : Space d → ℂ} {hf : MemHS f} {hg : MemHS g} :
 lemma ext_iff {f g : SpaceDHilbertSpace d} :
     f = g ↔ (f : Space d → ℂ) =ᵐ[volume] (g : Space d → ℂ) := Lp.ext_iff
 
+
+/-!
+## Limits
+-/
+
+open Filter
+
+lemma tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq
+    {d : ℕ} {α : Type*} {l : Filter α} {ψ : α → SpaceDHilbertSpace d} :
+    Tendsto ψ l (nhds 0) ↔ Tendsto (fun a ↦ ∫⁻ x : Space d, ‖ψ a x‖ₑ ^ 2) l (nhds 0) := by
+  trans Tendsto (fun a ↦ (∫⁻ x, ‖ψ a x‖ₑ ^ 2) ^ (2⁻¹ : ℝ)) l (nhds 0)
+  · simp [tendsto_iff_edist_tendsto_0, edist_zero_right, Lp.enorm_def, eLpNorm, eLpNorm']
+  constructor <;> intro h
+  · apply Tendsto.ennrpow_const 2 at h
+    simp_all [← ENNReal.rpow_mul_natCast]
+  · apply Tendsto.ennrpow_const 2⁻¹ at h
+    simp_all
+
 end SpaceDHilbertSpace
 end
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
@@ -105,7 +105,34 @@ def polyBddSchwartzEquiv {d : ℕ} {a : ℕ∞} :
   LinearEquiv.ofInjective polyBddSchwartzIncl.toLinearMap (polyBddSchwartzIncl_injective d a)
 
 /-!
-### B. (In)equalities
+## B. Coercions
+-/
+
+instance {d : ℕ} {a : ℕ∞} : CoeOut (polyBddSchwartzMap d a) 𝓢(Space d, ℂ) := ⟨fun f ↦ f.val⟩
+
+instance {d : ℕ} {a : ℕ∞} : CoeFun (polyBddSchwartzMap d a) (fun _ ↦ Space d → ℂ) :=
+  ⟨fun f ↦ ⇑f.val⟩
+
+@[simp]
+lemma toFun_eq_coe {d : ℕ} {a : ℕ∞} (f : polyBddSchwartzMap d a) (x : Space d) :
+    f.val.toFun x = f.val x :=
+  rfl
+
+lemma polyBddSchwartzEquiv_symm_apply_coe {d : ℕ} {a : ℕ∞}
+    {ψ : schwartzSubmodule d} (hψ : ↑ψ ∈ polyBddSchwartzSubmodule d a) :
+    (polyBddSchwartzEquiv.symm ⟨ψ, hψ⟩).val = schwartzEquiv.symm ψ := by
+  apply schwartzEquiv.injective
+  apply SetLike.coe_eq_coe.mp
+  obtain ⟨g, hg⟩ := polyBddSchwartzEquiv.surjective ⟨ψ.val, hψ⟩
+  have hg' : polyBddSchwartzIncl g = ψ := SetLike.coe_eq_coe.mpr hg
+  rw [← hg, LinearEquiv.symm_apply_apply, LinearEquiv.apply_symm_apply, ← hg']
+  rfl
+
+lemma polyBddSchwartzEquiv_coe_ae {d : ℕ} {a : ℕ∞} (f : polyBddSchwartzMap d a) :
+    polyBddSchwartzEquiv f =ᵐ[volume] f.val := schwartzEquiv_coe_ae f.val
+
+/-!
+### C. (In)equalities
 -/
 
 lemma polyBddSchwartzMap_zero_eq_top (d : ℕ) : polyBddSchwartzMap d 0 = ⊤ := by

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
@@ -147,12 +147,11 @@ lemma polyBddSchwartzMap_zero_eq_top (d : ℕ) : polyBddSchwartzMap d 0 = ⊤ :=
 lemma polyBddSchwartzMap_antitone (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
     polyBddSchwartzMap d b ≤ polyBddSchwartzMap d a := fun _ hx k hk ↦ hx k (hk.trans h)
 
-lemma of_zero_eq (d : ℕ) :
-    polyBddSchwartzSubmodule d 0 = schwartzSubmodule d := by
+lemma of_zero_eq (d : ℕ) : polyBddSchwartzSubmodule d 0 = schwartzSubmodule d := by
   simp [polyBddSchwartzSubmodule, polyBddSchwartzIncl, polyBddSchwartzMap_zero_eq_top]
 
-lemma le_schwartzSubmodule (d : ℕ) (a : ℕ∞) :
-    polyBddSchwartzSubmodule d a ≤ schwartzSubmodule d := LinearMap.range_domRestrict_le_range _ _
+lemma le_schwartzSubmodule (d : ℕ) (a : ℕ∞) : polyBddSchwartzSubmodule d a ≤ schwartzSubmodule d :=
+  LinearMap.range_domRestrict_le_range _ _
 
 lemma antitone (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
     polyBddSchwartzSubmodule d b ≤ polyBddSchwartzSubmodule d a := by
@@ -186,8 +185,7 @@ private lemma dense_zero_top :
   · simp
   · simp [hk', add_nonneg]
 
-lemma dense_top (d : ℕ) :
-    Dense (polyBddSchwartzSubmodule d ⊤ : Set (SpaceDHilbertSpace d)) := by
+lemma dense_top (d : ℕ) : Dense (polyBddSchwartzSubmodule d ⊤ : Set (SpaceDHilbertSpace d)) := by
   rcases eq_zero_or_pos d with (rfl | hd)
   · -- `d = 0`: Every function `Space 0 ≅ {0} → ℂ` is in `polyBddSchwartzSubmodule 0 ⊤`.
     exact dense_zero_top
@@ -288,8 +286,7 @@ lemma dense_top (d : ℕ) :
         simp_rw [h, h', Pi.sub_apply, hg, s, ← mul_sub]
         exact ENNReal.pow_le_pow_left <| enorm_bump_mul_le_enorm (b n) (fun x ↦ f n x - ξ x) x
 
-lemma dense (d : ℕ) (a : ℕ∞) :
-    Dense (polyBddSchwartzSubmodule d a : Set (SpaceDHilbertSpace d)) :=
+lemma dense (d : ℕ) (a : ℕ∞) : Dense (polyBddSchwartzSubmodule d a : Set (SpaceDHilbertSpace d)) :=
   (dense_top d).mono (antitone d le_top)
 
 end PolyBddSchwartzSubmodule

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
@@ -38,13 +38,14 @@ their being dense in `SpaceDHilbertSpace 0 ≅ ℂ`).
 
 - `polyBddSchwartzSubmodule d (a : ℕ∞)`: Restriction of `schwartzSubmodule d` to those Schwartz maps
   which are bounded by powers of `‖x‖`.
-- `polyBddSchwartzSubmodule_dense d a`: These submodules are dense in `SpaceDHilbertSpace`.
+- `PolyBddSchwartzSubmodule.dense d a`: These submodules are dense in `SpaceDHilbertSpace`.
 
 ## iii. Table of contents
 
 - A. Definitions
-- B. (In)equalities
-- C. Density
+- B. Coercions
+- C. (In)equalities
+- D. Density
 
 ## iv. References
 
@@ -55,14 +56,15 @@ their being dense in `SpaceDHilbertSpace 0 ≅ ℂ`).
 namespace QuantumMechanics
 namespace SpaceDHilbertSpace
 
+noncomputable section
+
 open MeasureTheory
 open InnerProductSpace
 open SchwartzMap
-
-noncomputable section
+open SchwartzSubmodule
 
 /-!
-### A. Definitions
+## A. Definitions
 -/
 
 /-- A function is a bounded Schwartz map if it is both Schwartz and bounded by powers of `‖x‖`. -/
@@ -104,6 +106,8 @@ def polyBddSchwartzEquiv {d : ℕ} {a : ℕ∞} :
     polyBddSchwartzMap d a ≃ₗ[ℂ] polyBddSchwartzSubmodule d a :=
   LinearEquiv.ofInjective polyBddSchwartzIncl.toLinearMap (polyBddSchwartzIncl_injective d a)
 
+namespace PolyBddSchwartzSubmodule
+
 /-!
 ## B. Coercions
 -/
@@ -140,23 +144,23 @@ lemma polyBddSchwartzMap_zero_eq_top (d : ℕ) : polyBddSchwartzMap d 0 = ⊤ :=
   have := f.decay 0 0
   simp_all [polyBddSchwartzMap]
 
-lemma polyBddSchwartzMap_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
+lemma polyBddSchwartzMap_antitone (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
     polyBddSchwartzMap d b ≤ polyBddSchwartzMap d a := fun _ hx k hk ↦ hx k (hk.trans h)
 
-lemma polyBddSchwartzSubmodule_zero_eq (d : ℕ) :
+lemma of_zero_eq (d : ℕ) :
     polyBddSchwartzSubmodule d 0 = schwartzSubmodule d := by
   simp [polyBddSchwartzSubmodule, polyBddSchwartzIncl, polyBddSchwartzMap_zero_eq_top]
 
-lemma polyBddSchwartzSubmodule_le (d : ℕ) (a : ℕ∞) :
+lemma le_schwartzSubmodule (d : ℕ) (a : ℕ∞) :
     polyBddSchwartzSubmodule d a ≤ schwartzSubmodule d := LinearMap.range_domRestrict_le_range _ _
 
-lemma polyBddSchwartzSubmodule_le_of_ge (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
+lemma antitone (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
     polyBddSchwartzSubmodule d b ≤ polyBddSchwartzSubmodule d a := by
   simp only [polyBddSchwartzSubmodule, polyBddSchwartzIncl, LinearMap.range_domRestrict]
-  exact Submodule.map_mono (polyBddSchwartzMap_le_of_ge d h)
+  exact Submodule.map_mono (polyBddSchwartzMap_antitone d h)
 
 /-!
-### C. Density
+### D. Density
 -/
 
 open Filter Complex
@@ -171,10 +175,10 @@ private lemma enorm_bump_mul_le_enorm {𝕜 E : Type*} [RCLike 𝕜] [NormedAddC
   rw [norm_algebraMap', Real.norm_eq_abs, norm_one, ← abs_one]
   exact abs_le_abs_of_nonneg f.nonneg f.le_one
 
-private lemma polyBddSchwartzSubmodule_zero_top_dense :
+private lemma dense_zero_top :
     Dense (polyBddSchwartzSubmodule 0 ⊤ : Set (SpaceDHilbertSpace 0)) := by
   suffices polyBddSchwartzMap 0 ⊤ = ⊤ by
-    simp [polyBddSchwartzSubmodule, polyBddSchwartzIncl, this, schwartzSubmodule_dense]
+    simp [polyBddSchwartzSubmodule, polyBddSchwartzIncl, this, SchwartzSubmodule.dense]
   refine Submodule.eq_top_iff'.mpr (fun f k hk ↦ ?_)
   refine ⟨1 + ‖f 0‖, by positivity, fun x ↦ ?_⟩
   simp only [Space.point_dim_zero_eq, norm_zero, zpow_neg, zpow_natCast]
@@ -182,16 +186,16 @@ private lemma polyBddSchwartzSubmodule_zero_top_dense :
   · simp
   · simp [hk', add_nonneg]
 
-lemma polyBddSchwartzSubmodule_top_dense (d : ℕ) :
+lemma dense_top (d : ℕ) :
     Dense (polyBddSchwartzSubmodule d ⊤ : Set (SpaceDHilbertSpace d)) := by
   rcases eq_zero_or_pos d with (rfl | hd)
   · -- `d = 0`: Every function `Space 0 ≅ {0} → ℂ` is in `polyBddSchwartzSubmodule 0 ⊤`.
-    exact polyBddSchwartzSubmodule_zero_top_dense
+    exact dense_zero_top
   · -- `d > 0`: Construct a sequence in `polyBddSchwartzSubmodule d ⊤` which tends to `ξ`
     intro ξ
     apply mem_closure_iff_seq_limit.mpr
     -- `ψₙ = [fₙ]` is a sequence in `schwartzSubmodule` which tends to `ξ`
-    obtain ⟨ψ, hψ, hψξ⟩ := mem_closure_iff_seq_limit.mp (schwartzSubmodule_dense d ξ)
+    obtain ⟨ψ, hψ, hψξ⟩ := mem_closure_iff_seq_limit.mp (SchwartzSubmodule.dense d ξ)
     let f (n : ℕ) : 𝓢(Space d, ℂ) := schwartzEquiv.symm ⟨ψ n, hψ n⟩
     -- `bₙ` is a sequence of bump functions with shrinking domain
     let b (n : ℕ) : ContDiffBump (0 : Space d) :=
@@ -284,11 +288,11 @@ lemma polyBddSchwartzSubmodule_top_dense (d : ℕ) :
         simp_rw [h, h', Pi.sub_apply, hg, s, ← mul_sub]
         exact ENNReal.pow_le_pow_left <| enorm_bump_mul_le_enorm (b n) (fun x ↦ f n x - ξ x) x
 
-lemma polyBddSchwartzSubmodule_dense (d : ℕ) (a : ℕ∞) :
+lemma dense (d : ℕ) (a : ℕ∞) :
     Dense (polyBddSchwartzSubmodule d a : Set (SpaceDHilbertSpace d)) :=
-  (polyBddSchwartzSubmodule_top_dense d).mono (polyBddSchwartzSubmodule_le_of_ge d le_top)
+  (dense_top d).mono (antitone d le_top)
 
+end PolyBddSchwartzSubmodule
 end
-
 end SpaceDHilbertSpace
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
@@ -144,17 +144,6 @@ private lemma enorm_bump_mul_le_enorm {𝕜 E : Type*} [RCLike 𝕜] [NormedAddC
   rw [norm_algebraMap', Real.norm_eq_abs, norm_one, ← abs_one]
   exact abs_le_abs_of_nonneg f.nonneg f.le_one
 
-private lemma tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq
-    {d : ℕ} {α : Type*} {l : Filter α} {ψ : α → SpaceDHilbertSpace d} :
-    Tendsto ψ l (nhds 0) ↔ Tendsto (fun a ↦ ∫⁻ x : Space d, ‖ψ a x‖ₑ ^ 2) l (nhds 0) := by
-  trans Tendsto (fun a ↦ (∫⁻ x, ‖ψ a x‖ₑ ^ 2) ^ (2⁻¹ : ℝ)) l (nhds 0)
-  · simp [tendsto_iff_edist_tendsto_0, edist_zero_right, Lp.enorm_def, eLpNorm, eLpNorm']
-  constructor <;> intro h
-  · apply Tendsto.ennrpow_const 2 at h
-    simp_all [← ENNReal.rpow_mul_natCast]
-  · apply Tendsto.ennrpow_const 2⁻¹ at h
-    simp_all
-
 private lemma polyBddSchwartzSubmodule_zero_top_dense :
     Dense (polyBddSchwartzSubmodule 0 ⊤ : Set (SpaceDHilbertSpace 0)) := by
   suffices polyBddSchwartzMap 0 ⊤ = ⊤ by

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -22,6 +22,10 @@ In this module we define the Schwartz submodule of `SpaceDHilbertSpace`.
 
 ## iii. Table of contents
 
+- A. Definitions
+- B. Coercions
+- D. Misc.
+
 ## iv. References
 
 -/
@@ -31,17 +35,17 @@ In this module we define the Schwartz submodule of `SpaceDHilbertSpace`.
 namespace QuantumMechanics
 namespace SpaceDHilbertSpace
 
+noncomputable section
+
 open MeasureTheory
 open InnerProductSpace
 open SchwartzMap
 
-/-!
-## A. Schwartz submodule
--/
-
-noncomputable section
-
 variable {d : ℕ}
+
+/-!
+## A. Definitions
+-/
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The continuous linear map including Schwartz maps into `SpaceDHilbertSpace d`. -/
@@ -51,30 +55,39 @@ set_option backward.isDefEq.respectTransparency false in
 /-- The submodule of `SpaceDHilbertSpace d` corresponding to Schwartz maps. -/
 abbrev schwartzSubmodule (d : ℕ) := (schwartzIncl (d := d)).range
 
-instance : CoeFun (schwartzSubmodule d) fun _ ↦ Space d → ℂ := ⟨fun ψ ↦ ψ.val⟩
-
-@[simp]
-lemma val_eq_coe (ψ : schwartzSubmodule d) (x : Space d) : ψ.val x = ψ x := rfl
-
-lemma schwartzSubmodule_dense (d : ℕ) :
-    Dense (schwartzSubmodule d : Set (SpaceDHilbertSpace d)) :=
-  denseRange_toLpCLM ENNReal.top_ne_ofNat.symm
-
 set_option backward.isDefEq.respectTransparency false in
 /-- The linear equivalence between the Schwartz maps `𝓢(Space d, ℂ)` and the Schwartz submodule
   of `SpaceDHilbertSpace d`. -/
 def schwartzEquiv : 𝓢(Space d, ℂ) ≃ₗ[ℂ] schwartzSubmodule d :=
   LinearEquiv.ofInjective schwartzIncl.toLinearMap (injective_toLp (E := Space d) 2)
 
+namespace SchwartzSubmodule
+
 variable (f g : 𝓢(Space d, ℂ)) (ψ : schwartzSubmodule d)
 
-lemma schwartzEquiv_coe_ae : (schwartzEquiv f) =ᵐ[volume] f := coeFn_toLp f 2 volume
+/-!
+## B. Coercions
+-/
+
+instance : CoeFun (schwartzSubmodule d) fun _ ↦ Space d → ℂ := ⟨fun ψ ↦ ψ.val⟩
+
+lemma schwartzEquiv_apply_coe : ↑(schwartzEquiv f) = schwartzIncl f := by simp [schwartzEquiv]
+
+lemma schwartzEquiv_coe_ae : schwartzEquiv f =ᵐ[volume] f := coeFn_toLp f 2 volume
 
 lemma schwartzEquiv_symm_coe_ae : schwartzEquiv.symm ψ =ᵐ[volume] ψ := by
   nth_rw 2 [← schwartzEquiv.apply_symm_apply ψ]
   exact (schwartzEquiv_coe_ae _).symm
 
-lemma schwartzEquiv_apply_coe : ↑(schwartzEquiv f) = schwartzIncl f := by simp [schwartzEquiv]
+lemma schwartzEquiv_ae_eq (h : schwartzEquiv f =ᵐ[volume] schwartzEquiv g) : f = g :=
+  (EmbeddingLike.apply_eq_iff_eq _).mp (SetLike.coe_eq_coe.mp (ext_iff.mpr h))
+
+/-!
+## C. Misc.
+-/
+
+lemma dense (d : ℕ) : Dense (schwartzSubmodule d : Set (SpaceDHilbertSpace d)) :=
+  denseRange_toLpCLM ENNReal.top_ne_ofNat.symm
 
 lemma schwartzEquiv_inner :
     ⟪schwartzEquiv f, schwartzEquiv g⟫_ℂ = ∫ x : Space d, starRingEnd ℂ (f x) * g x := by
@@ -82,13 +95,10 @@ lemma schwartzEquiv_inner :
   filter_upwards [schwartzEquiv_coe_ae f, schwartzEquiv_coe_ae g] with _ hf hg
   simp [hf, hg, mul_comm]
 
-lemma schwartzEquiv_ae_eq (h : schwartzEquiv f =ᵐ[volume] schwartzEquiv g) : f = g :=
-  (EmbeddingLike.apply_eq_iff_eq _).mp (SetLike.coe_eq_coe.mp (ext_iff.mpr h))
-
 lemma schwartzIncl_ker : schwartzIncl.ker = (⊥ : Submodule ℂ 𝓢(Space d, ℂ)) := by
   ext; simp [← schwartzEquiv_apply_coe]
 
+end SchwartzSubmodule
 end
-
 end SpaceDHilbertSpace
 end QuantumMechanics


### PR DESCRIPTION
- Adds Schwartz maps and function coercions.
- Adds `(PolyBdd)SchwartzSubmodule` namespaces and simplifies some lemma names.
- Relocates `tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq`.