### PR TITLE
chore: Add t-quantum-info to tag list

### DIFF
--- a/.github/workflows/labels_from_comment.yml
+++ b/.github/workflows/labels_from_comment.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - name: Add / remove label based on comment
       run: |
-        labelArray=("awaiting-author" "blocked-by-mathlib-PR" "blocked-by-PR" "documentation" "easy" "help-wanted" "merge-conflict" "new-contributor" "please-adopt" "RFC" "WIP" "t-classical-mechanics" "t-condensed-matter" "t-cosmology" "t-electromagnetism" "t-mathematics" "t-meta" "t-optics" "t-particles" "t-quantum-field-theory" "t-quantum-mechanics" "t-relativity" "t-space-time" "t-statistical-mechanics" "t-string-theory" "t-thermodynamics" "t-units")
+        labelArray=("awaiting-author" "blocked-by-mathlib-PR" "blocked-by-PR" "documentation" "easy" "help-wanted" "merge-conflict" "new-contributor" "please-adopt" "RFC" "WIP" "t-classical-mechanics" "t-condensed-matter" "t-cosmology" "t-electromagnetism" "t-mathematics" "t-meta" "t-optics" "t-particles" "t-quantum-field-theory" "t-quantum-info" "t-quantum-mechanics" "t-relativity" "t-space-time" "t-statistical-mechanics" "t-string-theory" "t-thermodynamics" "t-units")
 
         # we strip `\r` since line endings from GitHub contain this character
         COMMENT="${COMMENT//$'\r'/}"


### PR DESCRIPTION
This adds the new "t-quantum-info" tag to the list of tags than can be added/removed using a comment.