### PR TITLE
Add basic formalisation of the free particle in classical mechanics

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -2,9 +2,9 @@ module
 
 public import Physlib.ClassicalFieldTheory.Local.Variation
 public import Physlib.ClassicalMechanics.Basic
-public import Physlib.ClassicalMechanics.FreeParticle.Basic
 public import Physlib.ClassicalMechanics.DampedHarmonicOscillator.Basic
 public import Physlib.ClassicalMechanics.EulerLagrange
+public import Physlib.ClassicalMechanics.FreeParticle.Basic
 public import Physlib.ClassicalMechanics.HamiltonsEquations
 public import Physlib.ClassicalMechanics.HarmonicOscillator.Basic
 public import Physlib.ClassicalMechanics.HarmonicOscillator.ConfigurationSpace

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -2,6 +2,7 @@ module
 
 public import Physlib.ClassicalFieldTheory.Local.Variation
 public import Physlib.ClassicalMechanics.Basic
+public import Physlib.ClassicalMechanics.FreeParticle.Basic
 public import Physlib.ClassicalMechanics.DampedHarmonicOscillator.Basic
 public import Physlib.ClassicalMechanics.EulerLagrange
 public import Physlib.ClassicalMechanics.HamiltonsEquations

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -76,23 +76,21 @@ The mass of the free particle.
 This parameter determines the inertial response of the particle in
 Newton's second law.
 -/
-
   mass : ℝ
   mass_pos : 0 < mass
 
 namespace FreeParticle
+
 /-- 
 A trajectory is a time-dependent position function describing the motion
 of the particle in one spatial dimension. Defining the trajectory.
 -/
-
 abbrev Trajectory := Time → ℝ
 
 /-- 
 The velocity of a trajectory at a given time.
 This is defined as the time derivative of the position function.
 -/
