### PR TITLE
auto-task(positionOperatorSchwartz): fix doc-string mislabeling it the parity operator

### DIFF
--- a/Physlib/QuantumMechanics/OneDimension/Operators/Position.lean
+++ b/Physlib/QuantumMechanics/OneDimension/Operators/Position.lean
@@ -59,7 +59,7 @@ open ContDiff
 
 open SchwartzMap
 
-/-- The parity operator on the Schwartz maps is defined as the linear map from
+/-- The position operator on the Schwartz maps is defined as the linear map from
   `𝓢(ℝ, ℂ)` to itself, such that `ψ` is taken to `fun x => x * ψ x`. -/
 def positionOperatorSchwartz : 𝓢(ℝ, ℂ) →L[ℂ] 𝓢(ℝ, ℂ) := Distribution.powOneMul ℂ
 


### PR DESCRIPTION
## Summary

Fixed one factually incorrect doc-string in
`Physlib/QuantumMechanics/OneDimension/Operators/Position.lean`.

**Location:** `Physlib/QuantumMechanics/OneDimension/Operators/Position.lean:62`

**Before → After:**
- Before: `/-- The parity operator on the Schwartz maps is defined as the linear map from `𝓢(ℝ, ℂ)` to itself, such that `ψ` is taken to `fun x => x * ψ x`. -/`
- After: `/-- The position operator on the Schwartz maps is defined as the linear map from `𝓢(ℝ, ℂ)` to itself, such that `ψ` is taken to `fun x => x * ψ x`. -/`

## Evidence the original was wrong

The doc-string documents `positionOperatorSchwartz`
([Position.lean:64](https://github.com/leanprover-community/physlib/blob/c6252487cb688ac76fe8f5f181726caef8131af9/Physlib/QuantumMechanics/OneDimension/Operators/Position.lean#L62-L74)),
which is `Distribution.powOneMul ℂ` — the map `ψ ↦ fun x => x * ψ x` (confirmed by the
`positionOperatorSchwartz_apply` simp lemma). Multiplication by the coordinate `x` **is** the
position operator, and the enclosing section header (Position.lean:54) reads
"## The position operator on Schwartz maps".

The genuine parity operator is a different declaration, `parityOperatorSchwartz`
([Parity.lean:52-53](https://github.com/leanprover-community/physlib/blob/c6252487cb688ac76fe8f5f181726caef8131af9/Physlib/QuantumMechanics/OneDimension/Operators/Parity.lean#L51-L53)),
which maps `ψ ↦ fun x => ψ (-x)` — not `x * ψ x`. The old wording was a copy-paste of that
doc-string, mislabeling the position operator as the "parity operator".

## How to confirm in one step

Compare the doc-string at Position.lean:62 against the declaration name
`positionOperatorSchwartz` and its body `Distribution.powOneMul ℂ` (→ `x * ψ x`) two lines below:
the map is multiplication by `x` (position), not `ψ(-x)` (parity), so "position operator" is the
correct label.

Only the one word `parity → position` was changed; no code was touched. `lake build` of the
module succeeds, and `./scripts/lint-style.sh` and `lake exe runPhyslibLinters` both pass.
