### PR TITLE
auto-task(exists_boost_mul_rotation): prove restricted Lorentz elements are a boost times a rotation

### DIFF
--- a/Physlib/Relativity/LorentzGroup/Restricted/Basic.lean
+++ b/Physlib/Relativity/LorentzGroup/Restricted/Basic.lean
@@ -16,9 +16,6 @@ This file is currently a stub.
 
 @[expose] public section
 
-TODO "Prove that every member of the restricted Lorentz group is
-  combination of a boost and a rotation."
-
 namespace LorentzGroup
 
 open Matrix

--- a/Physlib/Relativity/LorentzGroup/Restricted/FromBoostRotation.lean
+++ b/Physlib/Relativity/LorentzGroup/Restricted/FromBoostRotation.lean
@@ -102,6 +102,16 @@ def toBoostRotation {d} : LorentzGroup.restricted d ≃ₜ Lorentz.Velocity d ×
   continuous_toFun := by fun_prop
   continuous_invFun := by fun_prop
 
+/-- Every element of the restricted Lorentz group can be written as a product of a
+  generalized boost and a rotation. -/
+theorem exists_boost_mul_rotation {d} (Λ : LorentzGroup.restricted d) :
+    ∃ (v : Lorentz.Velocity d) (R : Rotations d),
+      (Λ : LorentzGroup d) = generalizedBoost 0 v * (R : LorentzGroup d) := by
+  refine ⟨toVelocity Λ, toRotation Λ, ?_⟩
+  have h : (toRotation Λ : LorentzGroup d) =
+      (generalizedBoost 0 (toVelocity Λ))⁻¹ * (Λ : LorentzGroup d) := rfl
+  rw [h, mul_inv_cancel_left]
+
 end LorentzGroup
 
 end

--- a/Physlib/Relativity/LorentzGroup/Restricted/FromBoostRotation.lean
+++ b/Physlib/Relativity/LorentzGroup/Restricted/FromBoostRotation.lean
@@ -107,10 +107,8 @@ def toBoostRotation {d} : LorentzGroup.restricted d ≃ₜ Lorentz.Velocity d ×
 theorem exists_boost_mul_rotation {d} (Λ : LorentzGroup.restricted d) :
     ∃ (v : Lorentz.Velocity d) (R : Rotations d),
       (Λ : LorentzGroup d) = generalizedBoost 0 v * (R : LorentzGroup d) := by
-  refine ⟨toVelocity Λ, toRotation Λ, ?_⟩
-  have h : (toRotation Λ : LorentzGroup d) =
-      (generalizedBoost 0 (toVelocity Λ))⁻¹ * (Λ : LorentzGroup d) := rfl
-  rw [h, mul_inv_cancel_left]
+  have h : toRotation Λ = (generalizedBoost 0 (toVelocity Λ))⁻¹ * Λ := rfl
+  exact ⟨toVelocity Λ, toRotation Λ, by rw [h, mul_inv_cancel_left]⟩
 
 end LorentzGroup
 


### PR DESCRIPTION
## Summary

Completes the TODO in `Physlib/Relativity/LorentzGroup/Restricted/Basic.lean`:

> `TODO "Prove that every member of the restricted Lorentz group is combination of a boost and a rotation."`

The homeomorphism `LorentzGroup.toBoostRotation` in
`Physlib/Relativity/LorentzGroup/Restricted/FromBoostRotation.lean` already
provides the boost–rotation decomposition; its file docstring states that the
inverse "writes elements of the restricted Lorentz group as a product of a
generalized boost and a rotation". This PR turns that into an explicit,
user-facing existence theorem and removes the now-satisfied TODO note.

## Changes

- Added `LorentzGroup.exists_boost_mul_rotation` to `FromBoostRotation.lean`:
  for every `Λ : LorentzGroup.restricted d` there exist a velocity
  `v : Lorentz.Velocity d` and a rotation `R : Rotations d` with
  `(Λ : LorentzGroup d) = generalizedBoost 0 v * (R : LorentzGroup d)`.
  The proof uses the existing `toVelocity`/`toRotation` maps and
  `mul_inv_cancel_left`.
- Removed the corresponding `TODO "..."` marker from
  `Restricted/Basic.lean`.

## How to review

1. Read the new theorem `exists_boost_mul_rotation`; confirm its statement
   says every restricted Lorentz element equals a generalized boost times a
   rotation, and that it builds with no `sorry`.
2. Confirm the `TODO "Prove that every member of the restricted Lorentz group
   is combination of a boost and a rotation."` note is gone from
   `Restricted/Basic.lean`.
3. `lake build` (project builds green; the theorem depends only on
   `propext`, `Classical.choice`, `Quot.sound` — no new axioms).
