### PR TITLE
feat: Differentiability of the field strength

### DIFF
--- a/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
@@ -194,9 +194,7 @@ lemma isExtrema_lorentzGroup_apply_iff {𝓕 : FreeSpace}
     rw [toFieldStrength_equivariant _ _ (hA.differentiable (by simp))]
   conv_lhs =>
     enter [x]
-    rw [tensorDeriv_equivariant _ _ _ (by
-      apply toFieldStrength_differentiable
-      exact hA.of_le ENat.LEInfty.out)]
+    rw [tensorDeriv_equivariant _ _ _ (differentiable_toFieldStrength_of_smooth hA)]
     rw [smul_comm]
     rw [Tensorial.toTensor_smul, Tensorial.toTensor_smul]
     simp only [one_div, map_smul, actionT_smul,

--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -668,14 +668,6 @@ lemma gradKineticTerm_eq_sum_sum {d} {𝓕 : FreeSpace}
     A.gradKineticTerm 𝓕 x = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
         (1 / (𝓕.μ₀) * (η μ μ * η ν ν * ∂_ μ (fun x' => ∂_ μ A x' ν) x -
         ∂_ μ (fun x' => ∂_ ν A x' μ) x)) • Lorentz.Vector.basis ν := by
-  have diff_partial (μ) :
-      ∀ ν, Differentiable ℝ fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
-    rw [Lorentz.Vector.differentiable_apply]
-    refine Differentiable.clm_apply ?_ ?_
-    · refine ((contDiff_succ_iff_fderiv (n := 1)).mp ?_).2.2.differentiable
-        (by simp)
-      exact ContDiff.of_le ha (right_eq_inf.mp rfl)
-    · fun_prop
   rw [gradKineticTerm_eq_sum_fderiv A ha]
   calc _
       _ = ∑ (μ : (Fin 1 ⊕ Fin d)), ∑ (ν : (Fin 1 ⊕ Fin d)),
@@ -729,12 +721,10 @@ lemma gradKineticTerm_eq_sum_sum {d} {𝓕 : FreeSpace}
         congr
         · rw [fderiv_const_mul]
           simp [SpaceTime.deriv_eq]
-          conv => enter [2, x]; rw [SpaceTime.deriv_eq]
-          apply diff_partial μ ν
+          fun_prop
         · rw [fderiv_const_mul]
           simp [SpaceTime.deriv_eq]
-          conv => enter [2, x]; rw [SpaceTime.deriv_eq]
-          apply diff_partial ν μ
+          fun_prop
       _ = ∑ (μ : (Fin 1 ⊕ Fin d)), ∑ (ν : (Fin 1 ⊕ Fin d)),
         ((1 / (𝓕.μ₀) * (η μ μ * η ν ν * ∂_ μ (fun x' => ∂_ μ A x' ν) x -
         ∂_ μ (fun x' => ∂_ ν A x' μ) x)) • Lorentz.Vector.basis ν) := by
@@ -759,73 +749,59 @@ lemma gradKineticTerm_eq_fieldStrength {d} {𝓕 : FreeSpace} (A : Electromagnet
     A.gradKineticTerm 𝓕 x = ∑ (ν : (Fin 1 ⊕ Fin d)), (1/𝓕.μ₀ * η ν ν) •
     (∑ (μ : (Fin 1 ⊕ Fin d)), (∂_ μ (A.fieldStrengthMatrix · (μ, ν)) x))
     • Lorentz.Vector.basis ν := by
-  have diff_partial (μ) :
-      ∀ ν, Differentiable ℝ fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
-    rw [Lorentz.Vector.differentiable_apply]
-    refine Differentiable.clm_apply ?_ ?_
-    · refine ((contDiff_succ_iff_fderiv (n := 1)).mp ?_).2.2.differentiable
-        (by simp)
-      exact ContDiff.of_le ha (right_eq_inf.mp rfl)
-    · fun_prop
   calc _
-      _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
-        (1/𝓕.μ₀ * (η μ μ * η ν ν * ∂_ μ (fun x' => ∂_ μ A x' ν) x -
-        ∂_ μ (fun x' => ∂_ ν A x' μ) x)) • Lorentz.Vector.basis ν := by
-          rw [gradKineticTerm_eq_sum_sum A x ha]
-      _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
-        ((1/𝓕.μ₀ * η ν ν) * (η μ μ * ∂_ μ (fun x' => ∂_ μ A x' ν) x -
-        η ν ν * ∂_ μ (fun x' => ∂_ ν A x' μ) x)) • Lorentz.Vector.basis ν := by
-          apply Finset.sum_congr rfl (fun ν _ => ?_)
-          apply Finset.sum_congr rfl (fun μ _ => ?_)
-          congr 1
-          ring_nf
-          simp
-      _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
-        ((1/𝓕.μ₀ * η ν ν) * (∂_ μ (fun x' => η μ μ * ∂_ μ A x' ν) x -
-            ∂_ μ (fun x' => η ν ν * ∂_ ν A x' μ) x)) • Lorentz.Vector.basis ν := by
-          apply Finset.sum_congr rfl (fun ν _ => ?_)
-          apply Finset.sum_congr rfl (fun μ _ => ?_)
-          congr
-          · rw [SpaceTime.deriv_eq, SpaceTime.deriv_eq, fderiv_const_mul]
-            rfl
-            apply diff_partial μ ν
-          · rw [SpaceTime.deriv_eq, SpaceTime.deriv_eq, fderiv_const_mul]
-            rfl
-            apply diff_partial ν μ
-      _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
-        ((1/𝓕.μ₀ * η ν ν) * (∂_ μ (fun x' => η μ μ * ∂_ μ A x' ν -
-            η ν ν * ∂_ ν A x' μ) x)) • Lorentz.Vector.basis ν := by
-          apply Finset.sum_congr rfl (fun ν _ => ?_)
-          apply Finset.sum_congr rfl (fun μ _ => ?_)
-          congr
-          rw [SpaceTime.deriv_eq, SpaceTime.deriv_eq, SpaceTime.deriv_eq, fderiv_fun_sub]
-          simp only [ContinuousLinearMap.coe_sub', Pi.sub_apply]
-          · conv => enter [2, x]; rw [SpaceTime.deriv_eq]
-            apply Differentiable.differentiableAt
-            apply Differentiable.const_mul
-            exact diff_partial μ ν
-          · conv => enter [2, x]; rw [SpaceTime.deriv_eq]
-            apply Differentiable.differentiableAt
-            apply Differentiable.const_mul
-            exact diff_partial ν μ
-      _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
-        ((1/𝓕.μ₀ * η ν ν) * (∂_ μ (A.fieldStrengthMatrix · (μ, ν)) x)) •
-            Lorentz.Vector.basis ν := by
-          apply Finset.sum_congr rfl (fun ν _ => ?_)
-          apply Finset.sum_congr rfl (fun μ _ => ?_)
-          congr
-          funext x
-          rw [toFieldStrength_basis_repr_apply_eq_single]
-      _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ((1/𝓕.μ₀ * η ν ν) *
-          ∑ (μ : (Fin 1 ⊕ Fin d)), (∂_ μ (A.fieldStrengthMatrix · (μ, ν)) x))
-          • Lorentz.Vector.basis ν := by
-          apply Finset.sum_congr rfl (fun ν _ => ?_)
-          rw [← Finset.sum_smul, Finset.mul_sum]
-      _ = ∑ (ν : (Fin 1 ⊕ Fin d)), (1/𝓕.μ₀ * η ν ν) •
-          (∑ (μ : (Fin 1 ⊕ Fin d)), (∂_ μ (A.fieldStrengthMatrix · (μ, ν)) x))
-          • Lorentz.Vector.basis ν := by
-          apply Finset.sum_congr rfl (fun ν _ => ?_)
-          rw [smul_smul]
+    _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
+      (1/𝓕.μ₀ * (η μ μ * η ν ν * ∂_ μ (fun x' => ∂_ μ A x' ν) x -
+      ∂_ μ (fun x' => ∂_ ν A x' μ) x)) • Lorentz.Vector.basis ν := by
+        rw [gradKineticTerm_eq_sum_sum A x ha]
+    _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
+      ((1/𝓕.μ₀ * η ν ν) * (η μ μ * ∂_ μ (fun x' => ∂_ μ A x' ν) x -
+      η ν ν * ∂_ μ (fun x' => ∂_ ν A x' μ) x)) • Lorentz.Vector.basis ν := by
+        apply Finset.sum_congr rfl (fun ν _ => ?_)
+        apply Finset.sum_congr rfl (fun μ _ => ?_)
+        congr 1
+        ring_nf
+        simp
+    _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
+      ((1/𝓕.μ₀ * η ν ν) * (∂_ μ (fun x' => η μ μ * ∂_ μ A x' ν) x -
+          ∂_ μ (fun x' => η ν ν * ∂_ ν A x' μ) x)) • Lorentz.Vector.basis ν := by
+        apply Finset.sum_congr rfl (fun ν _ => ?_)
+        apply Finset.sum_congr rfl (fun μ _ => ?_)
+        congr
+        · rw [SpaceTime.deriv_eq, SpaceTime.deriv_eq, fderiv_const_mul]
+          rfl
+          fun_prop
+        · rw [SpaceTime.deriv_eq, SpaceTime.deriv_eq, fderiv_const_mul]
+          rfl
+          fun_prop
+    _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
+      ((1/𝓕.μ₀ * η ν ν) * (∂_ μ (fun x' => η μ μ * ∂_ μ A x' ν -
+          η ν ν * ∂_ ν A x' μ) x)) • Lorentz.Vector.basis ν := by
+        apply Finset.sum_congr rfl (fun ν _ => ?_)
+        apply Finset.sum_congr rfl (fun μ _ => ?_)
+        congr
+        rw [SpaceTime.deriv_eq, SpaceTime.deriv_eq, SpaceTime.deriv_eq, fderiv_fun_sub]
+        simp only [ContinuousLinearMap.coe_sub', Pi.sub_apply]
+        · fun_prop
+        · fun_prop
+    _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ∑ (μ : (Fin 1 ⊕ Fin d)),
+      ((1/𝓕.μ₀ * η ν ν) * (∂_ μ (A.fieldStrengthMatrix · (μ, ν)) x)) •
+          Lorentz.Vector.basis ν := by
+        apply Finset.sum_congr rfl (fun ν _ => ?_)
+        apply Finset.sum_congr rfl (fun μ _ => ?_)
+        congr
+        funext x
+        rw [toFieldStrength_basis_repr_apply_eq_single]
+    _ = ∑ (ν : (Fin 1 ⊕ Fin d)), ((1/𝓕.μ₀ * η ν ν) *
+        ∑ (μ : (Fin 1 ⊕ Fin d)), (∂_ μ (A.fieldStrengthMatrix · (μ, ν)) x))
+        • Lorentz.Vector.basis ν := by
+        apply Finset.sum_congr rfl (fun ν _ => ?_)
+        rw [← Finset.sum_smul, Finset.mul_sum]
+    _ = ∑ (ν : (Fin 1 ⊕ Fin d)), (1/𝓕.μ₀ * η ν ν) •
+        (∑ (μ : (Fin 1 ⊕ Fin d)), (∂_ μ (A.fieldStrengthMatrix · (μ, ν)) x))
+        • Lorentz.Vector.basis ν := by
+        apply Finset.sum_congr rfl (fun ν _ => ?_)
+        rw [smul_smul]
 
 /-!
 
@@ -845,22 +821,9 @@ lemma gradKineticTerm_eq_electric_magnetic {𝓕 : FreeSpace} (A : Electromagnet
     ∑ i, (𝓕.μ₀⁻¹ * (1 / 𝓕.c ^ 2 * ∂ₜ (fun t => A.electricField 𝓕.c t x.space) (x.time 𝓕.c) i-
       ∑ j, Space.deriv j (A.magneticFieldMatrix 𝓕.c (x.time 𝓕.c) · (j, i)) x.space)) •
       Lorentz.Vector.basis (Sum.inr i) := by
-  have diff_partial (μ) :
-      ∀ ν, Differentiable ℝ fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
-    rw [Lorentz.Vector.differentiable_apply]
-    refine Differentiable.clm_apply ?_ ?_
-    · refine ((contDiff_succ_iff_fderiv (n := 1)).mp ?_).2.2.differentiable
-        (by simp)
-      exact ContDiff.of_le ha (right_eq_inf.mp rfl)
-    · fun_prop
   have hdiff (μ ν) : Differentiable ℝ fun x => (A.fieldStrengthMatrix x) (μ, ν) := by
-    conv => enter [2, x]; rw [toFieldStrength_basis_repr_apply_eq_single,
-      SpaceTime.deriv_eq, SpaceTime.deriv_eq]
-    apply Differentiable.sub
-    apply Differentiable.const_mul
-    · exact diff_partial (μ, ν).1 (μ, ν).2
-    apply Differentiable.const_mul
-    · exact diff_partial (μ, ν).2 (μ, ν).1
+    conv => enter [2, x]; rw [toFieldStrength_basis_repr_apply_eq_single]
+    fun_prop
   rw [gradKineticTerm_eq_fieldStrength A x ha]
   rw [Fintype.sum_sum_type, Fin.sum_univ_one]
   congr 1
@@ -1029,9 +992,7 @@ lemma gradKineticTerm_eq_tensorDeriv {d} {𝓕 : FreeSpace}
   rw [permT_basis_repr_symm_apply, contrT_basis_repr_apply_eq_fin]
   conv_rhs =>
     enter [2, 2, 2, μ]
-    rw [tensorDeriv_toTensor_basis_repr (by
-      apply toFieldStrength_differentiable
-      apply hA.of_le (ENat.LEInfty.out))]
+    rw [tensorDeriv_toTensor_basis_repr (by fun_prop)]
     enter [2, x]
     rw [toFieldStrength_tensor_basis_eq_basis]
     change fieldStrengthMatrix A x _

--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -148,6 +148,8 @@ TODO "Lift the action on `ElectromagneticPotential d` to a `DistribMulAction`."
 We show that the components of field strength tensor are differentiable if the potential is.
 -/
 
+open ContDiff
+
 @[fun_prop]
 lemma differentiable_component {d : ℕ}
     (A : ElectromagneticPotential d) (hA : Differentiable ℝ A) (μ : Fin 1 ⊕ Fin d) :
@@ -164,6 +166,41 @@ lemma differentiable_action {d} (Λ : LorentzGroup d) (A : ElectromagneticPotent
   · apply Differentiable.comp
     · exact hA
     · exact ContinuousLinearMap.differentiable (Lorentz.Vector.actionCLM Λ⁻¹)
+
+@[fun_prop]
+lemma contDiff_action {d} (Λ : LorentzGroup d) (A : ElectromagneticPotential d)
+    (hA : ContDiff ℝ n A) : ContDiff ℝ n (fun x => Λ • A (Λ⁻¹ • x)) := by
+  apply ContDiff.comp
+  · exact ContinuousLinearMap.contDiff (Lorentz.Vector.actionCLM Λ)
+  · apply ContDiff.comp
+    · exact hA
+    · exact ContinuousLinearMap.contDiff (Lorentz.Vector.actionCLM Λ⁻¹)
+
+@[fun_prop]
+lemma differentiable_deriv {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ 2 A) (μ ν : Fin 1 ⊕ Fin d) :
+    Differentiable ℝ (fun x => ∂_ μ A x ν) := by
+  have diff_partial (μ) :
+      ∀ ν, Differentiable ℝ fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
+    rw [SpaceTime.differentiable_vector]
+    fun_prop
+  exact diff_partial μ ν
+
+@[fun_prop]
+lemma differentiable_deriv_of_smooth {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ ∞ A) (μ ν : Fin 1 ⊕ Fin d) :
+    Differentiable ℝ (fun x => ∂_ μ A x ν) := by
+  apply differentiable_deriv (hA.of_le (ENat.LEInfty.out)) μ ν
+
+@[fun_prop]
+lemma contDiff_deriv {n} {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ (n + 1) A) (μ ν : Fin 1 ⊕ Fin d) :
+    ContDiff ℝ n (fun x => ∂_ μ A x ν) := by
+  have diff_partial (μ) :
+      ∀ ν, ContDiff ℝ n fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
+    rw [SpaceTime.contDiff_vector]
+    fun_prop
+  exact diff_partial μ ν
 
 TODO "Add results related to the differentiability of the
   derivative of the Electromagnetic potential."

--- a/Physlib/Electromagnetism/Kinematics/FieldStrength.lean
+++ b/Physlib/Electromagnetism/Kinematics/FieldStrength.lean
@@ -32,12 +32,13 @@ We define a tensor version and a matrix version and prover various properties of
   - A.1. Tensor equalities
   - A.2. Vector equalities
   - A.3. The group action acting on the field strength tensor
-  - A.4. Elements of the field strength tensor in terms of basis
-  - A.5. The field strength matrix
-    - A.5.1. Differentiability of the field strength matrix
-  - A.6. The antisymmetry of the field strength tensor
-  - A.7. Equivariance of the field strength matrix
-  - A.8. Linearity of the field strength tensor
+  - A.4. Differentiability and smoothness of the field strength tensor
+  - A.5. Elements of the field strength tensor in terms of basis
+  - A.6. The field strength matrix
+    - A.6.1. Differentiability of the field strength matrix
+  - A.7. The antisymmetry of the field strength tensor
+  - A.8. Equivariance of the field strength matrix
+  - A.9. Linearity of the field strength tensor
 - B. Field strength for distributions
   - B.1. Auxiliary definition of field strength for distributions, with no linearity
   - B.2. The definition of the field strength
@@ -158,7 +159,6 @@ TODO "Generalize the proof of `toFieldStrength_eq_sum_basis_eval` so that any te
   The likely location for this is in the `Tensorial` module.
   The TODO item with tag: 8285454220008908699 is likely a prerequisite to this."
 
-
 /-- The statement that `F = F^{μν} eᵤ ⊗ eᵥ` written explicitly, with
   the components extracted via `toField`. -/
 lemma toFieldStrength_eq_sum_basis_eval {d} {A : ElectromagneticPotential d} :
@@ -269,7 +269,7 @@ lemma toFieldStrength_action_eq_sum {d} (A : ElectromagneticPotential d) (Λ : L
       Vector.basis μ ⊗ₜ[ℝ] Vector.basis ν := by
   conv_lhs => rw [toFieldStrength_equivariant A Λ hf x, toFieldStrength_eq_sum_basis_eval]
   change Tensorial.smulLinearMap _ _ = _
-  simp only [Nat.reduceSucc, Nat.reduceAdd, Fin.isValue, Fin.succAbove_zero, map_sum, map_smul]
+  simp only [map_sum, map_smul]
   simp [smulLinearMap, smul_prod, Vector.smul_basis, tmul_sum, sum_tmul,
     Finset.smul_sum, tmul_smul, smul_tmul, smul_smul]
   conv_lhs => enter [2, μ, 2, ν]; rw [Finset.sum_comm]
@@ -285,7 +285,35 @@ lemma toFieldStrength_action_eq_sum {d} (A : ElectromagneticPotential d) (Λ : L
 
 /-!
 
-### A.4. Elements of the field strength tensor in terms of basis
+## A.4. Differentiability and smoothness of the field strength tensor
+
+-/
+
+@[fun_prop]
+lemma differentiable_toFieldStrength {d} {A : ElectromagneticPotential d} (hA : ContDiff ℝ 2 A) :
+    Differentiable ℝ A.toFieldStrength := by
+  change Differentiable ℝ (A.toFieldStrength ·)
+  simp only [toFieldStrength_eq_sum_basis_single (hA.differentiable (by simp))]
+  fun_prop
+
+open ContDiff
+
+@[fun_prop]
+lemma differentiable_toFieldStrength_of_smooth {d}
+    {A : ElectromagneticPotential d} (hA : ContDiff ℝ ∞ A) :
+    Differentiable ℝ A.toFieldStrength :=
+  differentiable_toFieldStrength (hA.of_le (ENat.LEInfty.out))
+
+@[fun_prop]
+lemma contDiff_toFieldStrength {d} {n : WithTop ℕ∞} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ (n + 1) A) : ContDiff ℝ n A.toFieldStrength := by
+  change ContDiff ℝ n (A.toFieldStrength ·)
+  simp only [toFieldStrength_eq_sum_basis_single (hA.differentiable (by simp))]
+  fun_prop
+
+/-!
+
+### A.5. Elements of the field strength tensor in terms of basis
 
 -/
 
@@ -377,7 +405,7 @@ lemma toFieldStrength_basis_repr_apply_eq_single {d} {μν : (Fin 1 ⊕ Fin d) �
 
 /-!
 
-### A.5. The field strength matrix
+### A.6. The field strength matrix
 
 We define the field strength matrix to be the matrix representation of the field strength tensor
 in the standard basis.
@@ -416,7 +444,7 @@ lemma toFieldStrength_eq_fieldStrengthMatrix {d} (A : ElectromagneticPotential d
 
 /-!
 
-#### A.5.1. Differentiability of the field strength matrix
+#### A.6.1. Differentiability of the field strength matrix
 
 -/
 
@@ -437,20 +465,6 @@ lemma fieldStrengthMatrix_differentiable {d} {A : ElectromagneticPotential d}
   · exact diff_partial _ _
   apply Differentiable.const_mul
   · exact diff_partial _ _
-
-set_option backward.isDefEq.respectTransparency false in
-lemma toFieldStrength_differentiable {d} {A : ElectromagneticPotential d}
-    (hA : ContDiff ℝ 2 A) :
-    Differentiable ℝ (toFieldStrength A) := by
-  conv =>
-    enter [2]
-    rw [toFieldStrength_eq_fieldStrengthMatrix]
-  apply Differentiable.fun_sum
-  intro μ _
-  apply Differentiable.fun_sum
-  intro ν _
-  apply Differentiable.smul_const
-  exact fieldStrengthMatrix_differentiable hA
 
 lemma fieldStrengthMatrix_differentiable_space {d} {A : ElectromagneticPotential d}
     {μν} (hA : ContDiff ℝ 2 A) (t : Time) {c : SpeedOfLight} :
@@ -503,7 +517,7 @@ lemma fieldStrengthMatrix_smooth {d} {A : ElectromagneticPotential d}
 
 /-!
 
-### A.6. The antisymmetry of the field strength tensor
+### A.7. The antisymmetry of the field strength tensor
 
 We show that the field strength tensor is antisymmetric.
 
@@ -539,7 +553,7 @@ lemma fieldStrengthMatrix_diag_eq_zero {d} (A : ElectromagneticPotential d) (x :
 
 /-!
 
-### A.7. Equivariance of the field strength matrix
+### A.8. Equivariance of the field strength matrix
 
 -/
 
@@ -582,7 +596,7 @@ lemma fieldStrengthMatrix_equivariant {d} (A : ElectromagneticPotential d)
 
 /-!
 
-### A.8. Linearity of the field strength tensor
+### A.9. Linearity of the field strength tensor
 
 We show that the field strength tensor is linear in the potential.
 


### PR DESCRIPTION
We add some basic API about the differentiability of the field-strength tensor. This is then used to golf some down-stream proofs. 