-
 noncomputable
 def velocity (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
   deriv q t
@@ -103,7 +101,6 @@ The kinetic energy of the free particle along a trajectory.
 This is given by the classical expression `E = (1 / 2) m v²`,
 where `m` is the particle mass and `v` is the velocity.
 -/
-
 noncomputable
 def kineticEnergy (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
   (1 / 2) * s.mass * (s.velocity q t)^2

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -54,6 +54,8 @@ Newton’s law → zero acceleration → constant velocity → constant energy.
 
 -/
 
+@[expose] public section
+
 namespace ClassicalMechanics
 
 open Time
@@ -150,7 +152,6 @@ lemma velocity_const_of_zero_acc (q : Time → ℝ) (h : ∀ t, deriv (deriv q) 
     (hcont : ContDiff ℝ 1 q) : ∃ v₀, ∀ t, deriv q t = v₀ := by
   -- this is a standard analysis result (related to `is_const_of_fderiv_eq_zero`)
   sorry
-
 /--
 A free particle satisfying the equation of motion conserves kinetic energy.
 
@@ -160,6 +161,7 @@ turn implies that the velocity is constant. Since the kinetic energy
 depends only on the square of the velocity, it follows that the kinetic
 energy is constant in time.
 -/
+@[sorryful]
 theorem kineticEnergy_conserved (s : FreeParticle) (q : Trajectory)
     (h : ∀ t, s.NewtonsSecondLaw q t) (hcont : ContDiff ℝ 1 q) :
     ∃ E, ∀ t, s.kineticEnergy q t = E := by

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -8,7 +8,8 @@ module
 public import Mathlib.Data.Real.Basic
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Physlib.Meta.TODO.Basic
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.Meta.Sorry
+public import Physlib.SpaceAndTime.Time.Derivatives
 /-!
 # The Free Particle
 
@@ -55,10 +56,10 @@ Newton’s law → zero acceleration → constant velocity → constant energy.
 
 namespace ClassicalMechanics
 
-
+open Time
 TODO "Prove conservation of linear momentum for the free particle."
 
-/-- 
+/--
 A classical free particle with positive mass.
 
 A free particle is a mechanical system evolving in the absence of
@@ -70,32 +71,34 @@ that the mass is strictly positive is physically natural and is used
 throughout the development when simplifying the equation of motion.
 -/
 structure FreeParticle where
-/-- 
-The mass of the free particle.
+  /--
+  The mass of the free particle.
 
-This parameter determines the inertial response of the particle in
-Newton's second law.
--/
+  This parameter determines the inertial response of the particle in
+  Newton's second law.
+  -/
   mass : ℝ
   mass_pos : 0 < mass
 
 namespace FreeParticle
 
-/-- 
+/--
 A trajectory is a time-dependent position function describing the motion
 of the particle in one spatial dimension. Defining the trajectory.
 -/
 abbrev Trajectory := Time → ℝ
 
-/-- 
+set_option linter.unusedVariables false in
+/--
 The velocity of a trajectory at a given time.
 This is defined as the time derivative of the position function.
 -/
+@[nolint unusedArguments]
 noncomputable
 def velocity (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
   deriv q t
 
-/-- 
+/--
 The kinetic energy of the free particle along a trajectory.
 
 This is given by the classical expression `E = (1 / 2) m v²`,
@@ -105,7 +108,7 @@ noncomputable
 def kineticEnergy (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
   (1 / 2) * s.mass * (s.velocity q t)^2
 
-/-- 
+/--
 Newton's second law for the free particle.
 
 Since no external forces act on the particle, Newton's second law
@@ -115,7 +118,7 @@ vanishes identically.
 def NewtonsSecondLaw (s : FreeParticle) (q : Trajectory) (t : Time) : Prop :=
   s.mass * deriv (s.velocity q) t = 0
 
-/-- 
+/--
 Newton's second law for a free particle implies that the acceleration
 vanishes identically.
 
@@ -123,17 +126,14 @@ Since the particle mass is strictly positive, the equation
 `m q'' = 0` can be simplified to `q'' = 0` by cancelling the mass
 factor.
 -/
-lemma accel_zero
-    (s : FreeParticle)
-    (q : Trajectory)
-    (h : ∀ t, s.NewtonsSecondLaw q t) :
+lemma accel_zero (s : FreeParticle) (q : Trajectory) (h : ∀ t, s.NewtonsSecondLaw q t) :
     ∀ t, deriv (deriv q) t = 0 := by
-    intro t
-    have h₀ : s.mass ≠ 0 := ne_of_gt s.mass_pos
-    have h1 := h t
-    exact (mul_eq_zero.mp h1).resolve_left h₀
+  intro t
+  have h₀ : s.mass ≠ 0 := ne_of_gt s.mass_pos
+  have h1 := h t
+  exact (mul_eq_zero.mp h1).resolve_left h₀
 
-/-- 
+/--
 If the acceleration of a trajectory vanishes everywhere, then the
 velocity is constant.
 
@@ -146,13 +146,10 @@ results from real analysis relating vanishing derivatives to constant
 functions.
 -/
 @[sorryful]
-lemma velocity_const_of_zero_acc
-    (q : ℝ → ℝ)
-    (h : ∀ t, deriv (deriv q) t = 0)
-    (hcont : Continuous (deriv q)) :
-    ∃ v₀, ∀ t, deriv q t = v₀ := by
-    -- this is a standard analysis result (can be proved later)
-    sorry
+lemma velocity_const_of_zero_acc (q : Time → ℝ) (h : ∀ t, deriv (deriv q) t = 0)
+    (hcont : ContDiff ℝ 1 q) : ∃ v₀, ∀ t, deriv q t = v₀ := by
+  -- this is a standard analysis result (related to `is_const_of_fderiv_eq_zero`)
+  sorry
 
 /--
 A free particle satisfying the equation of motion conserves kinetic energy.
@@ -163,25 +160,18 @@ turn implies that the velocity is constant. Since the kinetic energy
 depends only on the square of the velocity, it follows that the kinetic
 energy is constant in time.
 -/
-theorem kineticEnergy_conserved
-    (s : FreeParticle)
-    (q : Trajectory)
-    (h : ∀ t, s.NewtonsSecondLaw q t)
-    (hcont : Continuous (deriv q)) :
-    ∃ E, ∀ t, s.kinetic_energy q t = E := by
-
-    -- get q'' = 0
-    have h_acc : ∀ t, deriv (deriv q) t = 0 :=
-    accel_zero s q h
-    -- get constant velocity
-    rcases velocity_const_of_zero_acc q h_acc hcont with ⟨v₀, hv⟩
-    -- energy is constant
-    have h_ke : ∀ t, s.kinetic_energy q t = (1 / 2) * s.mass * v₀^2 := by
-    intro t
-    unfold kinetic_energy velocity
-    rw [hv t]
-
-    exact ⟨(1 / 2) * s.mass * v₀^2, h_ke⟩
+theorem kineticEnergy_conserved (s : FreeParticle) (q : Trajectory)
+    (h : ∀ t, s.NewtonsSecondLaw q t) (hcont : ContDiff ℝ 1 q) :
+    ∃ E, ∀ t, s.kineticEnergy q t = E := by
+  -- get q'' = 0
+  have h_acc : ∀ t, deriv (deriv q) t = 0 :=
+  accel_zero s q h
+  -- get constant velocity
+  rcases velocity_const_of_zero_acc q h_acc hcont with ⟨v₀, hv⟩
+  -- energy is constant
+  refine ⟨(1 / 2) * s.mass * v₀^2, fun t => ?_⟩
+  unfold kineticEnergy velocity
+  rw [hv t]
 
 end FreeParticle
 end ClassicalMechanics

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -70,6 +70,13 @@ that the mass is strictly positive is physically natural and is used
 throughout the development when simplifying the equation of motion.
 -/
 structure FreeParticle where
+/-- 
+The mass of the free particle.
+
+This parameter determines the inertial response of the particle in
+Newton's second law.
+-/
+
   mass : ℝ
   mass_pos : 0 < mass
 

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -124,14 +124,14 @@ Since the particle mass is strictly positive, the equation
 factor.
 -/
 lemma accel_zero
-  (s : FreeParticle)
-  (q : Trajectory)
-  (h : ∀ t, s.NewtonsSecondLaw q t) :
-  ∀ t, deriv (deriv q) t = 0 := by
-  intro t
-  have h₀ : s.mass ≠ 0 := ne_of_gt s.mass_pos
-  have h1 := h t
-  exact (mul_eq_zero.mp h1).resolve_left h₀
+    (s : FreeParticle)
+    (q : Trajectory)
+    (h : ∀ t, s.NewtonsSecondLaw q t) :
+    ∀ t, deriv (deriv q) t = 0 := by
+    intro t
+    have h₀ : s.mass ≠ 0 := ne_of_gt s.mass_pos
+    have h1 := h t
+    exact (mul_eq_zero.mp h1).resolve_left h₀
 
 /-- 
 If the acceleration of a trajectory vanishes everywhere, then the
@@ -147,14 +147,14 @@ functions.
 -/
 @[sorryful]
 lemma velocity_const_of_zero_acc
-  (q : ℝ → ℝ)
-  (h : ∀ t, deriv (deriv q) t = 0)
-  (hcont : Continuous (deriv q)) :
-  ∃ v₀, ∀ t, deriv q t = v₀ := by
-  -- this is a standard analysis result (can be proved later)
-  sorry
+    (q : ℝ → ℝ)
+    (h : ∀ t, deriv (deriv q) t = 0)
+    (hcont : Continuous (deriv q)) :
+    ∃ v₀, ∀ t, deriv q t = v₀ := by
+    -- this is a standard analysis result (can be proved later)
+    sorry
 
-/-- 
+/--
 A free particle satisfying the equation of motion conserves kinetic energy.
 
 The proof follows the standard argument from classical mechanics:
@@ -164,24 +164,24 @@ depends only on the square of the velocity, it follows that the kinetic
 energy is constant in time.
 -/
 theorem kineticEnergy_conserved
-  (s : FreeParticle)
-  (q : Trajectory)
-  (h : ∀ t, s.NewtonsSecondLaw q t)
-  (hcont : Continuous (deriv q)) :
-  ∃ E, ∀ t, s.kinetic_energy q t = E := by
+    (s : FreeParticle)
+    (q : Trajectory)
+    (h : ∀ t, s.NewtonsSecondLaw q t)
+    (hcont : Continuous (deriv q)) :
+    ∃ E, ∀ t, s.kinetic_energy q t = E := by
 
-  -- get q'' = 0
-  have h_acc : ∀ t, deriv (deriv q) t = 0 :=
+    -- get q'' = 0
+    have h_acc : ∀ t, deriv (deriv q) t = 0 :=
     accel_zero s q h
-  -- get constant velocity
-  rcases velocity_const_of_zero_acc q h_acc hcont with ⟨v₀, hv⟩
-  -- energy is constant
-  have h_ke : ∀ t, s.kinetic_energy q t = (1 / 2) * s.mass * v₀^2 := by
+    -- get constant velocity
+    rcases velocity_const_of_zero_acc q h_acc hcont with ⟨v₀, hv⟩
+    -- energy is constant
+    have h_ke : ∀ t, s.kinetic_energy q t = (1 / 2) * s.mass * v₀^2 := by
     intro t
     unfold kinetic_energy velocity
     rw [hv t]
 
-  exact ⟨(1 / 2) * s.mass * v₀^2, h_ke⟩
+    exact ⟨(1 / 2) * s.mass * v₀^2, h_ke⟩
 
 end FreeParticle
 end ClassicalMechanics

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -55,9 +55,9 @@ Newton’s law → zero acceleration → constant velocity → constant energy.
 
 namespace ClassicalMechanics
 
-TODO "Make the documantation more descriptive"
-TODO "Prove momentum conservation"
-TODO "Prove the velocity_const_of_zero_acc lemma"
+
+TODO "Prove conservation of linear momentum for the free particle."
+
 /-- 
 A classical free particle with positive mass.
 

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -45,8 +45,6 @@ Newton’s law → zero acceleration → constant velocity → constant energy.
 
 ## iv. References
 
-- Landau & Lifshitz, *Mechanics*
-- Goldstein, *Classical Mechanics*
 
 -/
 import Mathlib.Data.Real.Basic

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Pranav Magdum. All rights reserved.
+Copyright (c) 2026 Pranav Magdum. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Pranav Magdum
 -/
@@ -15,7 +15,7 @@ at constant velocity.
 
 In this file, we work in a simple 1D coordinate system where position and velocity are functions
 of time with values in `ℝ`. This keeps things easy to reason about. A more complete treatment would
-use manifolds and tangent bundles, but that’s overkill here.
+use manifolds and tangent bundles.
 
 ## ii. Key results
 

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -3,6 +3,11 @@ Copyright (c) 2026 Pranav Magdum. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Pranav Magdum
 -/
+module
+
+public import Mathlib.Data.Real.Basic
+public import Mathlib.Analysis.Calculus.Deriv.Basic
+public import Physlib.Meta.TODO.Basic
 
 /-!
 # The Free Particle
@@ -47,9 +52,7 @@ Newton’s law → zero acceleration → constant velocity → constant energy.
 
 
 -/
-import Mathlib.Data.Real.Basic
-import Mathlib.Analysis.Calculus.Deriv.Basic
-import Physlib.Meta.TODO.Basic
+
 namespace ClassicalMechanics
 
 TODO "Make the documantation more descriptive"

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2025 Pranav Magdum. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pranav Magdum
+-/
+
+/-!
+# The Free Particle
+
+## i. Overview
+
+The free particle is one of the simplest systems in classical mechanics: a particle of mass `m`
+moving with no external forces acting on it. Physically, this means the particle just keeps moving
+at constant velocity.
+
+In this file, we work in a simple 1D coordinate system where position and velocity are functions
+of time with values in `ℝ`. This keeps things easy to reason about. A more complete treatment would
+use manifolds and tangent bundles, but that’s overkill here.
+
+## ii. Key results
+
+The main things we show about the free particle are:
+
+In the `Basic` module:
+- `FreeParticle` stores the mass of the particle.
+- `NewtonsSecondLaw` encodes the equation `m * q'' = 0`.
+- `accel_zero` shows that this implies `q'' = 0`.
+- `velocity_const_of_zero_acc` shows that zero acceleration means velocity is constant.
+- `energy_conservation_of_equationOfMotion` shows that kinetic energy stays constant over time.
+
+So overall, we formalise the usual chain:
+Newton’s law → zero acceleration → constant velocity → constant energy.
+
+## iii. Table of contents
+
+- A. The setup
+- B. Equation of motion
+  - B.1. Newton's second law
+  - B.2. Zero acceleration
+- C. What zero acceleration implies
+  - C.1. Constant velocity
+- D. Energy
+  - D.1. Kinetic energy
+  - D.2. Energy conservation
+
+## iv. References
+
+- Landau & Lifshitz, *Mechanics*
+- Goldstein, *Classical Mechanics*
+
+-/
+import Mathlib.Data.Real.Basic
+import Mathlib.Analysis.Calculus.Deriv.Basic
+import Physlib.Meta.TODO.Basic
+namespace ClassicalMechanics
+
+TODO "Make the documantation more descriptive"
+TODO "Prove momentum conservation"
+TODO "Prove the velocity_const_of_zero_acc lemma"
+
+structure FreeParticle where
+  mass : ℝ
+  mass_pos : 0 < mass
+
+namespace FreeParticle
+
+abbrev Time := ℝ
+abbrev Trajectory := Time → ℝ
+
+noncomputable
+def velocity (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
+  deriv q t
+
+noncomputable
+def kinetic_energy (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
+  (1 / 2) * s.mass * (s.velocity q t)^2
+
+def NewtonsSecondLaw (s : FreeParticle) (q : Trajectory) (t : Time) : Prop :=
+  s.mass * deriv (s.velocity q) t = 0
+
+-- Step 1: get q'' = 0
+lemma accel_zero
+  (s : FreeParticle)
+  (q : Trajectory)
+  (h : ∀ t, s.NewtonsSecondLaw q t) :
+  ∀ t, deriv (deriv q) t = 0 := by
+  intro t
+  have h₀ : s.mass ≠ 0 := ne_of_gt s.mass_pos
+  have h1 := h t
+  exact (mul_eq_zero.mp h1).resolve_left h₀
+
+-- Step 2: velocity is constant 
+lemma velocity_const_of_zero_acc
+  (q : ℝ → ℝ)
+  (h : ∀ t, deriv (deriv q) t = 0)
+  (hcont : Continuous (deriv q)) :
+  ∃ v₀, ∀ t, deriv q t = v₀ := by
+  -- this is a standard analysis result (can be proved later)
+  sorry
+
+-- Step 3: Energy conservation
+theorem Energy_is_Conserved
+  (s : FreeParticle)
+  (q : Trajectory)
+  (h : ∀ t, s.NewtonsSecondLaw q t)
+  (hcont : Continuous (deriv q)) :
+  ∃ E, ∀ t, s.kinetic_energy q t = E := by
+
+  -- get q'' = 0
+  have h_acc : ∀ t, deriv (deriv q) t = 0 :=
+    accel_zero s q h
+
+  -- get constant velocity
+  rcases velocity_const_of_zero_acc q h_acc hcont with ⟨v₀, hv⟩
+
+  -- energy is constant
+  have h_ke : ∀ t, s.kinetic_energy q t = (1 / 2) * s.mass * v₀^2 := by
+    intro t
+    unfold kinetic_energy velocity
+    rw [hv t]
+
+  exact ⟨(1 / 2) * s.mass * v₀^2, h_ke⟩
+
+end FreeParticle
+end ClassicalMechanics

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -85,12 +85,14 @@ namespace FreeParticle
 A trajectory is a time-dependent position function describing the motion
 of the particle in one spatial dimension. Defining the trajectory.
 -/
+
 abbrev Trajectory := Time → ℝ
+
 /-- 
 The velocity of a trajectory at a given time.
-
 This is defined as the time derivative of the position function.
 -/
+
 noncomputable
 def velocity (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
   deriv q t
@@ -113,7 +115,6 @@ Since no external forces act on the particle, Newton's second law
 reduces to the equation `m q'' = 0`, expressing that the acceleration
 vanishes identically.
 -/
-
 def NewtonsSecondLaw (s : FreeParticle) (q : Trajectory) (t : Time) : Prop :=
   s.mass * deriv (s.velocity q) t = 0
 

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -72,7 +72,7 @@ def velocity (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
   deriv q t
 
 noncomputable
-def kinetic_energy (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
+def kineticEnergy (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
   (1 / 2) * s.mass * (s.velocity q t)^2
 
 def NewtonsSecondLaw (s : FreeParticle) (q : Trajectory) (t : Time) : Prop :=
@@ -99,7 +99,7 @@ lemma velocity_const_of_zero_acc
   sorry
 
 -- Step 3: Energy conservation
-theorem Energy_is_Conserved
+theorem kineticEnergy_conserved
   (s : FreeParticle)
   (q : Trajectory)
   (h : ∀ t, s.NewtonsSecondLaw q t)

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -140,7 +140,7 @@ The continuity assumption on `deriv q` is included to apply standard
 results from real analysis relating vanishing derivatives to constant
 functions.
 -/
-
+[@sorryful]
 lemma velocity_const_of_zero_acc
   (q : ℝ → ℝ)
   (h : ∀ t, deriv (deriv q) t = 0)
@@ -168,10 +168,8 @@ theorem kineticEnergy_conserved
   -- get q'' = 0
   have h_acc : ∀ t, deriv (deriv q) t = 0 :=
     accel_zero s q h
-
   -- get constant velocity
   rcases velocity_const_of_zero_acc q h_acc hcont with ⟨v₀, hv⟩
-
   -- energy is constant
   have h_ke : ∀ t, s.kinetic_energy q t = (1 / 2) * s.mass * v₀^2 := by
     intro t

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -58,27 +58,66 @@ namespace ClassicalMechanics
 TODO "Make the documantation more descriptive"
 TODO "Prove momentum conservation"
 TODO "Prove the velocity_const_of_zero_acc lemma"
+/-- 
+A classical free particle with positive mass.
 
+A free particle is a mechanical system evolving in the absence of
+external forces. The dynamics are therefore entirely determined by
+Newton's second law with zero force.
+
+The only parameter of the system is the particle mass. The assumption
+that the mass is strictly positive is physically natural and is used
+throughout the development when simplifying the equation of motion.
+-/
 structure FreeParticle where
   mass : ℝ
   mass_pos : 0 < mass
 
 namespace FreeParticle
-
+/-- 
+A trajectory is a time-dependent position function describing the motion
+of the particle in one spatial dimension. Defining the trajectory.
+-/
 abbrev Trajectory := Time → ℝ
+/-- 
+The velocity of a trajectory at a given time.
 
+This is defined as the time derivative of the position function.
+-/
 noncomputable
 def velocity (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
   deriv q t
+
+/-- 
+The kinetic energy of the free particle along a trajectory.
+
+This is given by the classical expression `E = (1 / 2) m v²`,
+where `m` is the particle mass and `v` is the velocity.
+-/
 
 noncomputable
 def kineticEnergy (s : FreeParticle) (q : Trajectory) (t : Time) : ℝ :=
   (1 / 2) * s.mass * (s.velocity q t)^2
 
+/-- 
+Newton's second law for the free particle.
+
+Since no external forces act on the particle, Newton's second law
+reduces to the equation `m q'' = 0`, expressing that the acceleration
+vanishes identically.
+-/
+
 def NewtonsSecondLaw (s : FreeParticle) (q : Trajectory) (t : Time) : Prop :=
   s.mass * deriv (s.velocity q) t = 0
 
--- Step 1: get q'' = 0
+/-- 
+Newton's second law for a free particle implies that the acceleration
+vanishes identically.
+
+Since the particle mass is strictly positive, the equation
+`m q'' = 0` can be simplified to `q'' = 0` by cancelling the mass
+factor.
+-/
 lemma accel_zero
   (s : FreeParticle)
   (q : Trajectory)
@@ -89,7 +128,19 @@ lemma accel_zero
   have h1 := h t
   exact (mul_eq_zero.mp h1).resolve_left h₀
 
--- Step 2: velocity is constant 
+/-- 
+If the acceleration of a trajectory vanishes everywhere, then the
+velocity is constant.
+
+More precisely, if the second derivative of the trajectory is zero
+for all times, then there exists a constant `v₀` such that the
+velocity is equal to `v₀` at every time.
+
+The continuity assumption on `deriv q` is included to apply standard
+results from real analysis relating vanishing derivatives to constant
+functions.
+-/
+
 lemma velocity_const_of_zero_acc
   (q : ℝ → ℝ)
   (h : ∀ t, deriv (deriv q) t = 0)
@@ -98,7 +149,15 @@ lemma velocity_const_of_zero_acc
   -- this is a standard analysis result (can be proved later)
   sorry
 
--- Step 3: Energy conservation
+/-- 
+A free particle satisfying the equation of motion conserves kinetic energy.
+
+The proof follows the standard argument from classical mechanics:
+Newton's second law implies that the acceleration vanishes, which in
+turn implies that the velocity is constant. Since the kinetic energy
+depends only on the square of the velocity, it follows that the kinetic
+energy is constant in time.
+-/
 theorem kineticEnergy_conserved
   (s : FreeParticle)
   (q : Trajectory)

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -140,7 +140,7 @@ The continuity assumption on `deriv q` is included to apply standard
 results from real analysis relating vanishing derivatives to constant
 functions.
 -/
-[@sorryful]
+@[sorryful]
 lemma velocity_const_of_zero_acc
   (q : ℝ → ℝ)
   (h : ∀ t, deriv (deriv q) t = 0)

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Data.Real.Basic
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Physlib.Meta.TODO.Basic
-
+public import Physlib.SpaceAndTime.Time.Basic
 /-!
 # The Free Particle
 
@@ -65,7 +65,6 @@ structure FreeParticle where
 
 namespace FreeParticle
 
-abbrev Time := ℝ
 abbrev Trajectory := Time → ℝ
 
 noncomputable


### PR DESCRIPTION
This PR adds a simple formalisation of the free particle: a particle of mass m with no external forces acting on it.

The goal is to capture the standard first-step reasoning from classical mechanics in Lean. Starting from Newton’s second law (m * q'' = 0), we show:

acceleration is zero,
velocity is constant,
kinetic energy is conserved.

The development is intentionally minimal and 1-dimensional (ℝ → ℝ) to keep things easy to follow. The harder analysis step (showing zero acceleration implies constant velocity) is currently isolated in a lemma, so the overall structure is clear and can be extended later.
