### PR TITLE
refactor: golf proofs in HarmonicOscillator, IsExtrema, TotalDerivativeEquivalence, KineticTerm

### DIFF
--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -227,7 +227,7 @@ lemma equationOfMotion_iff_newtons_2nd_law (xₜ : Time → EuclideanSpace ℝ (
     have ha :
         S.m • ∂ₜ (∂ₜ xₜ) t = -(S.γ • ∂ₜ xₜ t + S.k • xₜ t) :=
       eq_neg_of_add_eq_zero_left h'
-    simpa [sub_eq_add_neg, neg_add, add_comm] using ha
+    simpa [force, sub_eq_add_neg, neg_add, add_comm] using ha
   · intro h t
     rw [h t]
     module

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -227,17 +227,18 @@ private lemma exp_decay_smul_equationOfMotion
 
 /-!
 
-private lemma fderiv_comp_val_eq_deriv (g : ℝ → ℝ) (hg : DifferentiableAt ℝ g t.val) :
-    (fderiv ℝ (fun s : Time => g s.val) t) 1 = _root_.deriv g t.val := by
-  rw [fderiv_fun_comp t hg (by fun_prop), ContinuousLinearMap.comp_apply, Time.fderiv_val]
-  simp
-
 ### B.4. Derivatives of the base trajectories
 
 The remaining private lemmas compute the velocity and acceleration of the trigonometric,
 polynomial, and hyperbolic base trajectories before the exponential decay factor is applied.
 
 -/
+
+private lemma fderiv_comp_val_eq_deriv {t : Time} (g : ℝ → ℝ)
+    (hg : DifferentiableAt ℝ g t.val) :
+    (fderiv ℝ (fun s : Time => g s.val) t) 1 = _root_.deriv g t.val := by
+  rw [fderiv_fun_comp t hg (by fun_prop), ContinuousLinearMap.comp_apply, Time.fderiv_val]
+  simp
 
 private lemma criticallyDampedBase_velocity (IC : InitialConditions) :
     ∂ₜ (S.criticallyDampedBase IC) =

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -207,7 +207,7 @@ private lemma exp_decay_smul_acceleration
     FunLike.coe_smul, Pi.smul_apply, smul_eq_mul]
   rw [hy''_t, ← Time.deriv_eq]
   simp [smul_add, smul_sub, smul_smul]
-  module
+  ext i; simp; ring
 
 private lemma exp_decay_smul_equationOfMotion
     (a μ : ℝ) (y : Time → EuclideanSpace ℝ (Fin 1))
@@ -219,7 +219,7 @@ private lemma exp_decay_smul_equationOfMotion
   rw [exp_decay_smul_acceleration a μ y hy hdy hy'', exp_decay_smul_velocity a y hy,
     hγ, hk]
   simp [smul_add, smul_sub, smul_smul]
-  module
+  ext i; simp; ring
 
 /-!
 

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -178,9 +178,8 @@ private lemma exp_decay_smul_velocity
     ∂ₜ (fun t : Time => exp (-a * t.val) • y t) =
       fun t : Time => exp (-a * t.val) • (∂ₜ y t - a • y t) := by
   funext t
-  rw [Time.deriv]
-  rw [fderiv_fun_smul (by fun_prop) (hy t)]
-  rw [fderiv_exp (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+  rw [Time.deriv, fderiv_fun_smul (by fun_prop) (hy t), fderiv_exp (by fun_prop),
+    fderiv_fun_mul (by fun_prop) (by fun_prop)]
   simp only [add_apply, ContinuousLinearMap.smulRight_apply,
     fderiv_fun_neg, fderiv_fun_const, Pi.zero_apply, Time.fderiv_val,
     _root_.neg_apply, FunLike.coe_smul, Pi.smul_apply, smul_eq_mul]
@@ -197,11 +196,9 @@ private lemma exp_decay_smul_acceleration
         (μ • y t - (2 * a) • ∂ₜ y t + a^2 • y t) := by
   rw [exp_decay_smul_velocity a y hy]
   funext t
-  rw [Time.deriv]
-  rw [fderiv_fun_smul (by fun_prop) (by fun_prop)]
-  rw [fderiv_exp (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
-  rw [fderiv_fun_sub (hdy t) (by fun_prop)]
-  rw [fderiv_fun_const_smul (hy t)]
+  rw [Time.deriv, fderiv_fun_smul (by fun_prop) (by fun_prop),
+    fderiv_exp (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop),
+    fderiv_fun_sub (hdy t) (by fun_prop), fderiv_fun_const_smul (hy t)]
   have hy''_t := congrFun hy'' t
   rw [Time.deriv] at hy''_t
   simp only [add_apply, _root_.sub_apply,
@@ -219,9 +216,8 @@ private lemma exp_decay_smul_equationOfMotion
     (hγ : S.γ = 2 * S.m * a) (hk : S.k = S.m * (a^2 - μ)) :
     S.EquationOfMotion (fun t : Time => exp (-a * t.val) • y t) := by
   intro t
-  rw [exp_decay_smul_acceleration a μ y hy hdy hy'']
-  rw [exp_decay_smul_velocity a y hy]
-  rw [hγ, hk]
+  rw [exp_decay_smul_acceleration a μ y hy hdy hy'', exp_decay_smul_velocity a y hy,
+    hγ, hk]
   simp [smul_add, smul_sub, smul_smul]
   module
 
@@ -244,8 +240,7 @@ private lemma criticallyDampedBase_velocity (IC : InitialConditions) :
     ∂ₜ (S.criticallyDampedBase IC) =
       fun _ : Time => IC.v₀ + S.decayRate • IC.x₀ := by
   funext t
-  change ∂ₜ (fun t : Time =>
-    IC.x₀ + t.val • (IC.v₀ + S.decayRate • IC.x₀)) t = _
+  unfold criticallyDampedBase
   rw [Time.deriv_eq, fderiv_fun_add (by fun_prop) (by fun_prop),
     fderiv_fun_const, fderiv_smul_const (by fun_prop)]
   simp
@@ -361,8 +356,9 @@ lemma trajectory_equationOfMotion_of_criticallyDamped (IC : InitialConditions)
       fun_prop)
     (by
       rw [S.criticallyDampedBase_velocity IC]
-      fun_prop) ?_ hγ hk
-  simpa using S.criticallyDampedBase_acceleration IC
+      fun_prop)
+    (by
+      simpa using S.criticallyDampedBase_acceleration IC) hγ hk
 
 /-- In the underdamped regime, the selected trajectory satisfies the damped equation of
 motion. -/
@@ -374,13 +370,14 @@ lemma trajectory_equationOfMotion_of_underdamped (IC : InitialConditions)
   have hk : S.k = S.m * (S.decayRate^2 - (-S.angularFrequency^2)) := by
     rw [S.k_eq_m_mul_ω_sq, S.angularFrequency_sq_of_underdamped hS]
     ring
-  refine S.exp_decay_smul_equationOfMotion S.decayRate
-    (-S.angularFrequency^2) (S.underdampedBase IC)
+  refine S.exp_decay_smul_equationOfMotion S.decayRate (-S.angularFrequency^2)
+    (S.underdampedBase IC)
     (by
       unfold underdampedBase
       fun_prop) ?_
     (S.underdampedBase_acceleration IC hS) hγ hk
-  rw [show ∂ₜ (S.underdampedBase IC) = _ from S.underdampedBase_velocity IC hS]
+  unfold underdampedBase
+  rw [S.underdampedBase_velocity IC hS]
   fun_prop
 
 /-- In the overdamped regime, the selected trajectory satisfies the damped equation of
@@ -399,7 +396,8 @@ lemma trajectory_equationOfMotion_of_overdamped (IC : InitialConditions)
       unfold overdampedBase
       fun_prop) ?_
     (S.overdampedBase_acceleration IC hS) hγ hk
-  rw [show ∂ₜ (S.overdampedBase IC) = _ from S.overdampedBase_velocity IC hS]
+  unfold overdampedBase
+  rw [S.overdampedBase_velocity IC hS]
   fun_prop
 
 /-- The selected trajectory satisfies the damped equation of motion. -/

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -184,8 +184,7 @@ private lemma exp_decay_smul_velocity
     fderiv_fun_neg, fderiv_fun_const, Pi.zero_apply, Time.fderiv_val,
     _root_.neg_apply, FunLike.coe_smul, Pi.smul_apply, smul_eq_mul]
   rw [← Time.deriv_eq]
-  simp [smul_sub, smul_smul]
-  module
+  simp [smul_smul, sub_eq_add_neg]
 
 private lemma exp_decay_smul_acceleration
     (a μ : ℝ) (y : Time → EuclideanSpace ℝ (Fin 1))

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -407,8 +407,9 @@ lemma trajectory_equationOfMotion (IC : InitialConditions) :
   · by_cases hCritical : S.IsCriticallyDamped
     · exact S.trajectory_equationOfMotion_of_criticallyDamped IC hCritical
     · have hOver : S.IsOverdamped := by
-        rw [IsOverdamped, IsUnderdamped] at *
-        exact lt_of_le_of_ne (not_lt.mp hUnder) (Ne.symm hCritical)
+        dsimp [IsOverdamped, IsUnderdamped, IsCriticallyDamped] at hUnder hCritical ⊢
+        have hle : 0 ≤ S.discriminant := not_lt.mp hUnder
+        exact lt_of_le_of_ne hle (Ne.symm hCritical)
       exact S.trajectory_equationOfMotion_of_overdamped IC hOver
 
 /-!

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -227,6 +227,11 @@ private lemma exp_decay_smul_equationOfMotion
 
 /-!
 
+private lemma fderiv_comp_val_eq_deriv (g : ℝ → ℝ) (hg : DifferentiableAt ℝ g t.val) :
+    (fderiv ℝ (fun s : Time => g s.val) t) 1 = _root_.deriv g t.val := by
+  rw [fderiv_fun_comp t hg (by fun_prop), ContinuousLinearMap.comp_apply, Time.fderiv_val]
+  simp
+
 ### B.4. Derivatives of the base trajectories
 
 The remaining private lemmas compute the velocity and acceleration of the trigonometric,
@@ -262,11 +267,6 @@ private lemma underdampedBase_velocity (IC : InitialConditions) (hS : S.IsUnderd
           (IC.v₀ + S.decayRate • IC.x₀) := by
   have hΩ : S.angularFrequency ≠ 0 := S.angularFrequency_ne_zero_of_underdamped hS
   funext t
-  have fderiv_comp_val_eq_deriv : ∀ g : ℝ → ℝ, DifferentiableAt ℝ g t.val →
-      (fderiv ℝ (fun s : Time => g s.val) t) 1 = _root_.deriv g t.val := by
-    intro g hg
-    rw [fderiv_fun_comp t hg (by fun_prop), ContinuousLinearMap.comp_apply, Time.fderiv_val]
-    simp
   rw [Time.deriv_eq, fderiv_fun_add (by fun_prop) (by fun_prop),
     fderiv_smul_const (by fun_prop), fderiv_smul_const (by fun_prop)]
   simp only [add_apply, ContinuousLinearMap.smulRight_apply]
@@ -287,11 +287,6 @@ private lemma underdampedBase_acceleration (IC : InitialConditions) (hS : S.IsUn
   have hΩ : S.angularFrequency ≠ 0 := S.angularFrequency_ne_zero_of_underdamped hS
   rw [S.underdampedBase_velocity IC hS]
   funext t
-  have fderiv_comp_val_eq_deriv : ∀ g : ℝ → ℝ, DifferentiableAt ℝ g t.val →
-      (fderiv ℝ (fun s : Time => g s.val) t) 1 = _root_.deriv g t.val := by
-    intro g hg
-    rw [fderiv_fun_comp t hg (by fun_prop), ContinuousLinearMap.comp_apply, Time.fderiv_val]
-    simp
   rw [Time.deriv_eq, fderiv_fun_add (by fun_prop) (by fun_prop),
     fderiv_smul_const (by fun_prop), fderiv_smul_const (by fun_prop)]
   simp only [add_apply, ContinuousLinearMap.smulRight_apply]
@@ -312,11 +307,6 @@ private lemma overdampedBase_velocity (IC : InitialConditions) (hS : S.IsOverdam
           (IC.v₀ + S.decayRate • IC.x₀) := by
   have hΩ : S.angularFrequency ≠ 0 := S.angularFrequency_ne_zero_of_overdamped hS
   funext t
-  have fderiv_comp_val_eq_deriv : ∀ g : ℝ → ℝ, DifferentiableAt ℝ g t.val →
-      (fderiv ℝ (fun s : Time => g s.val) t) 1 = _root_.deriv g t.val := by
-    intro g hg
-    rw [fderiv_fun_comp t hg (by fun_prop), ContinuousLinearMap.comp_apply, Time.fderiv_val]
-    simp
   rw [Time.deriv_eq, fderiv_fun_add (by fun_prop) (by fun_prop),
     fderiv_smul_const (by fun_prop), fderiv_smul_const (by fun_prop)]
   simp only [add_apply, ContinuousLinearMap.smulRight_apply]
@@ -337,11 +327,6 @@ private lemma overdampedBase_acceleration (IC : InitialConditions) (hS : S.IsOve
   have hΩ : S.angularFrequency ≠ 0 := S.angularFrequency_ne_zero_of_overdamped hS
   rw [S.overdampedBase_velocity IC hS]
   funext t
-  have fderiv_comp_val_eq_deriv : ∀ g : ℝ → ℝ, DifferentiableAt ℝ g t.val →
-      (fderiv ℝ (fun s : Time => g s.val) t) 1 = _root_.deriv g t.val := by
-    intro g hg
-    rw [fderiv_fun_comp t hg (by fun_prop), ContinuousLinearMap.comp_apply, Time.fderiv_val]
-    simp
   rw [Time.deriv_eq, fderiv_fun_add (by fun_prop) (by fun_prop),
     fderiv_smul_const (by fun_prop), fderiv_smul_const (by fun_prop)]
   simp only [add_apply, ContinuousLinearMap.smulRight_apply]

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -544,17 +544,9 @@ We now show that the force is equal to `- k x`.
 /-- The force on the classical harmonic oscillator is `- k x`. -/
 lemma force_eq_linear (x : EuclideanSpace ℝ (Fin 1)) : force S x = - S.k • x := by
   unfold force potentialEnergy
-  have hpot : (fun y : EuclideanSpace ℝ (Fin 1) => (1 / (2 : ℝ)) • S.k • ⟪y, y⟫_ℝ) =
-      fun y => ((1 / (2 : ℝ)) * S.k) * ⟪y, y⟫_ℝ := by
-    funext y
-    simp [smul_eq_mul, mul_assoc]
-  rw [hpot]
-  have hgrad : gradient (fun y : EuclideanSpace ℝ (Fin 1) => ((1 / (2 : ℝ)) * S.k) * ⟪y, y⟫_ℝ) x
-      = S.k • x := by
-    simpa [smul_eq_mul, mul_assoc] using
-      (gradient_const_mul_inner_self (c := (1 / (2 : ℝ)) * S.k) x)
-  rw [hgrad]
-  simp [neg_smul]
+  simp only [smul_eq_mul]
+  simpa [mul_assoc] using congrArg Neg.neg
+    (gradient_const_mul_inner_self (c := (1/2) * S.k) x)
 
 /-!
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -273,7 +273,7 @@ lemma kineticEnergy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : Con
   congr 1
   simp only [smul_add]
   module
-  repeat fun_prop
+  all_goals fun_prop
 
 lemma potentialEnergy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff ℝ ∞ xₜ) :
     ∂ₜ (fun t => potentialEnergy S (xₜ t)) = fun t => ⟪∂ₜ xₜ t, S.k • xₜ t⟫_ℝ := by
@@ -294,9 +294,8 @@ lemma potentialEnergy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : C
     module
   rw [real_inner_comm, ← inner_smul_right]
   repeat fun_prop
-  apply Differentiable.differentiableAt
-  rw [contDiff_infty_iff_fderiv] at hx
-  exact hx.1
+  · rw [contDiff_infty_iff_fderiv] at hx
+    apply hx.1
 
 lemma energy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff ℝ ∞ xₜ) :
     ∂ₜ (energy S xₜ) = fun t => ⟪∂ₜ xₜ t, S.m • ∂ₜ (∂ₜ xₜ) t + S.k • xₜ t⟫_ℝ := by
@@ -309,8 +308,7 @@ lemma energy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff �
   rw [potentialEnergy_deriv, kineticEnergy_deriv]
   simp only
   rw [← inner_add_right]
-  fun_prop
-  fun_prop
+  all_goals fun_prop
 
 /-!
 
@@ -400,8 +398,6 @@ lemma gradient_inner_self (x : EuclideanSpace ℝ (Fin 1)) :
   unfold gradient
   rw [InnerProductSpace.toDual_symm_apply]
   have hid : DifferentiableAt ℝ (fun y : EuclideanSpace ℝ (Fin 1) => y) x := differentiableAt_id
-  rw [show (fun y : EuclideanSpace ℝ (Fin 1) => ⟪y, y⟫_ℝ) =
-      fun y => ⟪(fun y => y) y, (fun y => y) y⟫_ℝ from rfl]
   rw [fderiv_inner_apply (𝕜 := ℝ) hid hid]
   simp only [fderiv_fun_id, ContinuousLinearMap.coe_id', id_eq, real_inner_comm, inner_smul_left',
     ringHom_apply]

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -370,19 +370,7 @@ The lagrangian is smooth in all its arguments.
 @[fun_prop]
 lemma contDiff_lagrangian (n : WithTop ℕ∞) : ContDiff ℝ n ↿S.lagrangian := by
   rw [lagrangian_eq]
-  apply ContDiff.sub
-  · apply ContDiff.mul
-    · apply ContDiff.mul
-      · exact contDiff_const
-      · exact contDiff_const
-    · exact ContDiff.inner (𝕜 := ℝ) (contDiff_snd.comp contDiff_snd)
-        (contDiff_snd.comp contDiff_snd)
-  · apply ContDiff.mul
-    · apply ContDiff.mul
-      · exact contDiff_const
-      · exact contDiff_const
-    · exact ContDiff.inner (𝕜 := ℝ) (contDiff_fst.comp contDiff_snd)
-        (contDiff_fst.comp contDiff_snd)
+  fun_prop
 
 lemma toDual_symm_innerSL (x : EuclideanSpace ℝ (Fin 1)) :
     (InnerProductSpace.toDual ℝ (EuclideanSpace ℝ (Fin 1))).symm (innerSL ℝ x) = x := by

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -293,9 +293,7 @@ lemma potentialEnergy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : C
     congr 1
     module
   rw [real_inner_comm, ← inner_smul_right]
-  repeat fun_prop
-  · rw [contDiff_infty_iff_fderiv] at hx
-    apply hx.1
+  all_goals (first | fun_prop | exact (hx.contDiffAt (x := t)).differentiableAt (by simp))
 
 lemma energy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff ℝ ∞ xₜ) :
     ∂ₜ (energy S xₜ) = fun t => ⟪∂ₜ xₜ t, S.m • ∂ₜ (∂ₜ xₜ) t + S.k • xₜ t⟫_ℝ := by

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -260,53 +260,24 @@ the time derivatives of the energies.
 lemma kineticEnergy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff ℝ ∞ xₜ) :
     ∂ₜ (kineticEnergy S xₜ) = fun t => ⟪∂ₜ xₜ t, S.m • ∂ₜ (∂ₜ xₜ) t⟫_ℝ := by
   funext t
-  unfold kineticEnergy
-  conv_lhs => simp only [Time.deriv, one_div, ringHom_apply]
-  change (fderiv ℝ ((fun x => 2⁻¹ * S.m * ⟪x, x⟫_ℝ) ∘ (fun t => ∂ₜ xₜ t)) t) 1 = _
-  rw [fderiv_comp]
-  rw [fderiv_const_mul (by fun_prop)]
-  simp only [ContinuousLinearMap.smul_comp, FunLike.coe_smul,
-    ContinuousLinearMap.coe_comp, Pi.smul_apply, Function.comp_apply, smul_eq_mul]
-  rw [fderiv_inner_apply]
-  simp only [fderiv_fun_id, ContinuousLinearMap.coe_id', id_eq]
-  rw [real_inner_comm, ← inner_add_left, ← Time.deriv, real_inner_comm, ← inner_smul_right]
-  congr 1
-  simp only [smul_add]
-  module
-  all_goals fun_prop
+  simp [kineticEnergy_eq, Time.deriv, fderiv_comp, fderiv_const_mul, fderiv_inner_apply,
+    real_inner_comm, inner_add_left, inner_smul_right, smul_add, mul_comm, add_comm]
+  fun_prop
 
 lemma potentialEnergy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff ℝ ∞ xₜ) :
     ∂ₜ (fun t => potentialEnergy S (xₜ t)) = fun t => ⟪∂ₜ xₜ t, S.k • xₜ t⟫_ℝ := by
   funext t
-  unfold potentialEnergy
-  conv_lhs => simp only [Time.deriv, one_div, smul_eq_mul]
-  change (fderiv ℝ ((fun x => 2⁻¹ * (S.k * ⟪x, x⟫_ℝ)) ∘ (fun t => xₜ t)) t) 1 = _
-  rw [fderiv_comp]
-  rw [fderiv_const_mul (by fun_prop), fderiv_const_mul (by fun_prop)]
-  simp only [ContinuousLinearMap.smul_comp, FunLike.coe_smul,
-    ContinuousLinearMap.coe_comp, Pi.smul_apply, Function.comp_apply, smul_eq_mul]
-  rw [fderiv_inner_apply]
-  simp only [fderiv_fun_id, ContinuousLinearMap.coe_id', id_eq]
-  trans S.k * ⟪xₜ t, ∂ₜ xₜ t⟫_ℝ
-  · rw [real_inner_comm, ← inner_add_left, ← Time.deriv, real_inner_comm, ← inner_smul_right,
-      ← inner_smul_right, ← inner_smul_right]
-    congr 1
-    module
-  rw [real_inner_comm, ← inner_smul_right]
-  all_goals (first | fun_prop | exact (hx.contDiffAt (x := t)).differentiableAt (by simp))
+  simp [potentialEnergy_eq, Time.deriv, fderiv_comp, fderiv_const_mul, fderiv_inner_apply,
+    real_inner_comm, inner_add_left, inner_smul_right, smul_add, mul_comm, add_comm]
+  fun_prop
 
 lemma energy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff ℝ ∞ xₜ) :
     ∂ₜ (energy S xₜ) = fun t => ⟪∂ₜ xₜ t, S.m • ∂ₜ (∂ₜ xₜ) t + S.k • xₜ t⟫_ℝ := by
   unfold energy
   funext t
-  rw [Time.deriv_eq]
-  rw [fderiv_fun_add (by fun_prop) (by apply S.potentialEnergy_differentiable xₜ hx)]
-  simp only [_root_.add_apply]
-  rw [← Time.deriv_eq, ← Time.deriv_eq]
-  rw [potentialEnergy_deriv, kineticEnergy_deriv]
-  simp only
-  rw [← inner_add_right]
-  all_goals fun_prop
+  simp [Time.deriv_eq, fderiv_fun_add, potentialEnergy_deriv, kineticEnergy_deriv,
+    inner_add_right, energy_differentiable, energy]
+  fun_prop
 
 /-!
 
@@ -383,11 +354,8 @@ lemma gradient_inner_self (x : EuclideanSpace ℝ (Fin 1)) :
   refine ext_inner_right (𝕜 := ℝ) fun y => ?_
   unfold gradient
   rw [InnerProductSpace.toDual_symm_apply]
-  have hid : DifferentiableAt ℝ (fun y : EuclideanSpace ℝ (Fin 1) => y) x := differentiableAt_id
-  rw [fderiv_inner_apply (𝕜 := ℝ) hid hid]
-  simp only [fderiv_fun_id, ContinuousLinearMap.coe_id', id_eq, real_inner_comm, inner_smul_left',
-    ringHom_apply]
-  ring
+  simp [fderiv_inner_apply, real_inner_comm, inner_smul_left', mul_comm]
+  fun_prop
 
 lemma gradient_const_mul_inner_self (c : ℝ) (x : EuclideanSpace ℝ (Fin 1)) :
     gradient (fun y : EuclideanSpace ℝ (Fin 1) => c * ⟪y, y⟫_ℝ) x = (2 * c) • x := by
@@ -400,10 +368,8 @@ lemma gradient_const_mul_inner_self (c : ℝ) (x : EuclideanSpace ℝ (Fin 1)) :
           rw [fderiv_const_mul]; fun_prop
     _ = c • gradient (fun y : EuclideanSpace ℝ (Fin 1) => ⟪y, y⟫_ℝ) x := by
           simp only [gradient, map_smul]
-    _ = c • ((2 : ℝ) • x) := by
-          rw [gradient_inner_self]
-    _ = (2 * c) • x := by
-          rw [smul_smul, mul_comm]
+    _ = c • ((2 : ℝ) • x) := by rw [gradient_inner_self]
+    _ = (2 * c) • x := by rw [smul_smul, mul_comm]
 
 /-!
 
@@ -744,17 +710,15 @@ We now write down the gradients of the Hamiltonian with respect to the momentum 
 lemma gradient_hamiltonian_position_eq (t : Time) (x : EuclideanSpace ℝ (Fin 1))
     (p : EuclideanSpace ℝ (Fin 1)) :
     gradient (hamiltonian S t p) x = S.k • x := by
-  have h_eq : (fun y : EuclideanSpace ℝ (Fin 1) => hamiltonian S t p y) =
-      fun y => ((1 / (2 : ℝ)) * S.k) * ⟪y, y⟫_ℝ +
+  have h_eq : hamiltonian S t p = fun y : EuclideanSpace ℝ (Fin 1) =>
+      ((1 / (2 : ℝ)) * S.k) * ⟪y, y⟫_ℝ +
         ((1 / (2 : ℝ)) * (1 / S.m) * ⟪p, p⟫_ℝ) := by
-    funext y; unfold hamiltonian; simp only [toCanonicalMomentum, lagrangian, one_div,
+    ext y; unfold hamiltonian; simp only [toCanonicalMomentum, lagrangian, one_div,
       inner_self_eq_norm_sq_to_K, ringHom_apply, potentialEnergy, smul_eq_mul,
       LinearEquiv.coe_symm_mk', inner_smul_right, norm_smul, norm_inv, norm_eq_abs]
-    have hm : S.m ≠ 0 := m_ne_zero S
     field_simp
-    ring_nf
-    simp [mul_two]
-  change gradient (fun y : EuclideanSpace ℝ (Fin 1) => hamiltonian S t p y) x = S.k • x
+    simp [sq_abs]
+    ring
   rw [h_eq, gradient_add_const', gradient_const_mul_inner_self]
   ext; simp
 
@@ -767,11 +731,9 @@ lemma gradient_hamiltonian_momentum_eq (t : Time) (x : EuclideanSpace ℝ (Fin 1
     funext y; unfold hamiltonian; simp only [toCanonicalMomentum, lagrangian, one_div,
       inner_self_eq_norm_sq_to_K, ringHom_apply, potentialEnergy, smul_eq_mul,
       LinearEquiv.coe_symm_mk', inner_smul_right, norm_smul, norm_inv, norm_eq_abs]
-    have hm : S.m ≠ 0 := m_ne_zero S
     field_simp
-    ring_nf
-    simp [mul_two]
-  change gradient (fun y : EuclideanSpace ℝ (Fin 1) => hamiltonian S t y x) p = (1 / S.m) • p
+    simp [sq_abs]
+    ring
   rw [h_eq, gradient_add_const', gradient_const_mul_inner_self]
   ext; simp
 
@@ -792,11 +754,7 @@ lemma hamiltonian_eq_energy (xₜ : Time → EuclideanSpace ℝ (Fin 1)) :
     rw [← toCanonicalMomentum_eq (S := S) (t := t) (x := xₜ t) (v := ∂ₜ xₜ t)]
     exact LinearEquiv.symm_apply_apply (toCanonicalMomentum S t (xₜ t)) (∂ₜ xₜ t)
   unfold hamiltonian lagrangian energy kineticEnergy potentialEnergy
-  simp only [toCanonicalMomentum_eq, inner_smul_left, one_div, smul_eq_mul]
-  rw [hsymm]
-  ring_nf
-  simp only [ringHom_apply, inner_self_eq_norm_sq_to_K, one_div, add_left_inj]
-  field_simp
+  simp [toCanonicalMomentum_eq, inner_smul_left, one_div, smul_eq_mul, hsymm]
   ring
 
 /-!

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -599,9 +599,7 @@ lemma energy_conservation_of_equationOfMotion (xₜ : Time → EuclideanSpace �
   rw [energy_deriv _ _ hx]
   rw [equationOfMotion_iff_newtons_2nd_law _ _ hx] at h
   funext x
-  simp only [Pi.zero_apply]
-  rw [h]
-  simp [force_eq_linear]
+  simp [h x, force_eq_linear]
 
 /-!
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -260,24 +260,53 @@ the time derivatives of the energies.
 lemma kineticEnergy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff ℝ ∞ xₜ) :
     ∂ₜ (kineticEnergy S xₜ) = fun t => ⟪∂ₜ xₜ t, S.m • ∂ₜ (∂ₜ xₜ) t⟫_ℝ := by
   funext t
-  simp [kineticEnergy_eq, Time.deriv, fderiv_comp, fderiv_const_mul, fderiv_inner_apply,
-    real_inner_comm, inner_add_left, inner_smul_right, smul_add, mul_comm, add_comm]
-  fun_prop
+  unfold kineticEnergy
+  conv_lhs => simp only [Time.deriv, one_div, ringHom_apply]
+  change (fderiv ℝ ((fun x => 2⁻¹ * S.m * ⟪x, x⟫_ℝ) ∘ (fun t => ∂ₜ xₜ t)) t) 1 = _
+  rw [fderiv_comp]
+  rw [fderiv_const_mul (by fun_prop)]
+  simp only [ContinuousLinearMap.smul_comp, FunLike.coe_smul,
+    ContinuousLinearMap.coe_comp, Pi.smul_apply, Function.comp_apply, smul_eq_mul]
+  rw [fderiv_inner_apply]
+  simp only [fderiv_fun_id, ContinuousLinearMap.coe_id', id_eq]
+  rw [real_inner_comm, ← inner_add_left, ← Time.deriv, real_inner_comm, ← inner_smul_right]
+  congr 1
+  simp only [smul_add]
+  module
+  all_goals fun_prop
 
 lemma potentialEnergy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff ℝ ∞ xₜ) :
     ∂ₜ (fun t => potentialEnergy S (xₜ t)) = fun t => ⟪∂ₜ xₜ t, S.k • xₜ t⟫_ℝ := by
   funext t
-  simp [potentialEnergy_eq, Time.deriv, fderiv_comp, fderiv_const_mul, fderiv_inner_apply,
-    real_inner_comm, inner_add_left, inner_smul_right, smul_add, mul_comm, add_comm]
-  fun_prop
+  unfold potentialEnergy
+  conv_lhs => simp only [Time.deriv, one_div, smul_eq_mul]
+  change (fderiv ℝ ((fun x => 2⁻¹ * (S.k * ⟪x, x⟫_ℝ)) ∘ (fun t => xₜ t)) t) 1 = _
+  rw [fderiv_comp]
+  rw [fderiv_const_mul (by fun_prop), fderiv_const_mul (by fun_prop)]
+  simp only [ContinuousLinearMap.smul_comp, FunLike.coe_smul,
+    ContinuousLinearMap.coe_comp, Pi.smul_apply, Function.comp_apply, smul_eq_mul]
+  rw [fderiv_inner_apply]
+  simp only [fderiv_fun_id, ContinuousLinearMap.coe_id', id_eq]
+  trans S.k * ⟪xₜ t, ∂ₜ xₜ t⟫_ℝ
+  · rw [real_inner_comm, ← inner_add_left, ← Time.deriv, real_inner_comm, ← inner_smul_right,
+      ← inner_smul_right, ← inner_smul_right]
+    congr 1
+    module
+  rw [real_inner_comm, ← inner_smul_right]
+  all_goals (first | fun_prop | exact ((contDiff_infty_iff_fderiv.mp hx).1 t))
 
 lemma energy_deriv (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff ℝ ∞ xₜ) :
     ∂ₜ (energy S xₜ) = fun t => ⟪∂ₜ xₜ t, S.m • ∂ₜ (∂ₜ xₜ) t + S.k • xₜ t⟫_ℝ := by
   unfold energy
   funext t
-  simp [Time.deriv_eq, fderiv_fun_add, potentialEnergy_deriv, kineticEnergy_deriv,
-    inner_add_right, energy_differentiable, energy]
-  fun_prop
+  rw [Time.deriv_eq]
+  rw [fderiv_fun_add (by fun_prop) (by apply S.potentialEnergy_differentiable xₜ hx)]
+  simp only [_root_.add_apply]
+  rw [← Time.deriv_eq, ← Time.deriv_eq]
+  rw [potentialEnergy_deriv, kineticEnergy_deriv]
+  simp only
+  rw [← inner_add_right]
+  all_goals fun_prop
 
 /-!
 
@@ -354,8 +383,11 @@ lemma gradient_inner_self (x : EuclideanSpace ℝ (Fin 1)) :
   refine ext_inner_right (𝕜 := ℝ) fun y => ?_
   unfold gradient
   rw [InnerProductSpace.toDual_symm_apply]
-  simp [fderiv_inner_apply, real_inner_comm, inner_smul_left', mul_comm]
-  fun_prop
+  have hid : DifferentiableAt ℝ (fun y : EuclideanSpace ℝ (Fin 1) => y) x := differentiableAt_id
+  rw [fderiv_inner_apply (𝕜 := ℝ) hid hid]
+  simp only [fderiv_fun_id, ContinuousLinearMap.coe_id', id_eq, real_inner_comm, inner_smul_left',
+    ringHom_apply]
+  ring
 
 lemma gradient_const_mul_inner_self (c : ℝ) (x : EuclideanSpace ℝ (Fin 1)) :
     gradient (fun y : EuclideanSpace ℝ (Fin 1) => c * ⟪y, y⟫_ℝ) x = (2 * c) • x := by

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -564,19 +564,8 @@ lemma gradLagrangian_eq_force (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx :
   rw [gradLagrangian_eq_eulerLagrangeOp S xₜ hx, eulerLagrangeOp]
   congr
   · simp [gradient_lagrangian_position_eq, force_eq_linear]
-  · conv_lhs =>
-      arg 1
-      ext t'
-      rw [gradient_lagrangian_velocity_eq]
-    show ∂ₜ (fun t' => S.m • ∂ₜ xₜ t') t = S.m • ∂ₜ (∂ₜ xₜ) t
-    have hd : DifferentiableAt ℝ (∂ₜ xₜ) t :=
-      (deriv_differentiable_of_contDiff xₜ hx).differentiableAt
-    calc
-      ∂ₜ (fun t' => S.m • ∂ₜ xₜ t') t
-          = fderiv ℝ (fun t' => S.m • ∂ₜ xₜ t') t 1 := rfl
-      _ = S.m • (fderiv ℝ (∂ₜ xₜ) t 1) := by
-          exact congrArg (fun L => L 1) (fderiv_const_smul (c := S.m) (f := ∂ₜ xₜ) hd)
-      _ = S.m • ∂ₜ (∂ₜ xₜ) t := rfl
+  · simp [gradient_lagrangian_velocity_eq, Time.deriv_smul (∂ₜ xₜ) S.m
+      (deriv_differentiable_of_contDiff xₜ hx)]
 
 /-!
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -1024,41 +1024,30 @@ lemma trajectory_velocity_eq_zero_iff_norm_eq_amplitude (IC : InitialConditions)
       ‖IC.trajectory S t‖ = (AmplitudePhase.fromInitialConditions S IC).A := by
   by_cases hA : (AmplitudePhase.fromInitialConditions S IC).A = 0
   · constructor
-    · intro _
-      rw [trajectory_eq_cos]
-      simp [hA]
-    · intro _
-      rw [trajectory_velocity_eq_sin]
-      ext i
-      fin_cases i
-      simp [hA]
-  rw [trajectory_velocity_eq_zero_iff_sin_eq_zero S IC hA t]
-  rw [trajectory_eq_cos]
+    · intro _; rw [trajectory_eq_cos]; simp [hA]
+    · intro _; rw [trajectory_velocity_eq_sin]; ext i; fin_cases i; simp [hA]
+  rw [trajectory_velocity_eq_zero_iff_sin_eq_zero S IC hA t, trajectory_eq_cos]
   set A := (AmplitudePhase.fromInitialConditions S IC).A
   set θ := S.ω * t.val - (AmplitudePhase.fromInitialConditions S IC).φ
-  show sin θ = 0 ↔ ‖EuclideanSpace.single 0 (A * cos θ)‖ = A
   have hA' : A ≠ 0 := by simpa [A] using hA
-  have hA_nonneg : 0 ≤ A := by
-    show 0 ≤ ‖(⟨IC.x₀ 0, IC.v₀ 0 / S.ω⟩ : ℂ)‖
-    exact norm_nonneg _
-  have hA_pos : 0 < A := lt_of_le_of_ne hA_nonneg (Ne.symm hA')
+  have hA_pos : 0 < A := by
+    have hA_nonneg : 0 ≤ A := norm_nonneg _
+    exact lt_of_le_of_ne hA_nonneg (Ne.symm hA')
+  show sin θ = 0 ↔ ‖EuclideanSpace.single 0 (A * cos θ)‖ = A
   constructor
   · intro hsin
-    rcases Real.sin_eq_zero_iff_cos_eq.mp hsin with hcos | hcos
+    rcases Real.sin_eq_zero_iff_cos_eq.mp hsin with (hcos | hcos)
     · simp [hcos, abs_of_pos hA_pos]
     · simp [hcos, abs_of_pos hA_pos]
   · intro hnorm
-    have hnorm' : |A * cos θ| = A := by
-      simpa using hnorm
+    have hnorm' : |A * cos θ| = A := by simpa using hnorm
     have hcos_abs : |cos θ| = 1 := by
       calc
         |cos θ| = |A * cos θ| / A := by
-          rw [abs_mul, abs_of_pos hA_pos]
-          field_simp [hA']
+          rw [abs_mul, abs_of_pos hA_pos]; field_simp [hA']
         _ = A / A := by rw [hnorm']
         _ = 1 := by field_simp [hA']
-    obtain ⟨n, hn⟩ := Real.abs_cos_eq_one_iff.mp hcos_abs
-    exact Real.sin_eq_zero_iff.mpr ⟨n, hn⟩
+    exact Real.sin_eq_zero_iff.mpr (Real.abs_cos_eq_one_iff.mp hcos_abs)
 
 /-!
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -466,7 +466,7 @@ lemma trajectory_acceleration (IC : InitialConditions) : ∂ₜ (∂ₜ (IC.traj
     FunLike.coe_smul, Pi.smul_apply, ContinuousLinearMap.smulRight_apply, fderiv_val,
     smul_eq_mul, mul_one, neg_smul]
   ring_nf
-  ext; simp; ring
+  module
 
 /-!
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -546,12 +546,10 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
     (trajectory_equationOfMotion S IC)
   have hEOM_y : S.EquationOfMotion y :=
     (S.equationOfMotion_iff_newtons_2nd_law y hyContDiff).2 fun t => by
-      have hy_deriv2 : ∂ₜ (∂ₜ y) t = ∂ₜ (∂ₜ x) t - ∂ₜ (∂ₜ (IC.trajectory S)) t := by
-        rw [hy_deriv]
-        simp [timeDeriv_sub (Time.deriv_differentiable_of_contDiff _ hx)
-          (Time.deriv_differentiable_of_contDiff _ hTraj)]
-      rw [hy_deriv2]
-      simp [smul_sub, hNewt_x, hNewt_traj, hydef, force_eq_linear]
+      rw [hy_deriv]
+      simp [timeDeriv_sub (deriv_differentiable_of_contDiff x hx)
+        (deriv_differentiable_of_contDiff (IC.trajectory S) hTraj),
+        smul_sub, hNewt_x, hNewt_traj, hydef, force_eq_linear]
   have hy0 : y 0 = 0 := by simp [hydef, hx0]
   have hyv0 : ∂ₜ y 0 = 0 := by
     simpa [hy_deriv, hv0, trajectory_velocity_at_zero S IC]
@@ -561,15 +559,21 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
         HarmonicOscillator.potentialEnergy, hy0, hyv0]
   funext t
   have hk : 0 ≤ S.kineticEnergy y t := by
-    simp [HarmonicOscillator.kineticEnergy, mul_nonneg, S.m_pos.le]
+    unfold HarmonicOscillator.kineticEnergy
+    refine mul_nonneg (mul_nonneg (by norm_num) S.m_pos.le) real_inner_self_nonneg
   have hp : 0 ≤ S.potentialEnergy (y t) := by
-    simp [HarmonicOscillator.potentialEnergy, mul_nonneg, S.k_pos.le]
-  have hpe' : S.k * inner ℝ (y t) (y t) = 0 := by
-    have hpe : S.potentialEnergy (y t) = 0 := ((add_eq_zero_iff_of_nonneg hk hp).mp (hE t)).2
-    simpa [HarmonicOscillator.potentialEnergy, smul_eq_mul] using hpe
-  rcases eq_zero_or_eq_zero_of_mul_eq_zero hpe' with h | h
-  · exact (S.k_pos.ne' h).elim
-  · exact sub_eq_zero.mp (inner_self_eq_zero.mp h)
+    unfold HarmonicOscillator.potentialEnergy
+    simp only [smul_eq_mul]
+    refine mul_nonneg (by norm_num) (mul_nonneg S.k_pos.le real_inner_self_nonneg)
+  have hsum : S.kineticEnergy y t + S.potentialEnergy (y t) = 0 := by
+    simpa [HarmonicOscillator.energy] using hE t
+  have hpe : S.potentialEnergy (y t) = 0 := ((add_eq_zero_iff_of_nonneg hk hp).mp hsum).2
+  have h_inner : inner ℝ (y t) (y t) = 0 := by
+    unfold HarmonicOscillator.potentialEnergy at hpe
+    simpa [smul_eq_mul] using hpe
+  have hy_eq : y t = 0 := inner_self_eq_zero.mp h_inner
+  apply sub_eq_zero.mp
+  simpa [hydef] using hy_eq
 
 /-!
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -526,11 +526,6 @@ for the given initial conditions.
   position and velocity, the difference `y = x - IC.trajectory S` also solves the
   equation of motion with zero initial conditions; energy conservation then forces
   its energy, and hence `y`, to vanish identically, so `x = IC.trajectory S`. -/
-private lemma timeDeriv_sub {f g : Time → EuclideanSpace ℝ (Fin 1)}
-    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) :
-    ∂ₜ (fun t => f t - g t) = fun t => ∂ₜ f t - ∂ₜ g t := by
-  funext s; simp [Time.deriv_eq, fderiv_fun_sub (hf s) (hg s)]
-
 lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace ℝ (Fin 1))
     (hx : ContDiff ℝ ∞ x) :
     S.EquationOfMotion x ∧ x 0 = IC.x₀ ∧ ∂ₜ x 0 = IC.v₀ →
@@ -539,16 +534,17 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
   have hTraj : ContDiff ℝ ∞ (IC.trajectory S) := by fun_prop
   set y : Time → EuclideanSpace ℝ (Fin 1) := fun t => x t - IC.trajectory S t with hydef
   have hyContDiff : ContDiff ℝ ∞ y := hx.sub hTraj
-  have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t :=
-    timeDeriv_sub (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
+  have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t := by
+    funext s; simp [Time.deriv_eq, fderiv_fun_sub (hx.differentiable (by simp) s)
+      (hTraj.differentiable (by simp) s)]
   have hNewt_x := (S.equationOfMotion_iff_newtons_2nd_law x hx).1 hEOM
   have hNewt_traj := (S.equationOfMotion_iff_newtons_2nd_law (IC.trajectory S) hTraj).1
     (trajectory_equationOfMotion S IC)
   have hEOM_y : S.EquationOfMotion y :=
     (S.equationOfMotion_iff_newtons_2nd_law y hyContDiff).2 fun t => by
       rw [hy_deriv]
-      simp [timeDeriv_sub (deriv_differentiable_of_contDiff x hx)
-        (deriv_differentiable_of_contDiff (IC.trajectory S) hTraj),
+      simp [Time.deriv_eq, fderiv_fun_sub (deriv_differentiable_of_contDiff x hx).differentiableAt
+        (deriv_differentiable_of_contDiff (IC.trajectory S) hTraj).differentiableAt,
         smul_sub, hNewt_x, hNewt_traj, hydef, force_eq_linear]
   have hy0 : y 0 = 0 := by simp [hydef, hx0]
   have hyv0 : ∂ₜ y 0 = 0 := by
@@ -558,20 +554,19 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
       simp [HarmonicOscillator.energy, HarmonicOscillator.kineticEnergy,
         HarmonicOscillator.potentialEnergy, hy0, hyv0]
   funext t
-  have hk : 0 ≤ S.kineticEnergy y t := by
-    unfold HarmonicOscillator.kineticEnergy
-    refine mul_nonneg (mul_nonneg (by norm_num) S.m_pos.le) real_inner_self_nonneg
-  have hp : 0 ≤ S.potentialEnergy (y t) := by
-    unfold HarmonicOscillator.potentialEnergy
-    simp only [smul_eq_mul]
-    refine mul_nonneg (by norm_num) (mul_nonneg S.k_pos.le real_inner_self_nonneg)
   have hsum : S.kineticEnergy y t + S.potentialEnergy (y t) = 0 := by
     simpa [HarmonicOscillator.energy] using hE t
-  have hpe : S.potentialEnergy (y t) = 0 := ((add_eq_zero_iff_of_nonneg hk hp).mp hsum).2
-  have h_inner : inner ℝ (y t) (y t) = 0 := by
-    unfold HarmonicOscillator.potentialEnergy at hpe
-    simpa [smul_eq_mul] using hpe
-  have hy_eq : y t = 0 := inner_self_eq_zero.mp h_inner
+  have hy_eq : y t = 0 := by
+    have hpe : S.potentialEnergy (y t) = 0 :=
+      ((add_eq_zero_iff_of_nonneg
+        (by unfold HarmonicOscillator.kineticEnergy
+          refine mul_nonneg (mul_nonneg (by norm_num) S.m_pos.le) real_inner_self_nonneg)
+        (by unfold HarmonicOscillator.potentialEnergy; simp only [smul_eq_mul]
+          refine mul_nonneg (by norm_num) (mul_nonneg S.k_pos.le real_inner_self_nonneg))).mp hsum).2
+    have h_inner : inner ℝ (y t) (y t) = 0 := by
+      unfold HarmonicOscillator.potentialEnergy at hpe
+      simpa [smul_eq_mul] using hpe
+    exact inner_self_eq_zero.mp h_inner
   apply sub_eq_zero.mp
   simpa [hydef] using hy_eq
 
@@ -1216,47 +1211,38 @@ lemma return_time (IC : InitialConditions) (non_trivial : IC.x₀ ≠ 0 ∨ IC.v
   have det_ne_zero : det ≠ 0 := by bound
   have hxx : c * xx + (s / S.ω) * xv = xx := by
     calc
-     c * xx + (s / S.ω) * xv =  (inner ℝ (c • IC.x₀) IC.x₀) + (s / S.ω) * xv := by
-       rw[real_inner_smul_left]
-     (inner ℝ (c • IC.x₀) IC.x₀) + (s / S.ω) * xv =
-       (inner ℝ (c • IC.x₀) IC.x₀) + (s / S.ω) * inner ℝ  IC.v₀ IC.x₀ := by
-         rw [real_inner_comm IC.x₀ IC.v₀]
-     _  = (inner ℝ (c • IC.x₀) IC.x₀) +  inner ℝ  ((s / S.ω)  • IC.v₀) IC.x₀ := by
-       rw [real_inner_smul_left IC.v₀]
-     _ = (inner ℝ (c • IC.x₀ + (s / S.ω)  • IC.v₀) IC.x₀) := by rw [inner_add_left]
-     _ = xx := by rw [htx]
+      c * xx + (s / S.ω) * xv
+          = (inner ℝ (c • IC.x₀) IC.x₀) + (s / S.ω) * inner ℝ IC.v₀ IC.x₀ := by
+            simp [xx, xv, real_inner_comm]
+      _ = (inner ℝ (c • IC.x₀) IC.x₀) + inner ℝ ((s / S.ω) • IC.v₀) IC.x₀ := by
+            simp
+      _ = inner ℝ (c • IC.x₀ + (s / S.ω) • IC.v₀) IC.x₀ := by rw [inner_add_left]
+      _ = xx := by rw [htx]
   have hvv : - S.ω * s * xv + c * vv = vv := by
     calc
-     - S.ω * s * xv + c * vv = - S.ω * (s * xv) + c * vv := by ring_nf
-     _ = - S.ω * inner ℝ (s • IC.x₀) IC.v₀ + c * vv := by rw[real_inner_smul_left]
-     _ = inner ℝ  (- S.ω • s • IC.x₀ ) IC.v₀ + c * vv := by rw [← real_inner_smul_left]
-     _ = inner ℝ  (- S.ω • s • IC.x₀ ) IC.v₀ + inner ℝ (c • IC.v₀) IC.v₀ := by
-       rw [← real_inner_smul_left]
-     _ = inner ℝ (- S.ω • s • IC.x₀ + c • IC.v₀) IC.v₀ := by rw [inner_add_left]
-     _ = inner ℝ (-( S.ω • s • IC.x₀) + c • IC.v₀) IC.v₀ := by rw [neg_smul]
-     _ = vv := by rw [htv]
+      - S.ω * s * xv + c * vv
+          = inner ℝ (-(S.ω • s • IC.x₀)) IC.v₀ + inner ℝ (c • IC.v₀) IC.v₀ := by
+            simp [xv, vv, real_inner_comm]
+      _ = inner ℝ (-(S.ω • s • IC.x₀) + c • IC.v₀) IC.v₀ := by rw [inner_add_left]
+      _ = inner ℝ (-(S.ω • s • IC.x₀) + c • IC.v₀) IC.v₀ := by rw [neg_smul]
+      _ = vv := by rw [htv]
   have hcos : 1 = cos (S.ω * t) := by
-    have h_eq : (c - 1) * det = 0 := by
+    have hω : S.ω ≠ 0 := ω_ne_zero S
+    field_simp [hω] at hxx
+    have hxx' : (c - 1) * xx * S.ω + s * xv = 0 := by linarith
+    have hvv' : (c - 1) * vv - S.ω * s * xv = 0 := by linarith
+    have h_comb : (c - 1) * det = 0 := by
       dsimp [det]
-      have hω : S.ω ≠ 0 := ω_ne_zero S
-      field_simp [hω] at hxx
-      have hxx' : (c - 1) * xx * S.ω + s * xv = 0 := by linarith
-      have hvv' : (c - 1) * vv - S.ω * s * xv = 0 := by linarith
-      have h_comb : (c - 1) * vv + (c - 1) * xx * S.ω ^ 2 = 0 := by
-        have hvv_eq : (c - 1) * vv = S.ω * s * xv := sub_eq_zero.mp hvv'
-        have htemp : s * xv = -(c - 1) * xx * S.ω := by linarith
-        calc
-          (c - 1) * vv + (c - 1) * xx * S.ω ^ 2
-              = S.ω * s * xv + (c - 1) * xx * S.ω ^ 2 := by rw [hvv_eq]
-          _ = S.ω * (s * xv) + (c - 1) * xx * S.ω ^ 2 := by ring
-          _ = S.ω * (-(c - 1) * xx * S.ω) + (c - 1) * xx * S.ω ^ 2 := by rw [htemp]
-          _ = (-(c - 1) * xx * S.ω ^ 2) + (c - 1) * xx * S.ω ^ 2 := by ring
-          _ = 0 := by ring
       calc
-        (c - 1) * (vv + xx * S.ω ^ 2) = (c - 1) * vv + (c - 1) * xx * S.ω ^ 2 := by ring
-        _ = 0 := by rw [h_comb]
+        (c - 1) * (vv + xx * S.ω ^ 2)
+            = (c - 1) * vv + (c - 1) * xx * S.ω ^ 2 := by ring
+        _ = (S.ω * s * xv) + (c - 1) * xx * S.ω ^ 2 := by linarith
+        _ = (S.ω * s * xv) + (-(S.ω * s * xv)) := by
+          have : (c - 1) * xx * S.ω ^ 2 = -(S.ω * s * xv) := by linarith
+          rw [this]
+        _ = 0 := by ring
     have hc1 : c = 1 := by
-      rcases mul_eq_zero.mp h_eq with h | h
+      rcases mul_eq_zero.mp h_comb with h | h
       · exact sub_eq_zero.mp h
       · exact (det_ne_zero h).elim
     exact hc1.symm

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -1250,26 +1250,37 @@ lemma return_time (IC : InitialConditions) (non_trivial : IC.x₀ ≠ 0 ∨ IC.v
      _ = inner ℝ (-( S.ω • s • IC.x₀) + c • IC.v₀) IC.v₀ := by rw [neg_smul]
      _ = vv := by rw [htv]
   have hcos : 1 = cos (S.ω * t) := by
-    calc
-    1 =  det / det := by simp only [ne_eq, det_ne_zero, not_false_eq_true, div_self]
-    _ = (vv + xx * S.ω^2 ) / det := by rfl
-    _ = c * ((vv + xx * S.ω^2) / det) + s * xv *S.ω* (S.ω/S.ω-1 ) / det := by
-      nth_rewrite 1 [← hvv, ← hxx]
-      ring_nf
-    _ = c * ((vv + xx * S.ω^2) / det ) := by
-      simp only [ne_eq, S.ω_ne_zero, not_false_eq_true,
-        div_self, sub_self, mul_zero, zero_div, add_zero]
-    _ = c * (det / det) := by rfl
-    _ = c := by simp only [ne_eq, det_ne_zero, not_false_eq_true, div_self, mul_one]
-    _ = _ := by rfl
+    have h_eq : (c - 1) * det = 0 := by
+      dsimp [det]
+      have hω : S.ω ≠ 0 := ω_ne_zero S
+      field_simp [hω] at hxx
+      have hxx' : (c - 1) * xx * S.ω + s * xv = 0 := by linarith
+      have hvv' : (c - 1) * vv - S.ω * s * xv = 0 := by linarith
+      have h_comb : (c - 1) * vv + (c - 1) * xx * S.ω ^ 2 = 0 := by
+        have hvv_eq : (c - 1) * vv = S.ω * s * xv := sub_eq_zero.mp hvv'
+        have htemp : s * xv = -(c - 1) * xx * S.ω := by linarith
+        calc
+          (c - 1) * vv + (c - 1) * xx * S.ω ^ 2
+              = S.ω * s * xv + (c - 1) * xx * S.ω ^ 2 := by rw [hvv_eq]
+          _ = S.ω * (s * xv) + (c - 1) * xx * S.ω ^ 2 := by ring
+          _ = S.ω * (-(c - 1) * xx * S.ω) + (c - 1) * xx * S.ω ^ 2 := by rw [htemp]
+          _ = (-(c - 1) * xx * S.ω ^ 2) + (c - 1) * xx * S.ω ^ 2 := by ring
+          _ = 0 := by ring
+      calc
+        (c - 1) * (vv + xx * S.ω ^ 2) = (c - 1) * vv + (c - 1) * xx * S.ω ^ 2 := by ring
+        _ = 0 := by rw [h_comb]
+    have hc1 : c = 1 := by
+      rcases mul_eq_zero.mp h_eq with h | h
+      · exact sub_eq_zero.mp h
+      · exact (det_ne_zero h).elim
+    exact hc1.symm
   let ⟨n, hn⟩ := (Real.cos_eq_one_iff (S.ω * t)).mp (Eq.symm hcos)
   use n
+  rw [period_eq]
   calc
-    (n : ℝ) * (T S) = (n : ℝ) * (2 * π / S.ω) := by rfl
-    _ = ((n : ℝ) * (2 * π)) / S.ω := by ring_nf
-    _ = (S.ω * t) / S.ω := by rw [hn]
-    _ = t * (S.ω / S.ω) := by ring_nf
-    _ = t := by simp only [ne_eq, S.ω_ne_zero, not_false_eq_true, div_self, mul_one]
+    (n : ℝ) * (2 * π / S.ω) = ((n : ℝ) * (2 * π)) / S.ω := by ring
+    _ = (S.ω * (t : ℝ)) / S.ω := by rw [hn]
+    _ = t := by field_simp [S.ω_ne_zero]
 end HarmonicOscillator
 
 end ClassicalMechanics

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -645,9 +645,7 @@ lemma toInitialConditions_energy_at_t₀ (S : HarmonicOscillator)
     S.energy ((IC.toInitialConditions S).trajectory S) IC.t₀ =
     1/2 * (S.m * ‖IC.v_t₀‖^2 + S.k * ‖IC.x_t₀‖^2) := by
   unfold energy kineticEnergy potentialEnergy
-  simp only [toInitialConditions_trajectory_at_t₀, toInitialConditions_velocity_at_t₀]
-  rw [real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq]
-  simp only [smul_eq_mul]
+  simp [toInitialConditions_trajectory_at_t₀, toInitialConditions_velocity_at_t₀, smul_eq_mul]
   ring
 
 end InitialConditionsAtTime

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -535,51 +535,53 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
     x = IC.trajectory S := by
   rintro ⟨hEOM, hx0, hv0⟩
   have hTraj : ContDiff ℝ ∞ (IC.trajectory S) := by fun_prop
-  -- Time-derivative of a difference of differentiable functions, used below on `x - traj`.
-  have dsub : ∀ f g : Time → EuclideanSpace ℝ (Fin 1),
-      Differentiable ℝ f → Differentiable ℝ g →
-      ∂ₜ (fun t => f t - g t) = fun t => ∂ₜ f t - ∂ₜ g t := by
-    intro f g hf hg
-    funext t
-    simp only [Time.deriv_eq, fderiv_fun_sub (hf t) (hg t), sub_apply]
-  -- The difference `y := x - traj` is smooth, again solves the equation of motion (the force is
-  -- linear), and has vanishing initial data; energy conservation then forces `y = 0`.
   set y : Time → EuclideanSpace ℝ (Fin 1) := fun t => x t - IC.trajectory S t with hydef
   have hyContDiff : ContDiff ℝ ∞ y := hx.sub hTraj
-  have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t :=
-    dsub x _ (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
-  have hy_deriv2 : ∂ₜ (∂ₜ y) = fun t => ∂ₜ (∂ₜ x) t - ∂ₜ (∂ₜ (IC.trajectory S)) t := by
-    rw [hy_deriv]
-    exact dsub _ _ (deriv_differentiable_of_contDiff _ hx)
-      (deriv_differentiable_of_contDiff _ hTraj)
   have hNewt_x := (S.equationOfMotion_iff_newtons_2nd_law x hx).1 hEOM
   have hNewt_traj := (S.equationOfMotion_iff_newtons_2nd_law (IC.trajectory S) hTraj).1
     (trajectory_equationOfMotion S IC)
   have hEOM_y : S.EquationOfMotion y :=
     (S.equationOfMotion_iff_newtons_2nd_law y hyContDiff).2 fun t => by
+      have hy_deriv2 : ∂ₜ (∂ₜ y) t = ∂ₜ (∂ₜ x) t - ∂ₜ (∂ₜ (IC.trajectory S)) t := by
+        have dsub : ∀ f g : Time → EuclideanSpace ℝ (Fin 1),
+            Differentiable ℝ f → Differentiable ℝ g →
+            ∂ₜ (fun t => f t - g t) = fun t => ∂ₜ f t - ∂ₜ g t := by
+          intro f g hf hg; funext s
+          simp [Time.deriv_eq, fderiv_fun_sub (hf s) (hg s)]
+        have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t :=
+          dsub x _ (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
+        rw [hy_deriv]
+        exact congrFun (dsub (∂ₜ x) (∂ₜ (IC.trajectory S))
+          (deriv_differentiable_of_contDiff _ hx) (deriv_differentiable_of_contDiff _ hTraj)) t
       rw [hy_deriv2]
       simp [smul_sub, hNewt_x, hNewt_traj, hydef, force_eq_linear]
   have hE : ∀ t, S.energy y t = 0 := fun t =>
     (S.energy_conservation_of_equationOfMotion' y hyContDiff hEOM_y t).trans <| by
       have hy0 : y 0 = 0 := by simp [hydef, hx0]
       have hyv0 : ∂ₜ y 0 = 0 := by
-        rw [congrFun hy_deriv 0, hv0, trajectory_velocity_at_zero S IC]; simp
+        have dsub : ∀ f g : Time → EuclideanSpace ℝ (Fin 1),
+            Differentiable ℝ f → Differentiable ℝ g →
+            ∂ₜ (fun t => f t - g t) = fun t => ∂ₜ f t - ∂ₜ g t := by
+          intro f g hf hg; funext s
+          simp [Time.deriv_eq, fderiv_fun_sub (hf s) (hg s)]
+        have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t :=
+          dsub x _ (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
+        rw [congrFun hy_deriv 0, hv0, trajectory_velocity_at_zero S IC]
+        simp
       simp [HarmonicOscillator.energy, HarmonicOscillator.kineticEnergy,
-        HarmonicOscillator.potentialEnergy, hy0, hyv0, one_div, smul_eq_mul]
-  -- Both energies are nonnegative, so a vanishing total energy forces `y t = 0`.
+        HarmonicOscillator.potentialEnergy, hy0, hyv0]
   funext t
   have hk : 0 ≤ S.kineticEnergy y t := by
-    simp only [HarmonicOscillator.kineticEnergy]
-    exact mul_nonneg (mul_nonneg (by norm_num) S.m_pos.le) real_inner_self_nonneg
+    simp [HarmonicOscillator.kineticEnergy, mul_nonneg, S.m_pos.le, real_inner_self_nonneg]
   have hp : 0 ≤ S.potentialEnergy (y t) := by
-    simp only [HarmonicOscillator.potentialEnergy, smul_eq_mul]
-    exact mul_nonneg (by norm_num) (mul_nonneg S.k_pos.le real_inner_self_nonneg)
+    simp [HarmonicOscillator.potentialEnergy, mul_nonneg, S.k_pos.le, real_inner_self_nonneg]
   have hpe : S.potentialEnergy (y t) = 0 := ((add_eq_zero_iff_of_nonneg hk hp).mp (hE t)).2
-  simp only [HarmonicOscillator.potentialEnergy, smul_eq_mul] at hpe
-  rcases mul_eq_zero.mp hpe with h | h
-  · norm_num at h
+  have hpe' : S.k * inner ℝ (y t) (y t) = 0 := by
+    simpa [HarmonicOscillator.potentialEnergy, smul_eq_mul] using hpe
+  rcases eq_zero_or_eq_zero_of_mul_eq_zero hpe' with h | h
+  · exact (S.k_pos.ne' h).elim
   · have hyt : x t - IC.trajectory S t = 0 :=
-      inner_self_eq_zero.mp ((mul_eq_zero.mp h).resolve_left S.k_ne_zero)
+      inner_self_eq_zero.mp h
     exact sub_eq_zero.mp hyt
 
 /-!

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -552,7 +552,7 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
         smul_sub, hNewt_x, hNewt_traj, hydef, force_eq_linear]
   have hy0 : y 0 = 0 := by simp [hydef, hx0]
   have hyv0 : ∂ₜ y 0 = 0 := by
-    simpa [hy_deriv, hv0, trajectory_velocity_at_zero S IC]
+    simp [hy_deriv, hv0, trajectory_velocity_at_zero S IC]
   have hE : ∀ t, S.energy y t = 0 := fun t =>
     (S.energy_conservation_of_equationOfMotion' y hyContDiff hEOM_y t).trans <| by
       simp [HarmonicOscillator.energy, HarmonicOscillator.kineticEnergy,

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -539,27 +539,24 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
   have hTraj : ContDiff ℝ ∞ (IC.trajectory S) := by fun_prop
   set y : Time → EuclideanSpace ℝ (Fin 1) := fun t => x t - IC.trajectory S t with hydef
   have hyContDiff : ContDiff ℝ ∞ y := hx.sub hTraj
+  have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t :=
+    timeDeriv_sub (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
   have hNewt_x := (S.equationOfMotion_iff_newtons_2nd_law x hx).1 hEOM
   have hNewt_traj := (S.equationOfMotion_iff_newtons_2nd_law (IC.trajectory S) hTraj).1
     (trajectory_equationOfMotion S IC)
   have hEOM_y : S.EquationOfMotion y :=
     (S.equationOfMotion_iff_newtons_2nd_law y hyContDiff).2 fun t => by
       have hy_deriv2 : ∂ₜ (∂ₜ y) t = ∂ₜ (∂ₜ x) t - ∂ₜ (∂ₜ (IC.trajectory S)) t := by
-        have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t :=
-          timeDeriv_sub (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
         rw [hy_deriv]
-        exact congrFun (timeDeriv_sub
-          (deriv_differentiable_of_contDiff _ hx) (deriv_differentiable_of_contDiff _ hTraj)) t
+        simp [timeDeriv_sub (Time.deriv_differentiable_of_contDiff _ hx)
+          (Time.deriv_differentiable_of_contDiff _ hTraj)]
       rw [hy_deriv2]
       simp [smul_sub, hNewt_x, hNewt_traj, hydef, force_eq_linear]
+  have hy0 : y 0 = 0 := by simp [hydef, hx0]
+  have hyv0 : ∂ₜ y 0 = 0 := by
+    simpa [hy_deriv, hv0, trajectory_velocity_at_zero S IC]
   have hE : ∀ t, S.energy y t = 0 := fun t =>
     (S.energy_conservation_of_equationOfMotion' y hyContDiff hEOM_y t).trans <| by
-      have hy0 : y 0 = 0 := by simp [hydef, hx0]
-      have hyv0 : ∂ₜ y 0 = 0 := by
-        have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t :=
-          timeDeriv_sub (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
-        rw [congrFun hy_deriv 0, hv0, trajectory_velocity_at_zero S IC]
-        simp
       simp [HarmonicOscillator.energy, HarmonicOscillator.kineticEnergy,
         HarmonicOscillator.potentialEnergy, hy0, hyv0]
   funext t
@@ -572,8 +569,7 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
     simpa [HarmonicOscillator.potentialEnergy, smul_eq_mul] using hpe
   rcases eq_zero_or_eq_zero_of_mul_eq_zero hpe' with h | h
   · exact (S.k_pos.ne' h).elim
-  · have hyt : x t - IC.trajectory S t = 0 := inner_self_eq_zero.mp h
-    exact sub_eq_zero.mp hyt
+  · exact sub_eq_zero.mp (inner_self_eq_zero.mp h)
 
 /-!
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -430,11 +430,9 @@ lemma trajectory_velocity (IC : InitialConditions) : ∂ₜ (IC.trajectory S) =
   rw [fderiv_smul_const (by fun_prop), fderiv_smul_const (by fun_prop)]
   have h1 : (fderiv ℝ (fun t => sin (S.ω * t.val) / S.ω) t) =
     (1/ S.ω) • (fderiv ℝ (fun t => sin (S.ω * t.val)) t) := by
-    rw [← fderiv_mul_const]
-    congr
-    funext t
-    field_simp
-    fun_prop
+    rw [div_eq_mul_inv, ← fderiv_mul_const (hc := ?_)]
+    · congr; funext t; ring
+    · fun_prop
   simp [h1]
   rw [fderiv_cos (by fun_prop), fderiv_sin (by fun_prop),
     fderiv_fun_mul (by fun_prop) (by fun_prop)]
@@ -507,8 +505,7 @@ lemma trajectory_equationOfMotion (IC : InitialConditions) :
   ext
   have hω : S.ω ≠ 0 := ω_ne_zero S
   have hωm : S.ω ^ 2 * S.m = S.k := by
-    rw [ω_sq]
-    field_simp [m_ne_zero S]
+    rw [ω_sq]; field_simp [m_ne_zero S]
   simp [trajectory_eq, smul_add, smul_smul, mul_comm]
   rw [← hωm]
   field_simp [hω]
@@ -529,6 +526,11 @@ for the given initial conditions.
   position and velocity, the difference `y = x - IC.trajectory S` also solves the
   equation of motion with zero initial conditions; energy conservation then forces
   its energy, and hence `y`, to vanish identically, so `x = IC.trajectory S`. -/
+private lemma timeDeriv_sub {f g : Time → EuclideanSpace ℝ (Fin 1)}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) :
+    ∂ₜ (fun t => f t - g t) = fun t => ∂ₜ f t - ∂ₜ g t := by
+  funext s; simp [Time.deriv_eq, fderiv_fun_sub (hf s) (hg s)]
+
 lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace ℝ (Fin 1))
     (hx : ContDiff ℝ ∞ x) :
     S.EquationOfMotion x ∧ x 0 = IC.x₀ ∧ ∂ₜ x 0 = IC.v₀ →
@@ -543,15 +545,10 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
   have hEOM_y : S.EquationOfMotion y :=
     (S.equationOfMotion_iff_newtons_2nd_law y hyContDiff).2 fun t => by
       have hy_deriv2 : ∂ₜ (∂ₜ y) t = ∂ₜ (∂ₜ x) t - ∂ₜ (∂ₜ (IC.trajectory S)) t := by
-        have dsub : ∀ f g : Time → EuclideanSpace ℝ (Fin 1),
-            Differentiable ℝ f → Differentiable ℝ g →
-            ∂ₜ (fun t => f t - g t) = fun t => ∂ₜ f t - ∂ₜ g t := by
-          intro f g hf hg; funext s
-          simp [Time.deriv_eq, fderiv_fun_sub (hf s) (hg s)]
         have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t :=
-          dsub x _ (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
+          timeDeriv_sub (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
         rw [hy_deriv]
-        exact congrFun (dsub (∂ₜ x) (∂ₜ (IC.trajectory S))
+        exact congrFun (timeDeriv_sub
           (deriv_differentiable_of_contDiff _ hx) (deriv_differentiable_of_contDiff _ hTraj)) t
       rw [hy_deriv2]
       simp [smul_sub, hNewt_x, hNewt_traj, hydef, force_eq_linear]
@@ -559,13 +556,8 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
     (S.energy_conservation_of_equationOfMotion' y hyContDiff hEOM_y t).trans <| by
       have hy0 : y 0 = 0 := by simp [hydef, hx0]
       have hyv0 : ∂ₜ y 0 = 0 := by
-        have dsub : ∀ f g : Time → EuclideanSpace ℝ (Fin 1),
-            Differentiable ℝ f → Differentiable ℝ g →
-            ∂ₜ (fun t => f t - g t) = fun t => ∂ₜ f t - ∂ₜ g t := by
-          intro f g hf hg; funext s
-          simp [Time.deriv_eq, fderiv_fun_sub (hf s) (hg s)]
         have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t :=
-          dsub x _ (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
+          timeDeriv_sub (hx.differentiable (by simp)) (hTraj.differentiable (by simp))
         rw [congrFun hy_deriv 0, hv0, trajectory_velocity_at_zero S IC]
         simp
       simp [HarmonicOscillator.energy, HarmonicOscillator.kineticEnergy,
@@ -575,13 +567,12 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
     simp [HarmonicOscillator.kineticEnergy, mul_nonneg, S.m_pos.le]
   have hp : 0 ≤ S.potentialEnergy (y t) := by
     simp [HarmonicOscillator.potentialEnergy, mul_nonneg, S.k_pos.le]
-  have hpe : S.potentialEnergy (y t) = 0 := ((add_eq_zero_iff_of_nonneg hk hp).mp (hE t)).2
   have hpe' : S.k * inner ℝ (y t) (y t) = 0 := by
+    have hpe : S.potentialEnergy (y t) = 0 := ((add_eq_zero_iff_of_nonneg hk hp).mp (hE t)).2
     simpa [HarmonicOscillator.potentialEnergy, smul_eq_mul] using hpe
   rcases eq_zero_or_eq_zero_of_mul_eq_zero hpe' with h | h
   · exact (S.k_pos.ne' h).elim
-  · have hyt : x t - IC.trajectory S t = 0 :=
-      inner_self_eq_zero.mp h
+  · have hyt : x t - IC.trajectory S t = 0 := inner_self_eq_zero.mp h
     exact sub_eq_zero.mp hyt
 
 /-!

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -535,7 +535,9 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
   set y : Time → EuclideanSpace ℝ (Fin 1) := fun t => x t - IC.trajectory S t with hydef
   have hyContDiff : ContDiff ℝ ∞ y := hx.sub hTraj
   have hy_deriv : ∂ₜ y = fun t => ∂ₜ x t - ∂ₜ (IC.trajectory S) t := by
-    funext s; simp [Time.deriv_eq, fderiv_fun_sub (hx.differentiable (by simp) s)
+    funext s
+    dsimp [y]
+    simp [Time.deriv_eq, fderiv_fun_sub (hx.differentiable (by simp) s)
       (hTraj.differentiable (by simp) s)]
   have hNewt_x := (S.equationOfMotion_iff_newtons_2nd_law x hx).1 hEOM
   have hNewt_traj := (S.equationOfMotion_iff_newtons_2nd_law (IC.trajectory S) hTraj).1
@@ -543,9 +545,13 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
   have hEOM_y : S.EquationOfMotion y :=
     (S.equationOfMotion_iff_newtons_2nd_law y hyContDiff).2 fun t => by
       rw [hy_deriv]
-      simp [Time.deriv_eq, fderiv_fun_sub (deriv_differentiable_of_contDiff x hx).differentiableAt
-        (deriv_differentiable_of_contDiff (IC.trajectory S) hTraj).differentiableAt,
-        smul_sub, hNewt_x, hNewt_traj, hydef, force_eq_linear]
+      dsimp [y]
+      rw [Time.deriv_eq]
+      rw [fderiv_fun_sub (deriv_differentiable_of_contDiff x hx).differentiableAt
+        (deriv_differentiable_of_contDiff (IC.trajectory S) hTraj).differentiableAt]
+      simp only [smul_sub, ContinuousLinearMap.sub_apply]
+      rw [← Time.deriv_eq, ← Time.deriv_eq]
+      simp [smul_sub, hNewt_x, hNewt_traj, force_eq_linear]
   have hy0 : y 0 = 0 := by simp [hydef, hx0]
   have hyv0 : ∂ₜ y 0 = 0 := by
     simp [hy_deriv, hv0, trajectory_velocity_at_zero S IC]
@@ -557,12 +563,14 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
   have hsum : S.kineticEnergy y t + S.potentialEnergy (y t) = 0 := by
     simpa [HarmonicOscillator.energy] using hE t
   have hy_eq : y t = 0 := by
+    have hk : 0 ≤ S.kineticEnergy y t := by
+      unfold HarmonicOscillator.kineticEnergy
+      refine mul_nonneg (mul_nonneg (by norm_num) S.m_pos.le) real_inner_self_nonneg
+    have hp : 0 ≤ S.potentialEnergy (y t) := by
+      unfold HarmonicOscillator.potentialEnergy; simp only [smul_eq_mul]
+      refine mul_nonneg (by norm_num) (mul_nonneg S.k_pos.le real_inner_self_nonneg)
     have hpe : S.potentialEnergy (y t) = 0 :=
-      ((add_eq_zero_iff_of_nonneg
-        (by unfold HarmonicOscillator.kineticEnergy
-          refine mul_nonneg (mul_nonneg (by norm_num) S.m_pos.le) real_inner_self_nonneg)
-        (by unfold HarmonicOscillator.potentialEnergy; simp only [smul_eq_mul]
-          refine mul_nonneg (by norm_num) (mul_nonneg S.k_pos.le real_inner_self_nonneg))).mp hsum).2
+      ((add_eq_zero_iff_of_nonneg hk hp).mp hsum).2
     have h_inner : inner ℝ (y t) (y t) = 0 := by
       unfold HarmonicOscillator.potentialEnergy at hpe
       simpa [smul_eq_mul] using hpe
@@ -1211,21 +1219,25 @@ lemma return_time (IC : InitialConditions) (non_trivial : IC.x₀ ≠ 0 ∨ IC.v
   have det_ne_zero : det ≠ 0 := by bound
   have hxx : c * xx + (s / S.ω) * xv = xx := by
     calc
-      c * xx + (s / S.ω) * xv
-          = (inner ℝ (c • IC.x₀) IC.x₀) + (s / S.ω) * inner ℝ IC.v₀ IC.x₀ := by
-            simp [xx, xv, real_inner_comm]
-      _ = (inner ℝ (c • IC.x₀) IC.x₀) + inner ℝ ((s / S.ω) • IC.v₀) IC.x₀ := by
-            simp
-      _ = inner ℝ (c • IC.x₀ + (s / S.ω) • IC.v₀) IC.x₀ := by rw [inner_add_left]
-      _ = xx := by rw [htx]
+     c * xx + (s / S.ω) * xv =  (inner ℝ (c • IC.x₀) IC.x₀) + (s / S.ω) * xv := by
+       rw[real_inner_smul_left]
+     (inner ℝ (c • IC.x₀) IC.x₀) + (s / S.ω) * xv =
+       (inner ℝ (c • IC.x₀) IC.x₀) + (s / S.ω) * inner ℝ  IC.v₀ IC.x₀ := by
+         rw [real_inner_comm IC.x₀ IC.v₀]
+     _  = (inner ℝ (c • IC.x₀) IC.x₀) +  inner ℝ  ((s / S.ω)  • IC.v₀) IC.x₀ := by
+       rw [real_inner_smul_left IC.v₀]
+     _ = (inner ℝ (c • IC.x₀ + (s / S.ω)  • IC.v₀) IC.x₀) := by rw [inner_add_left]
+     _ = xx := by rw [htx]
   have hvv : - S.ω * s * xv + c * vv = vv := by
     calc
-      - S.ω * s * xv + c * vv
-          = inner ℝ (-(S.ω • s • IC.x₀)) IC.v₀ + inner ℝ (c • IC.v₀) IC.v₀ := by
-            simp [xv, vv, real_inner_comm]
-      _ = inner ℝ (-(S.ω • s • IC.x₀) + c • IC.v₀) IC.v₀ := by rw [inner_add_left]
-      _ = inner ℝ (-(S.ω • s • IC.x₀) + c • IC.v₀) IC.v₀ := by rw [neg_smul]
-      _ = vv := by rw [htv]
+     - S.ω * s * xv + c * vv = - S.ω * (s * xv) + c * vv := by ring_nf
+     _ = - S.ω * inner ℝ (s • IC.x₀) IC.v₀ + c * vv := by rw[real_inner_smul_left]
+     _ = inner ℝ  (- S.ω • s • IC.x₀ ) IC.v₀ + c * vv := by rw [← real_inner_smul_left]
+     _ = inner ℝ  (- S.ω • s • IC.x₀ ) IC.v₀ + inner ℝ (c • IC.v₀) IC.v₀ := by
+       rw [← real_inner_smul_left]
+     _ = inner ℝ (- S.ω • s • IC.x₀ + c • IC.v₀) IC.v₀ := by rw [inner_add_left]
+     _ = inner ℝ (-( S.ω • s • IC.x₀) + c • IC.v₀) IC.v₀ := by rw [neg_smul]
+     _ = vv := by rw [htv]
   have hcos : 1 = cos (S.ω * t) := by
     have hω : S.ω ≠ 0 := ω_ne_zero S
     field_simp [hω] at hxx
@@ -1233,13 +1245,15 @@ lemma return_time (IC : InitialConditions) (non_trivial : IC.x₀ ≠ 0 ∨ IC.v
     have hvv' : (c - 1) * vv - S.ω * s * xv = 0 := by linarith
     have h_comb : (c - 1) * det = 0 := by
       dsimp [det]
+      have hvv_eq : (c - 1) * vv = S.ω * s * xv := sub_eq_zero.mp hvv'
+      have htemp : s * xv = -(c - 1) * xx * S.ω := by linarith
       calc
         (c - 1) * (vv + xx * S.ω ^ 2)
             = (c - 1) * vv + (c - 1) * xx * S.ω ^ 2 := by ring
-        _ = (S.ω * s * xv) + (c - 1) * xx * S.ω ^ 2 := by linarith
-        _ = (S.ω * s * xv) + (-(S.ω * s * xv)) := by
-          have : (c - 1) * xx * S.ω ^ 2 = -(S.ω * s * xv) := by linarith
-          rw [this]
+        _ = (S.ω * s * xv) + (c - 1) * xx * S.ω ^ 2 := by rw [hvv_eq]
+        _ = S.ω * (s * xv) + (c - 1) * xx * S.ω ^ 2 := by ring
+        _ = S.ω * (-(c - 1) * xx * S.ω) + (c - 1) * xx * S.ω ^ 2 := by rw [htemp]
+        _ = -(c - 1) * xx * S.ω ^ 2 + (c - 1) * xx * S.ω ^ 2 := by ring
         _ = 0 := by ring
     have hc1 : c = 1 := by
       rcases mul_eq_zero.mp h_comb with h | h

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -572,9 +572,9 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
         HarmonicOscillator.potentialEnergy, hy0, hyv0]
   funext t
   have hk : 0 ≤ S.kineticEnergy y t := by
-    simp [HarmonicOscillator.kineticEnergy, mul_nonneg, S.m_pos.le, real_inner_self_nonneg]
+    simp [HarmonicOscillator.kineticEnergy, mul_nonneg, S.m_pos.le]
   have hp : 0 ≤ S.potentialEnergy (y t) := by
-    simp [HarmonicOscillator.potentialEnergy, mul_nonneg, S.k_pos.le, real_inner_self_nonneg]
+    simp [HarmonicOscillator.potentialEnergy, mul_nonneg, S.k_pos.le]
   have hpe : S.potentialEnergy (y t) = 0 := ((add_eq_zero_iff_of_nonneg hk hp).mp (hE t)).2
   have hpe' : S.k * inner ℝ (y t) (y t) = 0 := by
     simpa [HarmonicOscillator.potentialEnergy, smul_eq_mul] using hpe

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -588,8 +588,7 @@ lemma trajectory_energy (IC : InitialConditions) : S.energy (IC.trajectory S) =
     fun _ => 1/2 * (S.m * ‖IC.v₀‖ ^2 + S.k * ‖IC.x₀‖ ^ 2) := by
   funext t
   rw [energy_conservation_of_equationOfMotion' _ _ (by fun_prop) (trajectory_equationOfMotion S IC)]
-  simp [energy, kineticEnergy, potentialEnergy]
-  ring
+  simp [energy, kineticEnergy, potentialEnergy]; ring
 
 end InitialConditions
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -466,7 +466,7 @@ lemma trajectory_acceleration (IC : InitialConditions) : ∂ₜ (∂ₜ (IC.traj
     FunLike.coe_smul, Pi.smul_apply, ContinuousLinearMap.smulRight_apply, fderiv_val,
     smul_eq_mul, mul_one, neg_smul]
   ring_nf
-  module
+  ext; simp; ring
 
 /-!
 

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -341,61 +341,21 @@ lemma isTotalTimeDerivativeVelocity  [CompleteSpace X]
     ∃ g : X, ∀ v, δL v = ⟪g, v⟫_ℝ := by
   classical
   rcases (isTotalTimeDerivative_explicit.mp h) with ⟨F, hFdiff, hEq⟩
-
-  -- Derivative of F at (0,0)
-  let dF : (Time  × X) →L[ℝ] ℝ :=
-    fderiv ℝ ↿F ((0 : Time), (0 : X))
-
-  -- The "time-direction" derivative must vanish because δL 0 = 0.
+  let dF : (Time × X) →L[ℝ] ℝ := fderiv ℝ ↿F ((0 : Time), (0 : X))
   have h_time : dF ((1 : Time), (0 : X)) = 0 := by
-    have h0 :
-        δL (0 : X) =
-          fderiv ℝ ↿F ((0 : Time), (0 : X))
-            ((1 : Time), (0 : X)) := by
-      simpa using (hEq (0 : Time) (0 : X)
-        (0 : X))
-    have : dF ((1 : Time), (0 : X)) =
-        δL (0 : X) := by
-      simpa [dF] using h0.symm
-    simpa [hδL0] using this
-
-  -- Induced continuous linear functional on velocity: v ↦ dF (0,v).
-  let φ : X →L[ℝ] ℝ :=
-    dF.comp (ContinuousLinearMap.inr ℝ Time X)
-
-  -- Show δL v = φ v for all v.
+    simpa [dF, hδL0] using (hEq (0 : Time) (0 : X) (0 : X)).symm
+  let φ : X →L[ℝ] ℝ := dF.comp (ContinuousLinearMap.inr ℝ Time X)
   have hφ : ∀ v : X, δL v = φ v := by
     intro v
-    have hv :
-        δL v =
-          fderiv ℝ ↿F ((0 : Time), (0 : X))
-            ((1 : Time), v) := by
-      simpa using (hEq (0 : Time) (0 : X) v)
-    have hv' : δL v = dF ((1 : Time), v) := by
-      simpa [dF] using hv
     calc
-      δL v = dF ((1 : Time), v) := hv'
-     _ = dF (((0  : Time), v) + ((1 : Time), (0 : X))) := by simp only [Prod.mk_add_mk, zero_add,
-        add_zero]
-      _ = dF ((0 : Time), v) + dF ((1 : Time), (0 : X)) := by
-        simpa using
-          (dF.map_add ((0 : Time), v) ((1 : Time), (0 : X)))
-      _ = dF ((0 : Time), v) := by
-        simp [h_time]
-      _ = φ v := by
-        simp [φ]
-
-  -- Frechet–Riesz: represent φ as inner product with some g.
-  refine ⟨(InnerProductSpace.toDual ℝ (X)).symm φ, ?_⟩
-  intro v
-  have hinner :
-      ⟪(InnerProductSpace.toDual ℝ (X)).symm φ, v⟫_ℝ = φ v := by
-    rw [InnerProductSpace.toDual_symm_apply (𝕜 := ℝ)
-        (E := X) (x := v) (y := φ)]
-  calc
-    δL v = φ v := hφ v
-    _ = ⟪(InnerProductSpace.toDual ℝ (X)).symm φ, v⟫_ℝ := by
-      rw [hinner.symm]
+      δL v = dF ((1 : Time), v) := by simpa [dF] using hEq (0 : Time) (0 : X) v
+      _ = dF (((0 : Time), v) + ((1 : Time), (0 : X))) := by simp
+      _ = dF ((0 : Time), v) + dF ((1 : Time), (0 : X)) := by rw [dF.map_add]
+      _ = dF ((0 : Time), v) := by simp [h_time]
+      _ = φ v := by simp [φ]
+  refine ⟨(InnerProductSpace.toDual ℝ (X)).symm φ, fun v => ?_⟩
+  simpa [hφ v] using
+    (InnerProductSpace.toDual_symm_apply (𝕜 := ℝ) (E := X) (x := v) (y := φ)).symm
 
 end Lagrangian
 

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -354,8 +354,7 @@ lemma isTotalTimeDerivativeVelocity  [CompleteSpace X]
       _ = dF ((0 : Time), v) := by simp [h_time]
       _ = φ v := by simp [φ]
   refine ⟨(InnerProductSpace.toDual ℝ (X)).symm φ, fun v => ?_⟩
-  simpa [hφ v] using
-    (InnerProductSpace.toDual_symm_apply (𝕜 := ℝ) (E := X) (x := v) (y := φ)).symm
+  simp [hφ v, InnerProductSpace.toDual_symm_apply]
 
 end Lagrangian
 

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -181,40 +181,25 @@ Elementary fact: if δL is a time derivative, then so is -δL.
 -/
 lemma isTotalTimeDerivative_neg {δL : Time → X → X → ℝ} (h :  IsTotalTimeDerivative δL) :
     IsTotalTimeDerivative (- δL) := by
-    rcases h with ⟨F, h_ContDiff, hF⟩
-    set F_neg := (fun t q => - F t q)
-    use F_neg
-    have h_neg_F_ContDiff : ContDiff ℝ ∞ ↿F_neg := by
-      fun_prop
-    use  h_neg_F_ContDiff
-    intro t q hq
-    simp only [Pi.neg_apply]
-    rw [hF t q hq]
-    unfold F_neg
-    unfold Time.deriv
-    simp only [fderiv_fun_neg, _root_.neg_apply]
+    rcases h with ⟨F, hF_contDiff, hF⟩
+    refine ⟨fun t q => -F t q, hF_contDiff.neg, fun t q hq => ?_⟩
+    calc
+      (-δL) t (q t) (∂ₜ q t) = -(δL t (q t) (∂ₜ q t)) := rfl
+      _ = -(∂ₜ (fun t' => F t' (q t')) t) := by rw [hF t q hq]
+      _ = ∂ₜ (-(fun t' => F t' (q t'))) t := by rw [← Time.deriv_neg]
+      _ = ∂ₜ (fun t' => -F t' (q t')) t := rfl
 
 /--
 If δL is a total time derivative (of a smooth function), then it is smooth
 -/
 lemma totalTimeDerivative_contDiff {δL : Time → X → X → ℝ} (h : IsTotalTimeDerivative δL):
     ContDiff ℝ ∞ ↿δL := by
- rcases isTotalTimeDerivative_explicit.mp h with ⟨F, hContDiff, heq⟩
- let Fder_v := Prod.map (fderiv ℝ ↿(fun t q => F t q)) (fun (v : X) => v )
- let regroup := ↿(fun (t : Time) (q : X) (v : X) => ((t, q), v))
- let appv := fun (FV : ((Time × X →L[ℝ] ℝ) × X )) => FV.fst (1, FV.snd)
- have hδL : ↿δL = appv ∘ Fder_v ∘ regroup := by
-   funext tqv
-   rcases tqv with ⟨t, q, v⟩
-   simp only [Function.comp_apply]
-   change δL t q v = appv (Fder_v (regroup (t, q, v)))
-   rw [heq t q v]
-   rfl
- rw [hδL]
- unfold appv
- unfold Fder_v
- unfold regroup
- fun_prop
+  rcases (isTotalTimeDerivative_explicit.mp h) with ⟨F, hF, heq⟩
+  have hδL :
+      δL = fun (t : Time) (q : X) (v : X) => fderiv ℝ ↿F (t, q) (1, v) := by
+    funext t q v; exact heq t q v
+  rw [hδL]
+  fun_prop
 
 /-!
 ## B. Total time derivative do not affect the physical content
@@ -265,13 +250,14 @@ lemma totalTimeDerivative_hasVarGradientAt_equivalence [CompleteSpace X] (L δL 
     (q : Time → X)    (hq : ContDiff ℝ ∞ q) (grad : Time → X)
     (hgrad :  HasVarGradientAt (fun q' t => L t (q' t) (fderiv ℝ  q' t 1)) grad q) :
     HasVarGradientAt (fun q' t => (L + δL) t (q' t) (fderiv ℝ q' t 1)) grad q := by
-  have h_add_zero : grad = grad + (fun _ => 0) := by
-    funext t
+  have h_add := HasVarGradientAt.add
+    (F := fun q' t => L t (q' t) (fderiv ℝ q' t 1))
+    (F' := fun q' t => δL t (q' t) (∂ₜ q' t))
+    hgrad (totalTimeDerivative_hasZeroVarGradient hδL q hq)
+  convert h_add using 1
+  · rfl
+  · ext
     simp
-  rw [h_add_zero]
-  apply HasVarGradientAt.add
-  · exact hgrad
-  · exact totalTimeDerivative_hasZeroVarGradient hδL q hq
 
 
 /-

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -281,32 +281,23 @@ lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : T
     (htot : IsTotalTimeDerivative (L' - L)) (hContDiff : (ContDiff ℝ ∞ ↿L) ∨ (ContDiff ℝ ∞ ↿L'))
     (q : Time → X) (hq : ContDiff ℝ ∞ q) : eulerLagrangeOp L q = eulerLagrangeOp L' q := by
   rcases (isTotalTimeDerivative_explicit.mp htot) with ⟨F, hFContDiff, hEq⟩
-  have hContDiff_both :  (ContDiff ℝ ∞ ↿L) ∧ (ContDiff ℝ ∞ ↿L') := by
+  have h_δL_contDiff := totalTimeDerivative_contDiff htot
+  have h_δL_contDiff_neg := totalTimeDerivative_contDiff (isTotalTimeDerivative_neg htot)
+  have hContDiff_both : (ContDiff ℝ ∞ ↿L) ∧ (ContDiff ℝ ∞ ↿L') := by
     cases hContDiff with
-      | inl hL =>
-        constructor
-        · exact hL
-        · have h_triv : ↿L' =  ↿L + ↿(L' - L) := by
-            funext tqv
-            rcases tqv with ⟨t, q', v⟩
-            rw [Pi.add_apply]
-            change L' t q' v = L t q' v + (L' - L) t q' v
-            simp
-          have h_δL_contDiff := totalTimeDerivative_contDiff htot
-          rw [h_triv]
-          exact hL.add h_δL_contDiff
-      | inr hL' =>
-        constructor
-        · have h_triv : ↿L =  ↿L' + ↿(-(L' - L)) := by
-            funext tqv
-            rcases tqv with ⟨t, q', v⟩
-            rw [Pi.add_apply]
-            change L t q' v = L' t q' v + (- (L' - L)) t q' v
-            simp
-          have h_δL_contDiff := totalTimeDerivative_contDiff (isTotalTimeDerivative_neg htot)
-          rw [h_triv]
-          exact hL'.add h_δL_contDiff
-        · exact hL'
+    | inl hL =>
+      have hL' : ContDiff ℝ ∞ ↿L' := by
+        have : ↿L' = ↿L + ↿(L' - L) := by ext tqv; rcases tqv with ⟨t, q', v⟩; simp
+        rw [this]
+        exact hL.add h_δL_contDiff
+      exact ⟨hL, hL'⟩
+    | inr hL' =>
+      have hL : ContDiff ℝ ∞ ↿L := by
+        have : ↿L = ↿L' + ↿(-(L' - L)) := by
+          ext ⟨t, q', v⟩; simp [Pi.add_apply, Pi.neg_apply, sub_eq_add_neg]
+        rw [this]
+        exact hL'.add h_δL_contDiff_neg
+      exact ⟨hL, hL'⟩
   rw [← euler_lagrange_varGradient L q hq hContDiff_both.left]
   rw [← euler_lagrange_varGradient L' q hq hContDiff_both.right]
   apply Eq.symm
@@ -347,12 +338,16 @@ lemma isTotalTimeDerivativeVelocity  [CompleteSpace X]
   let φ : X →L[ℝ] ℝ := dF.comp (ContinuousLinearMap.inr ℝ Time X)
   have hφ : ∀ v : X, δL v = φ v := by
     intro v
-    calc
-      δL v = dF ((1 : Time), v) := by simpa [dF] using hEq (0 : Time) (0 : X) v
-      _ = dF (((0 : Time), v) + ((1 : Time), (0 : X))) := by simp
-      _ = dF ((0 : Time), v) + dF ((1 : Time), (0 : X)) := by rw [dF.map_add]
-      _ = dF ((0 : Time), v) := by simp [h_time]
-      _ = φ v := by simp [φ]
+    have h := hEq (0 : Time) (0 : X) v
+    have h1 : δL v = dF ((1 : Time), v) := by simpa [dF] using h
+    have h2 : dF ((1 : Time), v) = dF ((0 : Time), v) := by
+      calc
+        dF ((1 : Time), v) = dF (((0 : Time), v) + ((1 : Time), (0 : X))) := by simp
+        _ = dF ((0 : Time), v) + dF ((1 : Time), (0 : X)) := by rw [map_add]
+        _ = dF ((0 : Time), v) + 0 := by rw [h_time]
+        _ = dF ((0 : Time), v) := by simp
+    have h3 : dF ((0 : Time), v) = φ v := by simp [φ, dF]
+    rw [h1, h2, h3]
   refine ⟨(InnerProductSpace.toDual ℝ (X)).symm φ, fun v => ?_⟩
   simp [hφ v, InnerProductSpace.toDual_symm_apply]
 

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -287,14 +287,15 @@ lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : T
     cases hContDiff with
     | inl hL =>
       have hL' : ContDiff ℝ ∞ ↿L' := by
-        have : ↿L' = ↿L + ↿(L' - L) := by ext tqv; rcases tqv with ⟨t, q', v⟩; simp
+        have : ↿L' = ↿L + ↿(L' - L) := by
+          ext tqv; rcases tqv with ⟨t, q', v⟩; show L' t q' v = L t q' v + (L' - L) t q' v; simp
         rw [this]
         exact hL.add h_δL_contDiff
       exact ⟨hL, hL'⟩
     | inr hL' =>
       have hL : ContDiff ℝ ∞ ↿L := by
         have : ↿L = ↿L' + ↿(-(L' - L)) := by
-          ext ⟨t, q', v⟩; simp [Pi.add_apply, Pi.neg_apply, sub_eq_add_neg]
+          ext ⟨t, q', v⟩; show L t q' v = L' t q' v + (-(L' - L)) t q' v; simp
         rw [this]
         exact hL'.add h_δL_contDiff_neg
       exact ⟨hL, hL'⟩

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -101,55 +101,40 @@ lemma isTotalTimeDerivative_explicit {δL : Time → X → X → ℝ} :
   let tq := fun (q : Time → X) t => (t, q t)
   have h_tq_contDiff : ∀ (q : Time → X), ContDiff ℝ ∞ q -> ContDiff ℝ ∞ (tq q) := by
     fun_prop
-  have h_tq_der :  ∀ (q : Time → X) t, ContDiff ℝ ∞ q -> ∂ₜ (tq q) t = (1, ∂ₜ q t) := by
-    intro q t h_ContDiff_q
-    ext
-    change (∂ₜ (tq q) t).1.val = (1 : Time).val
-    congr
-    apply Eq.symm
+  have h_tq_der_val : ∀ (q : Time → X) t, ContDiff ℝ ∞ q ->
+      fderiv ℝ (tq q) t 1 = (1, ∂ₜ q t) := by
+    intro q t hq
+    have h_diff_id : DifferentiableAt ℝ (fun (t' : Time) => t') t := by fun_prop
+    have h_diff_q : DifferentiableAt ℝ q t :=
+      hq.contDiffAt.differentiableAt (by simp)
+    have h_fderiv_eq : fderiv ℝ (fun (t' : Time) => (t', q t')) t =
+        (fderiv ℝ (fun (t' : Time) => t') t).prod (fderiv ℝ q t) :=
+      h_diff_id.fderiv_prodMk h_diff_q
     calc
-      (1 : Time) = fderiv ℝ (fun (t' : Time) => t') t 1 := by simp only [fderiv_fun_id,
-        ContinuousLinearMap.coe_id', id_eq]
-      _ = fderiv ℝ (fun (t' : Time) => (tq q t').1) t 1 := by rfl
-      _ = (∂ₜ (tq q) t).1 := by
-        rw [fderiv.fst]
-        · simp
-          rfl
-        · apply ContDiffAt.differentiableAt
-          · apply ContDiff.contDiffAt
-            exact h_tq_contDiff q h_ContDiff_q
-          · by_contra
-            rcases this
-    apply Eq.symm
-    calc
-       (1, ∂ₜ q t).2 = fderiv ℝ (fun t' => (tq q t').2) t 1 := by rfl
-       _ = (∂ₜ (tq q) t).2 := by
-        rw [fderiv.snd]
-        · simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.coe_snd']
-          rfl
-        · apply ContDiffAt.differentiableAt
-          · apply ContDiff.contDiffAt
-            exact h_tq_contDiff q h_ContDiff_q
-          · by_contra
-            rcases this
-  have h_F_tq_der : ∀ (q : Time → X) (F : Time → X → ℝ) t, (ContDiff ℝ ∞ ↿F) → (ContDiff ℝ ∞ q)  →
+      fderiv ℝ (tq q) t 1 = (fderiv ℝ (fun (t' : Time) => (t', q t')) t) 1 := rfl
+      _ = ((fderiv ℝ (fun (t' : Time) => t') t).prod (fderiv ℝ q t)) 1 := by rw [h_fderiv_eq]
+      _ = (fderiv ℝ (fun (t' : Time) => t') t 1, (fderiv ℝ q t) 1) := rfl
+      _ = (1, ∂ₜ q t) := by simp [Time.deriv_eq]
+  have h_tq_der : ∀ (q : Time → X) t, ContDiff ℝ ∞ q -> ∂ₜ (tq q) t = (1, ∂ₜ q t) := by
+    intro q t hq
+    rw [Time.deriv_eq, h_tq_der_val q t hq]
+  have h_F_tq_der : ∀ (q : Time → X) (F : Time → X → ℝ) t, (ContDiff ℝ ∞ ↿F) → (ContDiff ℝ ∞ q) →
       ∂ₜ (fun t' => ↿F (t', q t')) t = fderiv ℝ ↿F (t, q t) ((1 : Time), ∂ₜ q t) := by
     intro q F t hF hq
-    change  fderiv ℝ ((↿F) ∘ (tq q)) t 1 = fderiv ℝ ↿F (t, q t) ((1 : Time), ∂ₜ q t)
-    rw [fderiv_comp]
-    · simp only [ContinuousLinearMap.comp_apply]
-      rw [← Time.deriv_eq,h_tq_der]
-      exact hq
-    · apply ContDiffAt.differentiableAt
-      · apply ContDiff.contDiffAt
-        exact hF
-      · by_contra
-        rcases this
-    · apply ContDiffAt.differentiableAt
-      · apply ContDiff.contDiffAt
-        exact h_tq_contDiff q hq
-      · by_contra
-        rcases this
+    have h_diff_F : DifferentiableAt ℝ ↿F (t, q t) :=
+      hF.contDiffAt.differentiableAt (by simp)
+    have h_diff_tq : DifferentiableAt ℝ (tq q) t :=
+      (h_tq_contDiff q hq).contDiffAt.differentiableAt (by simp)
+    calc
+      ∂ₜ (fun t' => ↿F (t', q t')) t = fderiv ℝ (fun t' => ↿F (t', q t')) t 1 := by
+        rw [Time.deriv_eq]
+      _ = fderiv ℝ ((↿F) ∘ (tq q)) t 1 := rfl
+      _ = (fderiv ℝ ↿F ((tq q) t) ∘SL fderiv ℝ (tq q) t) 1 := by
+        rw [fderiv_comp t h_diff_F h_diff_tq]
+      _ = fderiv ℝ ↿F ((tq q) t) (fderiv ℝ (tq q) t 1) := rfl
+      _ = fderiv ℝ ↿F (t, q t) ((1 : Time), ∂ₜ q t) := by
+        rw [h_tq_der_val q t hq]
+
   -- beginning of the proof
   constructor
   -- From total the total derivative to the explicit form

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -97,34 +97,22 @@ def IsTotalTimeDerivative
 lemma isTotalTimeDerivative_explicit {δL : Time → X → X → ℝ} :
     IsTotalTimeDerivative δL ↔  (∃ (F : Time → X → ℝ) (_ : ContDiff ℝ ∞ ↿F),
     ∀ t q v, δL t q v = fderiv ℝ ↿F (t, q) ((1 : Time), v)) := by
-  -- Preliminary construction: properties of the function t => (t, q t)
   let tq := fun (q : Time → X) t => (t, q t)
-  have h_tq_contDiff : ∀ (q : Time → X), ContDiff ℝ ∞ q -> ContDiff ℝ ∞ (tq q) := by
-    fun_prop
   have h_tq_der_val : ∀ (q : Time → X) t, ContDiff ℝ ∞ q ->
       fderiv ℝ (tq q) t 1 = (1, ∂ₜ q t) := by
     intro q t hq
-    have h_diff_id : DifferentiableAt ℝ (fun (t' : Time) => t') t := by fun_prop
-    have h_diff_q : DifferentiableAt ℝ q t :=
-      hq.contDiffAt.differentiableAt (by simp)
-    have h_fderiv_eq : fderiv ℝ (fun (t' : Time) => (t', q t')) t =
-        (fderiv ℝ (fun (t' : Time) => t') t).prod (fderiv ℝ q t) :=
-      h_diff_id.fderiv_prodMk h_diff_q
-    calc
-      fderiv ℝ (tq q) t 1 = (fderiv ℝ (fun (t' : Time) => (t', q t')) t) 1 := rfl
-      _ = ((fderiv ℝ (fun (t' : Time) => t') t).prod (fderiv ℝ q t)) 1 := by rw [h_fderiv_eq]
-      _ = (fderiv ℝ (fun (t' : Time) => t') t 1, (fderiv ℝ q t) 1) := rfl
-      _ = (1, ∂ₜ q t) := by simp [Time.deriv_eq]
-  have h_tq_der : ∀ (q : Time → X) t, ContDiff ℝ ∞ q -> ∂ₜ (tq q) t = (1, ∂ₜ q t) := by
-    intro q t hq
-    rw [Time.deriv_eq, h_tq_der_val q t hq]
+    have h := (differentiableAt_id (𝕜 := ℝ) (x := t)).fderiv_prodMk
+      ((hq.contDiffAt (x := t)).differentiableAt (by simp))
+    dsimp [tq]
+    simpa [Time.deriv_eq] using congrArg (fun f => f 1) h
   have h_F_tq_der : ∀ (q : Time → X) (F : Time → X → ℝ) t, (ContDiff ℝ ∞ ↿F) → (ContDiff ℝ ∞ q) →
       ∂ₜ (fun t' => ↿F (t', q t')) t = fderiv ℝ ↿F (t, q t) ((1 : Time), ∂ₜ q t) := by
     intro q F t hF hq
     have h_diff_F : DifferentiableAt ℝ ↿F (t, q t) :=
       hF.contDiffAt.differentiableAt (by simp)
-    have h_diff_tq : DifferentiableAt ℝ (tq q) t :=
-      (h_tq_contDiff q hq).contDiffAt.differentiableAt (by simp)
+    have h_diff_tq : DifferentiableAt ℝ (tq q) t := by
+      have h_contDiff : ContDiff ℝ ∞ (tq q) := by fun_prop
+      exact h_contDiff.contDiffAt.differentiableAt (by simp)
     calc
       ∂ₜ (fun t' => ↿F (t', q t')) t = fderiv ℝ (fun t' => ↿F (t', q t')) t 1 := by
         rw [Time.deriv_eq]
@@ -134,47 +122,36 @@ lemma isTotalTimeDerivative_explicit {δL : Time → X → X → ℝ} :
       _ = fderiv ℝ ↿F ((tq q) t) (fderiv ℝ (tq q) t 1) := rfl
       _ = fderiv ℝ ↿F (t, q t) ((1 : Time), ∂ₜ q t) := by
         rw [h_tq_der_val q t hq]
-
-  -- beginning of the proof
   constructor
-  -- From total the total derivative to the explicit form
   · intro h
     rcases h with ⟨F, hF⟩
     rcases hF with ⟨hFdif, hFder⟩
-    use F
-    use hFdif
+    use F, hFdif
     intro t q₀ v
     let qv := fun (t' : Time) => (q₀ - t.val • v) + t'.val • v
-    have h_qv_contDiff : ContDiff ℝ ∞ qv := by
-      change ContDiff ℝ ∞ (((fun (tR : ℝ) => (q₀ - t.val • v) + tR • v)) ∘ Time.toRealCLE)
-      fun_prop
+    have h_qv_contDiff : ContDiff ℝ ∞ qv := by fun_prop
     have h_qv_t : qv t = q₀ := by
-      calc
-        qv t = (q₀ - t.val • v) + t.val • v := by rfl
-        _ = q₀ := by module
+      dsimp [qv]; simp [sub_add_cancel]
     have h_qv_der : ∂ₜ qv t = v := by
-      calc
-        ∂ₜ qv t = fderiv ℝ (fun t' => (q₀ - t.val • v) + t'.val • v) t 1 := by rfl
-        _ = v := by
-          rw [fderiv_const_add,fderiv_smul_const]
-          · simp only [ContinuousLinearMap.smulRight_apply, fderiv_val, one_smul]
-          · fun_prop
+      rw [Time.deriv_eq]
+      dsimp [qv]
+      rw [fderiv_const_add (q₀ - t.val • v) (f := fun (t' : Time) => t'.val • v)]
+      have h := fderiv_smul_const (by fun_prop : DifferentiableAt ℝ (fun (t' : Time) => t'.val) t) v
+      simpa [fderiv_val] using congrArg (fun f => f 1) h
     rw [← h_qv_t, ← h_qv_der, hFder, ← h_F_tq_der]
     · rfl
     · exact hFdif
     · exact h_qv_contDiff
     · exact h_qv_contDiff
-  -- From the explicit form to the total derivative
   · intro h
     rcases h with ⟨F, hF⟩
     rcases hF with ⟨hFdif, hFder⟩
-    use F
-    use hFdif
-    intro t q hq_ContDiff
+    use F, hFdif
+    intro t q hq
     rw [hFder, ← h_F_tq_der]
     · rfl
     · exact hFdif
-    · exact hq_ContDiff
+    · exact hq
 
 /--
 Elementary fact: if δL is a time derivative, then so is -δL.

--- a/Physlib/ClassicalMechanics/RigidBody/SolidSphere.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/SolidSphere.lean
@@ -44,9 +44,9 @@ noncomputable def solidSphere (d : ℕ) (m R : ℝ≥0) : RigidBody d where
       ring⟩
 
 lemma solidSphere_mass {d : ℕ} (m R : ℝ≥0) (hr : R ≠ 0) : (solidSphere d m R).mass = m := by
-  simp only [mass, solidSphere]
-  simp only [LinearMap.coe_mk, AddHom.coe_mk, ContMDiffMap.coeFn_mk, integral_const,
-    MeasurableSet.univ, measureReal_restrict_apply, Set.univ_inter, smul_eq_mul, mul_one]
+  simp only [mass, solidSphere, LinearMap.coe_mk, AddHom.coe_mk, ContMDiffMap.coeFn_mk,
+    integral_const, MeasurableSet.univ, measureReal_restrict_apply, Set.univ_inter, smul_eq_mul,
+    mul_one]
   have h1 : (@volume (Space d) measureSpaceOfInnerProductSpace).real
       (Metric.closedBall 0 R) ≠ 0 := by
     refine (measureReal_ne_zero_iff ?_).mpr ?_

--- a/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
+++ b/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
@@ -421,6 +421,6 @@ lemma wave_fderiv_inner_eq_inner_fderiv_proj {f₀ : ℝ → EuclideanSpace ℝ 
   rw [← mul_one (s.unit i), ← smul_eq_mul (s.unit i)]
   rw [← mul_one (inner ℝ y s.unit), ← smul_eq_mul (inner ℝ y s.unit)]
   simp only [smul_eq_mul, mul_comm, one_mul, ← mul_assoc]
-  repeat fun_prop
+  all_goals fun_prop
 
 end ClassicalMechanics

--- a/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
+++ b/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
@@ -101,11 +101,7 @@ lemma planeWave_differentiable_space {d f₀ c t} {s : Direction d}
   simp only [planeWave_eq]
   apply Differentiable.comp
   · fun_prop
-  · apply Differentiable.sub
-    · refine Differentiable.inner ℝ ?_ ?_
-      · fun_prop
-      · fun_prop
-    · fun_prop
+  apply Differentiable.sub <;> fun_prop
 
 @[fun_prop]
 lemma planeWave_differentiable {s : Direction d}

--- a/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
+++ b/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
@@ -122,6 +122,10 @@ lemma planeWave_differentiable {s : Direction d}
 
 -/
 
+lemma iteratedDeriv_two_eq_deriv_deriv (f : ℝ → EuclideanSpace ℝ (Fin d)) :
+    iteratedDeriv 2 f = deriv (deriv f) := by
+  ext x; rw [iteratedDeriv_succ', iteratedDeriv_one]
+
 lemma planeWave_time_deriv {d f₀ c x} {s : Direction d}
     (h' : Differentiable ℝ f₀) :
     ∂ₜ (planeWave f₀ c s · x) = -c • fun t => planeWave (fderiv ℝ f₀ · 1) c s t x := by
@@ -152,9 +156,7 @@ lemma planeWave_time_deriv_time_deriv {d f₀ c x} {s : Direction d}
   simp only [fderiv_eq_smul_deriv, one_smul, Pi.smul_apply, PiLp.smul_apply, smul_eq_mul, neg_mul,
     mul_neg, neg_neg]
   ring_nf
-  have h_iter : (fun x => _root_.deriv (fun x => _root_.deriv f₀ x) x) = fun x => iteratedDeriv 2 f₀ x := by
-    ext x; rw [iteratedDeriv_succ', iteratedDeriv_one]
-  rw [h_iter]
+  rw [iteratedDeriv_two_eq_deriv_deriv f₀]
 
 /-!
 
@@ -235,9 +237,7 @@ lemma planeWave_apply_space_deriv_space_deriv {d f₀ c} {s : Direction d}
   rw [← Space.deriv_eq_fderiv_basis, planeWave_apply_space_deriv]
   simp only [fderiv_eq_smul_deriv, one_smul, Pi.smul_apply, smul_eq_mul]
   ring_nf
-  have h_iter : (fun x => _root_.deriv (fun x => _root_.deriv f₀ x) x) = fun x => iteratedDeriv 2 f₀ x := by
-    ext x; rw [iteratedDeriv_succ', iteratedDeriv_one]
-  rw [h_iter]
+  rw [iteratedDeriv_two_eq_deriv_deriv f₀]
   repeat fun_prop
 
 /-!

--- a/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
+++ b/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
@@ -112,8 +112,7 @@ lemma planeWave_differentiable {s : Direction d}
   apply Differentiable.comp
   · fun_prop
   · apply Differentiable.sub
-    · apply Differentiable.inner
-      repeat fun_prop
+    · apply Differentiable.inner <;> fun_prop
     · fun_prop
 
 /-!
@@ -140,7 +139,7 @@ lemma planeWave_time_deriv {d f₀ c x} {s : Direction d}
   left
   simp
   rfl
-  repeat fun_prop
+  all_goals fun_prop
 
 lemma planeWave_time_deriv_time_deriv {d f₀ c x} {s : Direction d}
     (h' : ContDiff ℝ 2 f₀) :
@@ -183,7 +182,7 @@ lemma planeWave_space_deriv {d f₀ c} {s : Direction d}
     fderiv_fun_id, ContinuousLinearMap.coe_id', id_eq, basis_inner, zero_add, mul_eq_mul_left_iff]
   left
   simp [planeWave_eq]
-  repeat fun_prop
+  all_goals fun_prop
 
 lemma planeWave_apply_space_deriv {d f₀ c} {s : Direction d}
     (h' : Differentiable ℝ f₀) (i j : Fin d) :
@@ -238,7 +237,7 @@ lemma planeWave_apply_space_deriv_space_deriv {d f₀ c} {s : Direction d}
   simp only [fderiv_eq_smul_deriv, one_smul, Pi.smul_apply, smul_eq_mul]
   ring_nf
   rw [iteratedDeriv_two_eq_deriv_deriv f₀]
-  repeat fun_prop
+  all_goals fun_prop
 
 /-!
 
@@ -285,7 +284,7 @@ lemma wave_differentiable {s : Direction d} {c : ℝ} {x : Space d} :
     DifferentiableAt ℝ (fun x => inner ℝ x s.unit - c * t) x := by
   apply DifferentiableAt.sub
   apply DifferentiableAt.inner
-  repeat fun_prop
+  all_goals fun_prop
 
 lemma wave_dx2 {u v : Fin d} {s : Direction d}
     {f₀' : ℝ → ℝ →L[ℝ] EuclideanSpace ℝ (Fin d)} {f₀'' : ℝ → ℝ →L[ℝ] EuclideanSpace ℝ (Fin d)}

--- a/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
+++ b/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
@@ -152,11 +152,9 @@ lemma planeWave_time_deriv_time_deriv {d f₀ c x} {s : Direction d}
   simp only [fderiv_eq_smul_deriv, one_smul, Pi.smul_apply, PiLp.smul_apply, smul_eq_mul, neg_mul,
     mul_neg, neg_neg]
   ring_nf
-  suffices h : (fun x => _root_.deriv (fun x => _root_.deriv f₀ x) x) =
-      fun x => iteratedDeriv 2 f₀ x by rw [h]
-  funext x
-  erw [iteratedDeriv_succ]
-  simp only [iteratedDeriv_one]
+  have h_iter : (fun x => _root_.deriv (fun x => _root_.deriv f₀ x) x) = fun x => iteratedDeriv 2 f₀ x := by
+    ext x; rw [iteratedDeriv_succ', iteratedDeriv_one]
+  rw [h_iter]
 
 /-!
 
@@ -237,11 +235,9 @@ lemma planeWave_apply_space_deriv_space_deriv {d f₀ c} {s : Direction d}
   rw [← Space.deriv_eq_fderiv_basis, planeWave_apply_space_deriv]
   simp only [fderiv_eq_smul_deriv, one_smul, Pi.smul_apply, smul_eq_mul]
   ring_nf
-  suffices h : (fun x => _root_.deriv (fun x => _root_.deriv f₀ x) x) =
-      fun x => iteratedDeriv 2 f₀ x by rw [h]
-  ext x i
-  erw [iteratedDeriv_succ']
-  simp only [iteratedDeriv_one]
+  have h_iter : (fun x => _root_.deriv (fun x => _root_.deriv f₀ x) x) = fun x => iteratedDeriv 2 f₀ x := by
+    ext x; rw [iteratedDeriv_succ', iteratedDeriv_one]
+  rw [h_iter]
   repeat fun_prop
 
 /-!

--- a/Physlib/Electromagnetism/Dynamics/Hamiltonian.lean
+++ b/Physlib/Electromagnetism/Dynamics/Hamiltonian.lean
@@ -224,9 +224,7 @@ lemma hamiltonian_eq_electricField_scalarPotential {d} {𝓕 : FreeSpace}
         - lagrangian 𝓕 A J x := by
   rw [hamiltonian_eq_electricField_vectorPotential A hA J x]
   congr 1
-  conv_lhs =>
-    enter [2, 2, i]
-    rw [time_deriv_vectorPotential_eq_electricField]
+  conv_lhs => rw [time_deriv_vectorPotential_eq_electricField A (x.time 𝓕.c) x.space]
   simp [mul_sub, Finset.sum_sub_distrib]
   rw [EuclideanSpace.norm_sq_eq]
   ring_nf

--- a/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
@@ -189,32 +189,24 @@ lemma isExtrema_lorentzGroup_apply_iff {𝓕 : FreeSpace}
     simp only [one_div, map_smul, actionT_smul,
       contrT_equivariant, map_neg, permT_equivariant]
     rw [smul_comm, ← Tensor.actionT_neg, ← Tensor.actionT_add]
-  apply Iff.intro
-  · intro h
-    rw [isExtrema_iff_tensors A hA J hJ]
-    intro x
+  rw [isExtrema_iff_tensors A hA J hJ]
+  constructor
+  · intro h x
     apply MulAction.injective Λ
     simp only [one_div, map_smul, map_neg,
       _root_.smul_add, actionT_smul, _root_.smul_neg, _root_.smul_zero]
     simpa using h (Λ • x)
   · intro h x
-    rw [isExtrema_iff_tensors A hA J hJ] at h
     specialize h (Λ⁻¹ • x)
     simp at h
     rw [h]
     simp
   · change ContDiff ℝ ∞ (actionCLM Λ ∘ A ∘ actionCLM Λ⁻¹)
-    apply ContDiff.comp
-    · exact ContinuousLinearMap.contDiff (actionCLM Λ)
-    · apply ContDiff.comp
-      · exact hA
-      · exact ContinuousLinearMap.contDiff (actionCLM Λ⁻¹)
+    exact (ContinuousLinearMap.contDiff (actionCLM Λ)).comp
+      (hA.comp (ContinuousLinearMap.contDiff (actionCLM Λ⁻¹)))
   · change ContDiff ℝ ∞ (actionCLM Λ ∘ J ∘ actionCLM Λ⁻¹)
-    apply ContDiff.comp
-    · exact ContinuousLinearMap.contDiff (actionCLM Λ)
-    · apply ContDiff.comp
-      · exact hJ
-      · exact ContinuousLinearMap.contDiff (actionCLM Λ⁻¹)
+    exact (ContinuousLinearMap.contDiff (actionCLM Λ)).comp
+      (hJ.comp (ContinuousLinearMap.contDiff (actionCLM Λ⁻¹)))
 
 /-!
 

--- a/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
@@ -371,7 +371,7 @@ lemma time_deriv_time_deriv_electricField_of_isExtrema {A : ElectromagneticPoten
       𝓕.c ^ 2 / 𝓕.ε₀ * ∂[i] (J.chargeDensity 𝓕.c t ·) x -
       𝓕.c ^ 2 * 𝓕.μ₀ * ∂ₜ (J.currentDensity 𝓕.c · x i) t := by
   have hEs : ∀ j, ContDiff ℝ 2 (fun y => A.electricField 𝓕.c t y j) :=
-    fun j => electricField_apply_contDiff_space (i := j) (hA.of_le (ENat.LEInfty.out)) t
+    fun j => electricField_apply_contDiff_space (i := j) (hA.of_le (by decide)) t
   have hEd : ∀ j k, Differentiable ℝ (∂[k] (fun y => A.electricField 𝓕.c t y j)) :=
     fun j k => Space.deriv_differentiable (hEs j) k
   have hBt : ∀ j, Differentiable ℝ

--- a/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
@@ -371,7 +371,7 @@ lemma time_deriv_time_deriv_electricField_of_isExtrema {A : ElectromagneticPoten
       𝓕.c ^ 2 / 𝓕.ε₀ * ∂[i] (J.chargeDensity 𝓕.c t ·) x -
       𝓕.c ^ 2 * 𝓕.μ₀ * ∂ₜ (J.currentDensity 𝓕.c · x i) t := by
   have hEs : ∀ j, ContDiff ℝ 2 (fun y => A.electricField 𝓕.c t y j) :=
-    fun j => electricField_apply_contDiff_space (i := j) (hA.of_le (right_eq_inf.mp rfl)) t
+    fun j => electricField_apply_contDiff_space (i := j) (hA.of_le (ENat.LEInfty.out)) t
   have hEd : ∀ j k, Differentiable ℝ (∂[k] (fun y => A.electricField 𝓕.c t y j)) :=
     fun j k => Space.deriv_differentiable (hEs j) k
   have hBt : ∀ j, Differentiable ℝ

--- a/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
@@ -250,14 +250,14 @@ lemma isExtrema_iff_gauss_ampere_magneticFieldMatrix {d} {𝓕 : FreeSpace}
       field_simp
       simp only [FreeSpace.c_sq, one_div, mul_inv_rev, mul_zero]
       field_simp
-      ring
+      ring_nf
     · intro h x
       specialize h (x.time 𝓕.c) x.space
       linear_combination (norm := simp) (𝓕.μ₀⁻¹ * 𝓕.c⁻¹) * h
       field_simp
       simp only [FreeSpace.c_sq, one_div, mul_inv_rev, mul_zero]
       field_simp
-      ring
+      ring_nf
   · apply Iff.intro
     · intro h t x i
       specialize h ((toTimeAndSpace 𝓕.c).symm (t, x)) i

--- a/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
@@ -134,24 +134,20 @@ lemma isExtrema_iff_tensors {𝓕 : FreeSpace}
   · intro h
     simp only [IsExtrema] at h
     intro x
-    have h1 : ((Tensorial.toTensor (M := Lorentz.Vector d)).symm
-        (permT id (IsReindexing.auto) {((1/ 𝓕.μ₀ : ℝ) • tensorDeriv A.toFieldStrength x | κ κ ν') +
-        - (J x | ν')}ᵀ)) = 0 := by
-      funext ν
-      have h2 : gradLagrangian 𝓕 A J x ν = 0 := by simp [h]
-      rw [gradLagrangian_eq_tensor A hA J hJ] at h2
-      simp only [one_div, map_smul, map_neg, map_add,
-        permT_permT, CompTriple.comp_eq, apply_add, apply_smul, Lorentz.Vector.neg_apply,
-        mul_eq_zero] at h2
+    let V := {((1/ 𝓕.μ₀ : ℝ) • tensorDeriv A.toFieldStrength x | κ κ ν') +
+      - (J x | ν')}ᵀ
+    have h_tensor_eq : (Tensorial.toTensor (M := Lorentz.Vector d)).symm
+        (permT id (IsReindexing.auto) V) = 0 := by
+      ext ν
+      have hgrad := congr_fun (congr_fun h x) ν
+      rw [gradLagrangian_eq_tensor A hA J hJ x ν] at hgrad
       have hn : η ν ν ≠ 0 := η_diag_ne_zero
-      simp_all only [false_or, ne_eq, one_div, map_smul,
-        map_neg, map_add, permT_permT, CompTriple.comp_eq, apply_add, apply_smul,
-        Lorentz.Vector.neg_apply, Lorentz.Vector.zero_apply]
-    generalize {((1/ 𝓕.μ₀ : ℝ) • tensorDeriv A.toFieldStrength x | κ κ ν') +
-        - (J x | ν')}ᵀ = V at *
-    simp only [EmbeddingLike.map_eq_zero_iff] at h1
-    rw [permT_eq_zero_iff] at h1
-    exact h1
+      apply mul_eq_zero.mp at hgrad
+      rcases hgrad with hη | hX
+      · exact (hn hη).elim
+      · exact hX
+    rw [EmbeddingLike.map_eq_zero_iff] at h_tensor_eq
+    rwa [permT_eq_zero_iff] at h_tensor_eq
   · intro h
     simp only [IsExtrema]
     funext x

--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -795,9 +795,6 @@ lemma gradKineticTerm_eq_electric_magnetic {𝓕 : FreeSpace} (A : Electromagnet
     ∑ i, (𝓕.μ₀⁻¹ * (1 / 𝓕.c ^ 2 * ∂ₜ (fun t => A.electricField 𝓕.c t x.space) (x.time 𝓕.c) i-
       ∑ j, Space.deriv j (A.magneticFieldMatrix 𝓕.c (x.time 𝓕.c) · (j, i)) x.space)) •
       Lorentz.Vector.basis (Sum.inr i) := by
-  have hdiff (μ ν) : Differentiable ℝ fun x => (A.fieldStrengthMatrix x) (μ, ν) := by
-    conv => enter [2, x]; rw [toFieldStrength_basis_repr_apply_eq_single]
-    fun_prop
   rw [gradKineticTerm_eq_fieldStrength A x ha]
   rw [Fintype.sum_sum_type, Fin.sum_univ_one]
   congr 1
@@ -852,13 +849,13 @@ lemma gradKineticTerm_add {d} {𝓕 : FreeSpace} (A1 A2 : ElectromagneticPotenti
   rw [SpaceTime.deriv_eq, SpaceTime.deriv_eq, SpaceTime.deriv_eq]
   conv_lhs =>
     enter [1, 2, x]
-    rw [fieldStrengthMatrix_add _ _ _ (hA1.differentiable (by simp))
+    rw [fieldStrengthMatrix_add A1 A2 x (hA1.differentiable (by simp))
       (hA2.differentiable (by simp))]
-    simp [Finsupp.coe_add, Pi.add_apply]
+    simp
   rw [fderiv_fun_add]
   rfl
-  · apply fieldStrengthMatrix_differentiable <| hA1.of_le (ENat.LEInfty.out)
-  · apply fieldStrengthMatrix_differentiable <| hA2.of_le (ENat.LEInfty.out)
+  · exact (fieldStrengthMatrix_differentiable (hA1.of_le (ENat.LEInfty.out))) x
+  · exact (fieldStrengthMatrix_differentiable (hA2.of_le (ENat.LEInfty.out))) x
   · exact hA2
   · exact hA1
   · exact hA1.add hA2
@@ -878,15 +875,15 @@ lemma gradKineticTerm_smul {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential 
   congr
   rw [Finset.mul_sum]
   apply Finset.sum_congr rfl (fun μ _ => ?_)
-  conv_rhs =>
-    rw [SpaceTime.deriv_eq]
-    change (c • fderiv ℝ (fun x => (A.fieldStrengthMatrix x) (μ, ν)) x) (Lorentz.Vector.basis μ)
-    rw [← fderiv_const_smul
-      (fieldStrengthMatrix_differentiable <| hA.of_le (ENat.LEInfty.out)).differentiableAt]
-    rw [← SpaceTime.deriv_eq]
-  congr
-  funext x
-  rw [fieldStrengthMatrix_smul _ _ _]
+  have h_smul : ((c • A).fieldStrengthMatrix x) (μ, ν) = c * (A.fieldStrengthMatrix x) (μ, ν) := by
+    rw [fieldStrengthMatrix_smul c A x (hA.differentiable (by simp))]
+    simp
+  have hdiff : DifferentiableAt ℝ (fun x => (A.fieldStrengthMatrix x) (μ, ν)) x :=
+    (fieldStrengthMatrix_differentiable (μν := (μ, ν)) (hA.of_le (ENat.LEInfty.out))).differentiableAt x
+  have h_smul_fun : (fun x => ((c • A).fieldStrengthMatrix x) (μ, ν)) =
+      (fun x => c * (A.fieldStrengthMatrix x) (μ, ν)) := by
+    funext x; exact h_smul x
+  rw [SpaceTime.deriv_eq, SpaceTime.deriv_eq, h_smul_fun, fderiv_const_smul hdiff]
   rfl
   · exact hA.differentiable (by simp)
   · exact hA

--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -189,16 +189,14 @@ lemma kineticTerm_eq_sum_fieldStrengthMatrix_sq {d} {𝓕 : FreeSpace}
     · simp
       ring
     · intro b _ hb
-      nth_rewrite 2 [minkowskiMatrix.off_diag_zero]
-      simp only [mul_zero, zero_mul]
-      exact id (Ne.symm hb)
+      rw [minkowskiMatrix.off_diag_zero (Ne.symm hb)]
+      simp
     · simp
   · intro b _ hb
     rw [Finset.sum_eq_zero]
     intro ν' _
-    rw [minkowskiMatrix.off_diag_zero]
-    simp only [zero_mul]
-    exact id (Ne.symm hb)
+    rw [minkowskiMatrix.off_diag_zero (Ne.symm hb)]
+    simp
   · simp
 
 lemma kineticTerm_eq_sum_potential {d} {𝓕 : FreeSpace}

--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -381,28 +381,12 @@ lemma kineticTerm_eq_electricMatrix_magneticFieldMatrix {𝓕 : FreeSpace}
 
 lemma kineticTerm_const {d} {𝓕 : FreeSpace} (A₀ : Lorentz.Vector d) :
     kineticTerm 𝓕 ⟨fun _ : SpaceTime d => A₀⟩ = 0 := by
-  funext x
-  rw [kineticTerm_eq_sum_potential]
-  conv_lhs =>
-    enter [2, 2, μ, 2, ν]
-    repeat rw [SpaceTime.deriv_eq]
-    simp
-  simp
+  ext x; simp [kineticTerm_eq_sum_potential, SpaceTime.deriv_eq]
 
 lemma kineticTerm_add_const {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential d)
     (A₀ : Lorentz.Vector d) :
     kineticTerm 𝓕 ⟨fun x => A x + A₀⟩ = kineticTerm 𝓕 A := by
-  funext x
-  rw [kineticTerm_eq_sum_potential, kineticTerm_eq_sum_potential]
-  congr
-  funext μ
-  congr
-  funext ν
-  congr
-  all_goals
-  · rw [SpaceTime.deriv_eq]
-    simp
-    rfl
+  ext x; simp [kineticTerm_eq_sum_potential, SpaceTime.deriv_eq]
 
 /-!
 

--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -875,15 +875,15 @@ lemma gradKineticTerm_smul {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential 
   congr
   rw [Finset.mul_sum]
   apply Finset.sum_congr rfl (fun μ _ => ?_)
-  have h_smul : ((c • A).fieldStrengthMatrix x) (μ, ν) = c * (A.fieldStrengthMatrix x) (μ, ν) := by
-    rw [fieldStrengthMatrix_smul c A x (hA.differentiable (by simp))]
-    simp
-  have hdiff : DifferentiableAt ℝ (fun x => (A.fieldStrengthMatrix x) (μ, ν)) x :=
-    (fieldStrengthMatrix_differentiable (μν := (μ, ν)) (hA.of_le (ENat.LEInfty.out))).differentiableAt x
-  have h_smul_fun : (fun x => ((c • A).fieldStrengthMatrix x) (μ, ν)) =
-      (fun x => c * (A.fieldStrengthMatrix x) (μ, ν)) := by
-    funext x; exact h_smul x
-  rw [SpaceTime.deriv_eq, SpaceTime.deriv_eq, h_smul_fun, fderiv_const_smul hdiff]
+  conv_rhs =>
+    rw [SpaceTime.deriv_eq]
+    change (c • fderiv ℝ (fun x => (A.fieldStrengthMatrix x) (μ, ν)) x) (Lorentz.Vector.basis μ)
+    rw [← fderiv_const_smul
+      (fieldStrengthMatrix_differentiable <| hA.of_le (ENat.LEInfty.out)).differentiableAt]
+    rw [← SpaceTime.deriv_eq]
+  congr
+  funext x
+  rw [fieldStrengthMatrix_smul _ _ _]
   rfl
   · exact hA.differentiable (by simp)
   · exact hA

--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -472,12 +472,7 @@ lemma kineticTerm_add_time_mul_const {d} {𝓕 : FreeSpace} (A : Electromagnetic
       funext μ
       congr
       funext ν
-      congr
-      all_goals
-      · simp
-        split_ifs
-        simp
-        rfl
+      split_ifs <;> simp
     _ = -1 / (2 * 𝓕.μ₀) *
       ∑ μ, ∑ ν, ((η μ μ * η ν ν * (∂_ μ A x ν) ^ 2 - ∂_ μ A x ν * ∂_ ν A x μ) +
           (if μ = Sum.inl 0 then c ν else 0) * (2 * η μ μ * η ν ν * ∂_ μ A x ν +

--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -121,9 +121,7 @@ lemma kineticTerm_eq_sum {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential d)
       (Lorentz.CoVector.basis.tensorProduct Lorentz.Vector.basis).repr (A.toFieldStrength x) (μ, ν)
       * (Lorentz.CoVector.basis.tensorProduct Lorentz.Vector.basis).repr
         (A.toFieldStrength x) (μ', ν') := by
-  rw [kineticTerm]
-  rw [toField_eq_repr]
-  rw [contrT_basis_repr_apply_eq_fin]
+  rw [kineticTerm, toField_eq_repr, contrT_basis_repr_apply_eq_fin]
   conv_lhs =>
     enter [2, 2, μ]
     rw [contrT_basis_repr_apply_eq_fin]

--- a/Physlib/Electromagnetism/Dynamics/Lagrangian.lean
+++ b/Physlib/Electromagnetism/Dynamics/Lagrangian.lean
@@ -122,13 +122,9 @@ lemma freeCurrentPotential_hasVarGradientAt (A : ElectromagneticPotential d)
   have h2' : ContDiff ℝ ∞ fun x => η μ μ * J x μ :=
     ContDiff.mul (by fun_prop) ((Lorentz.Vector.contDiff_apply _).mpr hJ μ)
   have h2 := HasVarAdjDerivAt.fun_mul h2' _ _ A h1
-  have h3' : (fun (φ : SpaceTime d → Lorentz.Vector d) x => η μ μ * J x μ * φ x μ) =
-    (fun (φ : SpaceTime d → Lorentz.Vector d) x => η μ μ * φ x μ * J x μ) := by
-    funext φ x
-    ring
-  rw [h3'] at h2
-  apply HasVarGradientAt.intro _ h2
-  simp
+  apply HasVarGradientAt.intro _ (by
+    simpa [mul_comm, mul_left_comm, mul_assoc] using h2)
+  ext x; simp [mul_comm]
 
 /-!
 

--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -281,7 +281,7 @@ noncomputable instance {d} :
     simp
   smul_add Λ A B := by
     ext x μ
-    simp [Lorentz.Vector.smul_add]
+    simp
 
 /-!
 

--- a/Physlib/Mathematics/Calculus/Wirtinger/Basic.lean
+++ b/Physlib/Mathematics/Calculus/Wirtinger/Basic.lean
@@ -392,18 +392,14 @@ lemma realLinear_apply_eq_wirtinger (L : ℂ →L[ℝ] ℂ) (w : ℂ) :
     L w =
       ((1 / 2 : ℂ) * (L 1 - Complex.I * L Complex.I)) * w
         + ((1 / 2 : ℂ) * (L 1 + Complex.I * L Complex.I)) * star w := by
-  calc
-    L w = L ((w.re : ℝ) • (1 : ℂ) + (w.im : ℝ) • Complex.I) := by
-              congr 1; apply Complex.ext <;> simp
-    _ = (w.re : ℝ) • L 1 + (w.im : ℝ) • L Complex.I := by
-          rw [map_add, map_smul, map_smul]
-    _ = ((1 / 2 : ℂ) * (L 1 - Complex.I * L Complex.I)) * w
-          + ((1 / 2 : ℂ) * (L 1 + Complex.I * L Complex.I)) * star w := by
-      apply Complex.ext <;>
-        simp [Complex.add_re, Complex.add_im, Complex.sub_re, Complex.sub_im,
-          Complex.mul_re, Complex.mul_im, Complex.conj_re, Complex.conj_im,
-          Complex.I_re, Complex.I_im] <;>
-        ring
+  have h : (w.re : ℝ) • (1 : ℂ) + (w.im : ℝ) • Complex.I = w := by
+    simpa using (Complex.re_add_im w).symm
+  rw [← h, map_add, map_smul, map_smul]
+  apply Complex.ext <;>
+    simp [Complex.add_re, Complex.add_im, Complex.sub_re, Complex.sub_im,
+      Complex.mul_re, Complex.mul_im, Complex.conj_re, Complex.conj_im,
+      Complex.I_re, Complex.I_im] <;>
+    ring
 
 /-- The two-term Wirtinger chain rule for `dWirtingerDir`, outer `g : ℂ → ℂ` and inner
 `f : V → ℂ`:

--- a/Physlib/Mathematics/Calculus/Wirtinger/Basic.lean
+++ b/Physlib/Mathematics/Calculus/Wirtinger/Basic.lean
@@ -393,7 +393,7 @@ lemma realLinear_apply_eq_wirtinger (L : ℂ →L[ℝ] ℂ) (w : ℂ) :
       ((1 / 2 : ℂ) * (L 1 - Complex.I * L Complex.I)) * w
         + ((1 / 2 : ℂ) * (L 1 + Complex.I * L Complex.I)) * star w := by
   have h : (w.re : ℝ) • (1 : ℂ) + (w.im : ℝ) • Complex.I = w := by
-    simpa using (Complex.re_add_im w).symm
+    simp [Complex.re_add_im w]
   rw [← h, map_add, map_smul, map_smul]
   apply Complex.ext <;>
     simp [Complex.add_re, Complex.add_im, Complex.sub_re, Complex.sub_im,

--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -365,7 +365,7 @@ lemma physHermite_orthogonal_lt {n m : ℕ} (hnm : n < m) :
 
 theorem physHermite_orthogonal {n m : ℕ} (hnm : n ≠ m) :
     ∫ x : ℝ, (physHermite n x * physHermite m x) * Real.exp (- x ^ 2) = 0 := by
-  rcases hnm.lt_or_lt with h | h
+  rcases Nat.ne_iff_lt_or_gt.mp hnm with h | h
   · exact physHermite_orthogonal_lt h
   · conv_lhs =>
       enter [2, x, 1]
@@ -378,7 +378,7 @@ lemma physHermite_orthogonal_cons {n m : ℕ} (hnm : n ≠ m) (c : ℝ) :
   trans ∫ x : ℝ, (fun x => (physHermite n x * physHermite m x) * Real.exp (- x^2)) (c * x)
   · congr
     funext x
-    rw [neg_mul, mul_pow]
+    simp [mul_pow, neg_mul]
   rw [MeasureTheory.Measure.integral_comp_mul_left
     (fun x => physHermite n x * physHermite m x * Real.exp (-x ^ 2)) c]
   simp [physHermite_orthogonal hnm]
@@ -403,7 +403,7 @@ lemma physHermite_norm_cons (n : ℕ) (c : ℝ) :
   trans ∫ x : ℝ, (fun x => (physHermite n x * physHermite n x) * Real.exp (- x^2)) (c * x)
   · congr
     funext x
-    rw [neg_mul, mul_pow]
+    simp [mul_pow, neg_mul]
   rw [MeasureTheory.Measure.integral_comp_mul_left
     (fun x => physHermite n x * physHermite n x * Real.exp (-x ^ 2)) c]
   rw [physHermite_norm]

--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -97,9 +97,8 @@ lemma coeff_physHermite_self_succ (n : ℕ) : coeff (physHermite n) n = 2 ^ n :=
   induction n with
   | zero => exact coeff_C
   | succ n ih =>
-    rw [coeff_physHermite_succ_succ, ih, coeff_physHermite_of_lt, mul_zero, sub_zero]
-    · rw [← Int.pow_succ']
-    · simp
+    rw [coeff_physHermite_succ_succ, ih, coeff_physHermite_of_lt (by omega), mul_zero, sub_zero,
+      ← Int.pow_succ']
 
 @[simp]
 lemma degree_physHermite (n : ℕ) : degree (physHermite n) = n := by
@@ -115,8 +114,7 @@ lemma natDegree_physHermite {n : ℕ} : (physHermite n).natDegree = n :=
 
 lemma iterate_derivative_physHermite_of_gt {n m : ℕ} (h : n < m) :
     derivative^[m] (physHermite n) = 0 := by
-  refine iterate_derivative_eq_zero ?_
-  simpa using h
+  exact iterate_derivative_eq_zero (by simpa using h)
 
 open Nat
 
@@ -140,8 +138,7 @@ lemma physHermite_leadingCoeff {n : ℕ} : (physHermite n).leadingCoeff = 2 ^ n 
 
 @[simp]
 lemma physHermite_ne_zero {n : ℕ} : physHermite n ≠ 0 := by
-  refine leadingCoeff_ne_zero.mp ?_
-  simp
+  exact leadingCoeff_ne_zero.mp (by simp)
 
 noncomputable instance : CoeFun (Polynomial ℤ) (fun _ ↦ ℝ → ℝ)where
   coe p := fun x => p.aeval x
@@ -283,9 +280,8 @@ lemma guassian_integrable_polynomial_cons {b c : ℝ} (hb : 0 < b) (P : Polynomi
     simp only [neg_mul, mul_assoc, Real.rpow_natCast, Pi.smul_apply, smul_eq_mul]
     ring
   refine h2 ▸ MeasureTheory.Integrable.smul (c ^ i * P.coeff i : ℝ) ?_
-  apply integrable_rpow_mul_exp_neg_mul_sq (s := i)
-  · exact hb
-  · exact lt_of_le_of_lt' (Nat.cast_nonneg' i) neg_one_lt_zero
+  exact integrable_rpow_mul_exp_neg_mul_sq hb
+    (lt_of_le_of_lt' (Nat.cast_nonneg' i) neg_one_lt_zero)
 
 @[fun_prop]
 lemma guassian_integrable_polynomial {b : ℝ} (hb : 0 < b) (P : Polynomial ℤ) :
@@ -369,13 +365,12 @@ lemma physHermite_orthogonal_lt {n m : ℕ} (hnm : n < m) :
 
 theorem physHermite_orthogonal {n m : ℕ} (hnm : n ≠ m) :
     ∫ x : ℝ, (physHermite n x * physHermite m x) * Real.exp (- x ^ 2) = 0 := by
-  by_cases hnm' : n < m
-  · exact physHermite_orthogonal_lt hnm'
-  · have hmn : m < n := by omega
-    conv_lhs =>
+  rcases hnm.lt_or_lt with h | h
+  · exact physHermite_orthogonal_lt h
+  · conv_lhs =>
       enter [2, x, 1]
       rw [mul_comm]
-    rw [physHermite_orthogonal_lt hmn]
+    rw [physHermite_orthogonal_lt h]
 
 lemma physHermite_orthogonal_cons {n m : ℕ} (hnm : n ≠ m) (c : ℝ) :
     ∫ x : ℝ, (physHermite n (c * x) * physHermite m (c * x)) *
@@ -383,13 +378,10 @@ lemma physHermite_orthogonal_cons {n m : ℕ} (hnm : n ≠ m) (c : ℝ) :
   trans ∫ x : ℝ, (fun x => (physHermite n x * physHermite m x) * Real.exp (- x^2)) (c * x)
   · congr
     funext x
-    simp only [neg_mul, mul_eq_mul_left_iff, Real.exp_eq_exp, neg_inj, _root_.mul_eq_zero]
-    left
-    exact Eq.symm (mul_pow c x 2)
+    rw [neg_mul, mul_pow]
   rw [MeasureTheory.Measure.integral_comp_mul_left
     (fun x => physHermite n x * physHermite m x * Real.exp (-x ^ 2)) c]
-  rw [physHermite_orthogonal hnm]
-  simp
+  simp [physHermite_orthogonal hnm]
 
 theorem physHermite_norm (n : ℕ) :
     ∫ x : ℝ, (physHermite n x * physHermite n x) * Real.exp (- x ^ 2) =
@@ -411,9 +403,7 @@ lemma physHermite_norm_cons (n : ℕ) (c : ℝ) :
   trans ∫ x : ℝ, (fun x => (physHermite n x * physHermite n x) * Real.exp (- x^2)) (c * x)
   · congr
     funext x
-    simp only [neg_mul, mul_eq_mul_left_iff, Real.exp_eq_exp, neg_inj, _root_.mul_eq_zero, or_self]
-    left
-    exact Eq.symm (mul_pow c x 2)
+    rw [neg_mul, mul_pow]
   rw [MeasureTheory.Measure.integral_comp_mul_left
     (fun x => physHermite n x * physHermite n x * Real.exp (-x ^ 2)) c]
   rw [physHermite_norm]

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/AllowsTerm.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/AllowsTerm.lean
@@ -258,24 +258,14 @@ less than or equal to the degree of the potential term `T`.
 
 lemma allowsTermForm_card_le_degree {a b c : 𝓩} {T : PotentialTerm} :
     (allowsTermForm a b c T).card ≤ T.degree := by
-  cases T
+  cases T <;> simp [allowsTermForm, PotentialTerm.toFieldLabel, card, PotentialTerm.degree]
   all_goals
-    simp [allowsTermForm, PotentialTerm.toFieldLabel, card, PotentialTerm.degree]
-  case' Λ =>
-    have h1 : Finset.card {a, b} ≤ 2 := Finset.card_le_two
-    omega
-  case' W3 =>
-    have h1 : Finset.card {b, -b - 2 • a} ≤ 2 := Finset.card_le_two
-    omega
-  case' K1 =>
-    have h1 : Finset.card {b, -a - b} ≤ 2 := Finset.card_le_two
-    omega
-  case' topYukawa =>
-    have h1 : Finset.card {b, -a - b} ≤ 2 := Finset.card_le_two
-    omega
-  all_goals
-    have h1 : Finset.card {a, b, c} ≤ 3 := Finset.card_le_three
-    omega
+    first
+    | exact Finset.card_le_two
+    | exact Finset.card_le_three
+    | have h := Finset.card_le_two (a := b) (b := -b - 2 • a); omega
+    | have h := Finset.card_le_two (a := b) (b := -a - b); omega
+    | have h := Finset.card_le_three (a := a) (b := b) (c := c); omega
 
 /-!
 

--- a/Physlib/QFT/PerturbationTheory/FieldSpecification/TimeOrder.lean
+++ b/Physlib/QFT/PerturbationTheory/FieldSpecification/TimeOrder.lean
@@ -54,14 +54,14 @@ instance : Std.Total 𝓕.timeOrderRel where
   total a b := by
     cases a <;> cases b <;>
       simp only [or_self, or_false, or_true, timeOrderRel, Fin.isValue]
-    exact LinearOrder.le_total _ _
+    exact le_total _ _
 
 /-- Time ordering is transitive. -/
 instance : IsTrans 𝓕.FieldOp 𝓕.timeOrderRel where
   trans a b c := by
     cases a <;> cases b <;> cases c <;>
       simp only [timeOrderRel, Fin.isValue, implies_true, imp_self, IsEmpty.forall_iff]
-    exact fun h1 h2 => Preorder.le_trans _ _ _ h2 h1
+    exact fun h1 h2 => le_trans h2 h1
 
 noncomputable section
 
@@ -105,8 +105,7 @@ lemma eraseMaxTimeField_length (φ : 𝓕.FieldOp) (φs : List 𝓕.FieldOp) :
 
 lemma maxTimeFieldPos_lt_eraseMaxTimeField_length_succ (φ : 𝓕.FieldOp) (φs : List 𝓕.FieldOp) :
     maxTimeFieldPos φ φs < (eraseMaxTimeField φ φs).length.succ := by
-  simp only [eraseMaxTimeField_length, Nat.succ_eq_add_one]
-  exact maxTimeFieldPos_lt_length φ φs
+  simpa using maxTimeFieldPos_lt_length φ φs
 
 /-- Given a list `φ :: φs` of states, the position of the left-most state of maximum
   time as an element of `Fin (eraseMaxTimeField φ φs).length.succ`.
@@ -120,13 +119,13 @@ def maxTimeFieldPosFin (φ : 𝓕.FieldOp) (φs : List 𝓕.FieldOp) :
 lemma lt_maxTimeFieldPosFin_not_timeOrder (φ : 𝓕.FieldOp) (φs : List 𝓕.FieldOp)
     (i : Fin (eraseMaxTimeField φ φs).length)
     (hi : (maxTimeFieldPosFin φ φs).succAbove i < maxTimeFieldPosFin φ φs) :
-    ¬ timeOrderRel ((eraseMaxTimeField φ φs)[i.val]) (maxTimeField φ φs) := by
-  exact insertionSortMin_lt_mem_insertionSortDropMinPos_of_lt timeOrderRel φ φs i hi
+    ¬ timeOrderRel ((eraseMaxTimeField φ φs)[i.val]) (maxTimeField φ φs) :=
+  insertionSortMin_lt_mem_insertionSortDropMinPos_of_lt timeOrderRel φ φs i hi
 
 lemma timeOrder_maxTimeField (φ : 𝓕.FieldOp) (φs : List 𝓕.FieldOp)
     (i : Fin (eraseMaxTimeField φ φs).length) :
-    timeOrderRel (maxTimeField φ φs) ((eraseMaxTimeField φ φs)[i.val]) := by
-  exact insertionSortMin_lt_mem_insertionSortDropMinPos timeOrderRel φ φs _
+    timeOrderRel (maxTimeField φ φs) ((eraseMaxTimeField φ φs)[i.val]) :=
+  insertionSortMin_lt_mem_insertionSortDropMinPos timeOrderRel φ φs _
 
 /-- The sign associated with putting a list of states into time order (with
   the state of greatest time to the left).
@@ -136,20 +135,15 @@ def timeOrderSign (φs : List 𝓕.FieldOp) : ℂ :=
 
 @[simp]
 lemma timeOrderSign_nil : timeOrderSign (𝓕 := 𝓕) [] = 1 := by
-  simp only [timeOrderSign]
-  rfl
+  simp [timeOrderSign, Wick.koszulSign]
 
 lemma timeOrderSign_pair_ordered {φ ψ : 𝓕.FieldOp} (h : timeOrderRel φ ψ) :
     timeOrderSign [φ, ψ] = 1 := by
-  simp only [timeOrderSign, Wick.koszulSign, Wick.koszulSignInsert, mul_one, ite_eq_left_iff,
-    ite_eq_right_iff, and_imp]
-  exact fun h' => False.elim (h' h)
+  simp [timeOrderSign, Wick.koszulSign, Wick.koszulSignInsert, h]
 
 lemma timeOrderSign_pair_not_ordered {φ ψ : 𝓕.FieldOp} (h : ¬ timeOrderRel φ ψ) :
     timeOrderSign [φ, ψ] = 𝓢(𝓕 |>ₛ φ, 𝓕 |>ₛ ψ) := by
-  simp only [timeOrderSign, Wick.koszulSign, Wick.koszulSignInsert, mul_one]
-  rw [if_neg h]
-  simp [FieldStatistic.exchangeSign_eq_if]
+  simp [timeOrderSign, Wick.koszulSign, Wick.koszulSignInsert, h, FieldStatistic.exchangeSign_eq_if]
 
 lemma timerOrderSign_of_eraseMaxTimeField (φ : 𝓕.FieldOp) (φs : List 𝓕.FieldOp) :
     timeOrderSign (eraseMaxTimeField φ φs) = timeOrderSign (φ :: φs) *
@@ -167,23 +161,19 @@ def timeOrderList (φs : List 𝓕.FieldOp) : List 𝓕.FieldOp :=
 
 lemma timeOrderList_pair_ordered {φ ψ : 𝓕.FieldOp} (h : timeOrderRel φ ψ) :
     timeOrderList [φ, ψ] = [φ, ψ] := by
-  simp only [timeOrderList, List.insertionSort_cons, List.insertionSort_nil, List.orderedInsert,
-    ite_eq_left_iff, List.cons.injEq, and_true]
-  exact fun h' => False.elim (h' h)
+  simp [timeOrderList, List.insertionSort, h]
 
 lemma timeOrderList_pair_not_ordered {φ ψ : 𝓕.FieldOp} (h : ¬ timeOrderRel φ ψ) :
     timeOrderList [φ, ψ] = [ψ, φ] := by
-  simp only [timeOrderList, List.insertionSort_cons, List.insertionSort_nil, List.orderedInsert,
-    ite_eq_right_iff, List.cons.injEq, and_true]
-  exact fun h' => False.elim (h h')
+  simp [timeOrderList, List.insertionSort, List.orderedInsert, h]
 
 @[simp]
 lemma timeOrderList_nil : timeOrderList (𝓕 := 𝓕) [] = [] := by
   simp [timeOrderList]
 
 lemma timeOrderList_eq_maxTimeField_timeOrderList (φ : 𝓕.FieldOp) (φs : List 𝓕.FieldOp) :
-    timeOrderList (φ :: φs) = maxTimeField φ φs :: timeOrderList (eraseMaxTimeField φ φs) := by
-  exact insertionSort_eq_insertionSortMin_cons timeOrderRel φ φs
+    timeOrderList (φ :: φs) = maxTimeField φ φs :: timeOrderList (eraseMaxTimeField φ φs) :=
+  insertionSort_eq_insertionSortMin_cons timeOrderRel φ φs
 
 /-!
 
@@ -226,8 +216,8 @@ instance : IsTrans 𝓕.CrAnFieldOp 𝓕.crAnTimeOrderRel where
   trans a b c := IsTrans.trans (r := 𝓕.timeOrderRel) a.1 b.1 c.1
 
 @[simp]
-lemma crAnTimeOrderRel_refl (φ : 𝓕.CrAnFieldOp) : crAnTimeOrderRel φ φ := by
-  exact (Std.Total.to_refl (r := 𝓕.crAnTimeOrderRel)).refl φ
+lemma crAnTimeOrderRel_refl (φ : 𝓕.CrAnFieldOp) : crAnTimeOrderRel φ φ :=
+  (Std.Total.to_refl (r := 𝓕.crAnTimeOrderRel)).refl φ
 
 /-- For a field specification `𝓕`, and a list `φs` of `𝓕.CrAnFieldOp`,
   `𝓕.crAnTimeOrderSign φs` is the sign corresponding to the number of `ferimionic`-`fermionic`
@@ -238,25 +228,21 @@ def crAnTimeOrderSign (φs : List 𝓕.CrAnFieldOp) : ℂ :=
 
 @[simp]
 lemma crAnTimeOrderSign_nil : crAnTimeOrderSign (𝓕 := 𝓕) [] = 1 := by
-  simp only [crAnTimeOrderSign]
-  rfl
+  simp [crAnTimeOrderSign, Wick.koszulSign]
 
 lemma crAnTimeOrderSign_pair_ordered {φ ψ : 𝓕.CrAnFieldOp} (h : crAnTimeOrderRel φ ψ) :
     crAnTimeOrderSign [φ, ψ] = 1 := by
-  simp only [crAnTimeOrderSign, Wick.koszulSign, Wick.koszulSignInsert, mul_one, ite_eq_left_iff,
-    ite_eq_right_iff, and_imp]
-  exact fun h' => False.elim (h' h)
+  simp [crAnTimeOrderSign, Wick.koszulSign, Wick.koszulSignInsert, h]
 
 lemma crAnTimeOrderSign_pair_not_ordered {φ ψ : 𝓕.CrAnFieldOp} (h : ¬ crAnTimeOrderRel φ ψ) :
     crAnTimeOrderSign [φ, ψ] = 𝓢(𝓕 |>ₛ φ, 𝓕 |>ₛ ψ) := by
-  simp only [crAnTimeOrderSign, Wick.koszulSign, Wick.koszulSignInsert, mul_one]
-  rw [if_neg h]
-  simp [FieldStatistic.exchangeSign_eq_if]
+  simp [crAnTimeOrderSign, Wick.koszulSign, Wick.koszulSignInsert, h,
+    FieldStatistic.exchangeSign_eq_if]
 
 lemma crAnTimeOrderSign_swap_eq_time {φ ψ : 𝓕.CrAnFieldOp}
     (h1 : crAnTimeOrderRel φ ψ) (h2 : crAnTimeOrderRel ψ φ) (φs φs' : List 𝓕.CrAnFieldOp) :
-    crAnTimeOrderSign (φs ++ φ :: ψ :: φs') = crAnTimeOrderSign (φs ++ ψ :: φ :: φs') := by
-  exact Wick.koszulSign_swap_eq_rel _ _ h1 h2 _ _
+    crAnTimeOrderSign (φs ++ φ :: ψ :: φs') = crAnTimeOrderSign (φs ++ ψ :: φ :: φs') :=
+  Wick.koszulSign_swap_eq_rel _ _ h1 h2 _ _
 
 /-- For a field specification `𝓕`, and a list `φs` of `𝓕.CrAnFieldOp`,
   `𝓕.crAnTimeOrderList φs` is the list `φs` time-ordered using the insertion sort algorithm. -/
@@ -269,15 +255,11 @@ lemma crAnTimeOrderList_nil : crAnTimeOrderList (𝓕 := 𝓕) [] = [] := by
 
 lemma crAnTimeOrderList_pair_ordered {φ ψ : 𝓕.CrAnFieldOp} (h : crAnTimeOrderRel φ ψ) :
     crAnTimeOrderList [φ, ψ] = [φ, ψ] := by
-  simp only [crAnTimeOrderList, List.insertionSort_cons, List.insertionSort_nil, List.orderedInsert,
-    ite_eq_left_iff, List.cons.injEq, and_true]
-  exact fun h' => False.elim (h' h)
+  simp [crAnTimeOrderList, List.insertionSort, h]
 
 lemma crAnTimeOrderList_pair_not_ordered {φ ψ : 𝓕.CrAnFieldOp} (h : ¬ crAnTimeOrderRel φ ψ) :
     crAnTimeOrderList [φ, ψ] = [ψ, φ] := by
-  simp only [crAnTimeOrderList, List.insertionSort_cons, List.insertionSort_nil, List.orderedInsert,
-    ite_eq_right_iff, List.cons.injEq, and_true]
-  exact fun h' => False.elim (h h')
+  simp [crAnTimeOrderList, List.insertionSort, List.orderedInsert, h]
 
 lemma orderedInsert_swap_eq_time {φ ψ : 𝓕.CrAnFieldOp}
     (h1 : crAnTimeOrderRel φ ψ) (h2 : crAnTimeOrderRel ψ φ) (φs : List 𝓕.CrAnFieldOp) :
@@ -499,8 +481,7 @@ lemma crAnSectionTimeOrder_bijective (φs : List 𝓕.FieldOp) :
   rw [Fintype.bijective_iff_injective_and_card]
   apply And.intro crAnSectionTimeOrder_injective
   apply CrAnSection.card_perm_eq
-  simp only [timeOrderList]
-  exact List.Perm.symm (List.perm_insertionSort timeOrderRel φs)
+  exact (List.perm_insertionSort timeOrderRel φs).symm
 
 lemma sum_crAnSections_timeOrder {φs : List 𝓕.FieldOp} [AddCommMonoid M]
     (f : CrAnSection (timeOrderList φs) → M) : ∑ s, f s = ∑ s, f (𝓕.crAnSectionTimeOrder φs s) := by
@@ -531,27 +512,20 @@ instance : Std.Total 𝓕.normTimeOrderRel where
     | Or.inl h1, Or.inl h2 => simp [h1, h2]
     | Or.inr h1, Or.inl h2 =>
       simp only [h1, h2, imp_self, and_true, true_and]
-      by_cases hn : crAnTimeOrderRel a b
-      · simp [hn]
-      · simp [hn]
+      by_cases hn : crAnTimeOrderRel a b <;> simp [hn]
     | Or.inl h1, Or.inr h2 =>
       simp only [h1, true_and, h2, imp_self, and_true]
-      by_cases hn : crAnTimeOrderRel b a
-      · simp [hn]
-      · simp [hn]
+      by_cases hn : crAnTimeOrderRel b a <;> simp [hn]
     | Or.inr h1, Or.inr h2 => simp [h1, h2]
 
 /-- Norm-Time ordering of `CrAnFieldOp` is transitive. -/
 instance : IsTrans 𝓕.CrAnFieldOp 𝓕.normTimeOrderRel where
   trans a b c := by
     intro h1 h2
-    simp_all only [normTimeOrderRel]
-    apply And.intro
-    · exact IsTrans.trans _ _ _ h1.1 h2.1
-    · intro hc
-      refine IsTrans.trans _ _ _ (h1.2 ?_) (h2.2 ?_)
-      · exact IsTrans.trans _ _ _ h2.1 hc
-      · exact IsTrans.trans _ _ _ hc h1.1
+    simp only [normTimeOrderRel] at h1 h2 ⊢
+    refine ⟨IsTrans.trans _ _ _ h1.1 h2.1, fun hc => IsTrans.trans _ _ _ (h1.2 ?_) (h2.2 ?_)⟩
+    · exact IsTrans.trans _ _ _ h2.1 hc
+    · exact IsTrans.trans _ _ _ hc h1.1
 
 /-- The sign associated with putting a list of `CrAnFieldOp` into normal-time order (with
   the state of greatest time to the left).

--- a/Physlib/QFT/PerturbationTheory/WickAlgebra/TimeOrder.lean
+++ b/Physlib/QFT/PerturbationTheory/WickAlgebra/TimeOrder.lean
@@ -38,8 +38,8 @@ lemma ι_timeOrderF_superCommuteF_superCommuteF_eq_time_ofCrAnListF {φ1 φ2 φ3
           (ι (𝓣ᶠ(ofCrAnListF (φs1 ++ φ1 :: φ3 :: φ2 :: φs2))) -
           𝓢(𝓕.crAnStatistics φ1, ofList 𝓕.crAnStatistics [φ3, φ2]) •
           ι 𝓣ᶠ(ofCrAnListF (φs1 ++ φ3 :: φ2 :: φ1 :: φs2))) := by
-        rw [← ofCrAnListF_singleton, ← ofCrAnListF_singleton, ← ofCrAnListF_singleton]
-        rw [superCommuteF_ofCrAnListF_ofCrAnListF]
+        rw [← ofCrAnListF_singleton, ← ofCrAnListF_singleton, ← ofCrAnListF_singleton,
+          superCommuteF_ofCrAnListF_ofCrAnListF]
         simp only [List.singleton_append, ofList_singleton, map_sub, map_smul]
         rw [superCommuteF_ofCrAnListF_ofCrAnListF, superCommuteF_ofCrAnListF_ofCrAnListF]
         simp only [List.cons_append, List.nil_append, ofList_singleton, mul_sub, ←
@@ -71,21 +71,14 @@ lemma ι_timeOrderF_superCommuteF_superCommuteF_eq_time_ofCrAnListF {φ1 φ2 φ3
     simp only [decide_not,
       Bool.decide_and, ofCrAnListF_append, map_smul, map_mul, l1, l2, mul_assoc]
     congr 1
-    have hp : List.Perm [φ1, φ3, φ2] [φ1, φ2, φ3] := by
-      refine List.Perm.cons φ1 ?_
-      exact List.Perm.swap φ2 φ3 []
+    have hp : List.Perm [φ1, φ3, φ2] [φ1, φ2, φ3] :=
+      List.Perm.cons φ1 (List.Perm.swap φ2 φ3 [])
     rw [crAnTimeOrderSign, Wick.koszulSign_perm_eq _ _ φ1 _ _ _ _ _ hp, ← crAnTimeOrderSign]
     · simp
     · intro φ4 hφ4
-      simp only [List.mem_cons, List.not_mem_nil, or_false] at hφ4
-      rcases hφ4 with hφ4 | hφ4 | hφ4
-      all_goals
-        subst hφ4
-        simp_all
-  have hp231 : List.Perm [φ2, φ3, φ1] [φ1, φ2, φ3] := by
-      refine List.Perm.trans (l₂ := [φ2, φ1, φ3]) ?_ ?_
-      refine List.Perm.cons φ2 (List.Perm.swap φ1 φ3 [])
-      exact List.Perm.swap φ1 φ2 [φ3]
+      fin_cases hφ4 <;> simp_all
+  have hp231 : List.Perm [φ2, φ3, φ1] [φ1, φ2, φ3] :=
+    (List.Perm.cons φ2 (List.Perm.swap φ1 φ3 [])).trans (List.Perm.swap φ1 φ2 [φ3])
   have h231 : ι 𝓣ᶠ(ofCrAnListF (φs1 ++ φ2 :: φ3 :: φ1 :: φs2)) =
       crAnTimeOrderSign (φs1 ++ φ1 :: φ2 :: φ3 :: φs2)
       • (ι (ofCrAnListF l1) * ι (ofCrAnListF [φ2, φ3, φ1]) * ι (ofCrAnListF l2)) := by
@@ -99,11 +92,7 @@ lemma ι_timeOrderF_superCommuteF_superCommuteF_eq_time_ofCrAnListF {φ1 φ2 φ3
     rw [crAnTimeOrderSign, Wick.koszulSign_perm_eq _ _ φ1 _ _ _ _ _ hp231, ← crAnTimeOrderSign]
     · simp
     · intro φ4 hφ4
-      simp only [List.mem_cons, List.not_mem_nil, or_false] at hφ4
-      rcases hφ4 with hφ4 | hφ4 | hφ4
-      all_goals
-        subst hφ4
-        simp_all
+      fin_cases hφ4 <;> simp_all
   have h321 : ι 𝓣ᶠ(ofCrAnListF (φs1 ++ φ3 :: φ2 :: φ1 :: φs2)) =
       crAnTimeOrderSign (φs1 ++ φ1 :: φ2 :: φ3 :: φs2)
       • (ι (ofCrAnListF l1) * ι (ofCrAnListF [φ3, φ2, φ1]) * ι (ofCrAnListF l2)) := by
@@ -114,25 +103,19 @@ lemma ι_timeOrderF_superCommuteF_superCommuteF_eq_time_ofCrAnListF {φ1 φ2 φ3
     simp only [decide_not,
       Bool.decide_and, ofCrAnListF_append, map_smul, map_mul, l1, l2, mul_assoc]
     congr 1
-    have hp : List.Perm [φ3, φ2, φ1] [φ1, φ2, φ3] := by
-      refine List.Perm.trans ?_ hp231
-      exact List.Perm.swap φ2 φ3 [φ1]
+    have hp : List.Perm [φ3, φ2, φ1] [φ1, φ2, φ3] :=
+      (List.Perm.swap φ2 φ3 [φ1]).trans hp231
     rw [crAnTimeOrderSign, Wick.koszulSign_perm_eq _ _ φ1 _ _ _ _ _ hp, ← crAnTimeOrderSign]
     · simp
     · intro φ4 hφ4
-      simp only [List.mem_cons, List.not_mem_nil, or_false] at hφ4
-      rcases hφ4 with hφ4 | hφ4 | hφ4
-      all_goals
-        subst hφ4
-        simp_all
+      fin_cases hφ4 <;> simp_all
   rw [h123, h132, h231, h321]
   trans crAnTimeOrderSign (φs1 ++ φ1 :: φ2 :: φ3 :: φs2) • (ι (ofCrAnListF l1) *
     ι [ofCrAnOpF φ1, [ofCrAnOpF φ2, ofCrAnOpF φ3]ₛF]ₛF *
     ι (ofCrAnListF l2)); swap
   · simp
-  rw [mul_assoc]
-  rw [← ofCrAnListF_singleton, ← ofCrAnListF_singleton, ← ofCrAnListF_singleton]
-  rw [superCommuteF_ofCrAnListF_ofCrAnListF]
+  rw [mul_assoc, ← ofCrAnListF_singleton, ← ofCrAnListF_singleton, ← ofCrAnListF_singleton,
+    superCommuteF_ofCrAnListF_ofCrAnListF]
   simp only [List.singleton_append, ofList_singleton, map_sub, map_smul]
   rw [superCommuteF_ofCrAnListF_ofCrAnListF, superCommuteF_ofCrAnListF_ofCrAnListF]
   simp [List.cons_append, List.nil_append, ofList_singleton, map_sub,
@@ -183,7 +166,7 @@ lemma ι_timeOrderF_superCommuteF_superCommuteF {φ1 φ2 φ3 : 𝓕.CrAnFieldOp}
     simp_all [pb]
 
 example (c1 c2 : ℂ) (a : 𝓕.WickAlgebra) : c1 • c2 • a =
-  c2 • c1 • a := by exact smul_comm c1 c2 a
+  c2 • c1 • a := smul_comm c1 c2 a
 lemma ι_timeOrderF_superCommuteF_eq_time {φ ψ : 𝓕.CrAnFieldOp}
     (hφψ : crAnTimeOrderRel φ ψ) (hψφ : crAnTimeOrderRel ψ φ) (a b : 𝓕.FieldOpFreeAlgebra) :
     ι 𝓣ᶠ(a * [ofCrAnOpF φ, ofCrAnOpF ψ]ₛF * b) =
@@ -228,7 +211,7 @@ lemma ι_timeOrderF_superCommuteF_eq_time {φ ψ : 𝓕.CrAnFieldOp}
             trans crAnTimeOrderSign (φs' ++ [φ, ψ] ++ φs)
             simp only [List.append_assoc, List.cons_append, List.nil_append]
             rw [crAnTimeOrderSign]
-            have hp : List.Perm [φ,ψ] [ψ,φ] := by exact List.Perm.swap ψ φ []
+            have hp : List.Perm [φ,ψ] [ψ,φ] := List.Perm.swap ψ φ []
             rw [Wick.koszulSign_perm_eq _ _ φ _ _ _ _ _ hp]
             simp only [List.append_assoc, List.cons_append]
             rfl
@@ -294,11 +277,7 @@ lemma ι_timeOrderF_superCommuteF_eq_time {φ ψ : 𝓕.CrAnFieldOp}
               map_smul]
             rw [← ofCrAnListF_append]
             simp
-      have hc : ι ((superCommuteF (ofCrAnOpF φ)) (ofCrAnOpF ψ)) ∈
-          Subalgebra.center ℂ 𝓕.WickAlgebra := by
-        apply ι_superCommuteF_ofCrAnOpF_ofCrAnOpF_mem_center
-      rw [Subalgebra.mem_center_iff] at hc
-      rw [hc]
+      rw [Subalgebra.mem_center_iff.mp (ι_superCommuteF_ofCrAnOpF_ofCrAnOpF_mem_center φ ψ)]
       repeat rw [mul_assoc]
       rw [← map_mul, ← map_mul, ← map_mul]
       rw [← ofCrAnListF_append, ← ofCrAnListF_append, ← ofCrAnListF_append]
@@ -309,9 +288,8 @@ lemma ι_timeOrderF_superCommuteF_eq_time {φ ψ : 𝓕.CrAnFieldOp}
       by_cases hq : (𝓕 |>ₛ φ) ≠ (𝓕 |>ₛ ψ)
       · rw [ι_superCommuteF_of_diff_statistic hq]
         simp
-      · rw [crAnTimeOrderSign, Wick.koszulSign_eq_rel_eq_stat _ _, ← crAnTimeOrderSign]
-        rw [← ofCrAnListF_append]
-        rw [timeOrderF_ofCrAnListF]
+      · rw [crAnTimeOrderSign, Wick.koszulSign_eq_rel_eq_stat _ _, ← crAnTimeOrderSign,
+          ← ofCrAnListF_append, timeOrderF_ofCrAnListF]
         simp only [map_smul, Algebra.mul_smul_comm]
         exact hφψ
         exact hψφ
@@ -331,18 +309,16 @@ lemma ι_timeOrderF_superCommuteF_ne_time {φ ψ : 𝓕.CrAnFieldOp}
     (hφψ : ¬ (crAnTimeOrderRel φ ψ ∧ crAnTimeOrderRel ψ φ)) (a b : 𝓕.FieldOpFreeAlgebra) :
     ι 𝓣ᶠ(a * [ofCrAnOpF φ, ofCrAnOpF ψ]ₛF * b) = 0 := by
   rw [timeOrderF_timeOrderF_mid]
-  have hφψ : ¬ (crAnTimeOrderRel φ ψ) ∨ ¬ (crAnTimeOrderRel ψ φ) := by
-    exact Decidable.not_and_iff_or_not.mp hφψ
+  have hφψ : ¬ (crAnTimeOrderRel φ ψ) ∨ ¬ (crAnTimeOrderRel ψ φ) :=
+    Decidable.not_and_iff_or_not.mp hφψ
   rcases hφψ with hφψ | hφψ
-  · rw [timeOrderF_superCommuteF_ofCrAnOpF_ofCrAnOpF_not_crAnTimeOrderRel]
-    simp_all only [false_and, not_false_eq_true, mul_zero, zero_mul, map_zero]
-    simp_all
+  · rw [timeOrderF_superCommuteF_ofCrAnOpF_ofCrAnOpF_not_crAnTimeOrderRel hφψ]
+    simp
   · rw [superCommuteF_ofCrAnOpF_ofCrAnOpF_symm]
     simp only [neg_smul, map_neg, map_smul, mul_neg, Algebra.mul_smul_comm,
       neg_mul, Algebra.smul_mul_assoc, neg_eq_zero, smul_eq_zero]
-    rw [timeOrderF_superCommuteF_ofCrAnOpF_ofCrAnOpF_not_crAnTimeOrderRel]
-    simp only [mul_zero, zero_mul, map_zero, or_true]
-    simp_all
+    rw [timeOrderF_superCommuteF_ofCrAnOpF_ofCrAnOpF_not_crAnTimeOrderRel hφψ]
+    simp
 
 /-!
 
@@ -369,37 +345,20 @@ lemma ι_timeOrderF_zero_of_mem_ideal (a : 𝓕.FieldOpFreeAlgebra)
     | Or.inr (Or.inl hc) =>
       obtain ⟨φa, hφa, φb, hφb, rfl⟩ := hc
       by_cases heqt : (crAnTimeOrderRel φa φb ∧ crAnTimeOrderRel φb φa)
-      · rw [ι_timeOrderF_superCommuteF_eq_time]
-        simp only [map_mul]
-        rw [ι_superCommuteF_of_create_create]
-        simp only [zero_mul]
-        · exact hφa
-        · exact hφb
-        · exact heqt.1
-        · exact heqt.2
+      · rw [ι_timeOrderF_superCommuteF_eq_time heqt.1 heqt.2, map_mul,
+          ι_superCommuteF_of_create_create _ _ hφa hφb, zero_mul]
       · rw [ι_timeOrderF_superCommuteF_ne_time heqt]
     | Or.inr (Or.inr (Or.inl hc)) =>
       obtain ⟨φa, hφa, φb, hφb, rfl⟩ := hc
       by_cases heqt : (crAnTimeOrderRel φa φb ∧ crAnTimeOrderRel φb φa)
-      · rw [ι_timeOrderF_superCommuteF_eq_time]
-        simp only [map_mul]
-        rw [ι_superCommuteF_of_annihilate_annihilate]
-        simp only [zero_mul]
-        · exact hφa
-        · exact hφb
-        · exact heqt.1
-        · exact heqt.2
+      · rw [ι_timeOrderF_superCommuteF_eq_time heqt.1 heqt.2, map_mul,
+          ι_superCommuteF_of_annihilate_annihilate _ _ hφa hφb, zero_mul]
       · rw [ι_timeOrderF_superCommuteF_ne_time heqt]
     | Or.inr (Or.inr (Or.inr hc)) =>
       obtain ⟨φa, φb, hdiff, rfl⟩ := hc
       by_cases heqt : (crAnTimeOrderRel φa φb ∧ crAnTimeOrderRel φb φa)
-      · rw [ι_timeOrderF_superCommuteF_eq_time]
-        simp only [map_mul]
-        rw [ι_superCommuteF_of_diff_statistic]
-        simp only [zero_mul]
-        · exact hdiff
-        · exact heqt.1
-        · exact heqt.2
+      · rw [ι_timeOrderF_superCommuteF_eq_time heqt.1 heqt.2, map_mul,
+          ι_superCommuteF_of_diff_statistic hdiff, zero_mul]
       · rw [ι_timeOrderF_superCommuteF_ne_time heqt]
   · simp [p]
   · intro x y hx hy
@@ -497,12 +456,10 @@ lemma timeOrder_superCommute_eq_time_mid {φ ψ : 𝓕.CrAnFieldOp}
     (hφψ : crAnTimeOrderRel φ ψ) (hψφ : crAnTimeOrderRel ψ φ) (a b : 𝓕.WickAlgebra) :
     𝓣(a * [ofCrAnOp φ, ofCrAnOp ψ]ₛ * b) =
     [ofCrAnOp φ, ofCrAnOp ψ]ₛ * 𝓣(a * b) := by
-  rw [ofCrAnOp, ofCrAnOp]
-  rw [superCommute_eq_ι_superCommuteF]
+  rw [ofCrAnOp, ofCrAnOp, superCommute_eq_ι_superCommuteF]
   obtain ⟨a, rfl⟩ := ι_surjective a
   obtain ⟨b, rfl⟩ := ι_surjective b
-  rw [← map_mul, ← map_mul, timeOrder_eq_ι_timeOrderF]
-  rw [ι_timeOrderF_superCommuteF_eq_time]
+  rw [← map_mul, ← map_mul, timeOrder_eq_ι_timeOrderF, ι_timeOrderF_superCommuteF_eq_time]
   rfl
   · simp_all
   · simp_all
@@ -511,21 +468,13 @@ lemma timeOrder_superCommute_eq_time_left {φ ψ : 𝓕.CrAnFieldOp}
     (hφψ : crAnTimeOrderRel φ ψ) (hψφ : crAnTimeOrderRel ψ φ) (b : 𝓕.WickAlgebra) :
     𝓣([ofCrAnOp φ, ofCrAnOp ψ]ₛ * b) =
     [ofCrAnOp φ, ofCrAnOp ψ]ₛ * 𝓣(b) := by
-  trans 𝓣(1 * [ofCrAnOp φ, ofCrAnOp ψ]ₛ * b)
-  simp only [one_mul]
-  rw [timeOrder_superCommute_eq_time_mid hφψ hψφ]
-  simp
+  simpa using timeOrder_superCommute_eq_time_mid hφψ hψφ 1 b
 
 lemma timeOrder_superCommute_ne_time {φ ψ : 𝓕.CrAnFieldOp}
     (hφψ : ¬ (crAnTimeOrderRel φ ψ ∧ crAnTimeOrderRel ψ φ)) :
     𝓣([ofCrAnOp φ, ofCrAnOp ψ]ₛ) = 0 := by
-  rw [ofCrAnOp, ofCrAnOp]
-  rw [superCommute_eq_ι_superCommuteF]
-  rw [timeOrder_eq_ι_timeOrderF]
-  trans ι (timeOrderF (1 * (superCommuteF (ofCrAnOpF φ)) (ofCrAnOpF ψ) * 1))
-  simp only [one_mul, mul_one]
-  rw [ι_timeOrderF_superCommuteF_ne_time]
-  exact hφψ
+  rw [ofCrAnOp, ofCrAnOp, superCommute_eq_ι_superCommuteF, timeOrder_eq_ι_timeOrderF]
+  simpa using ι_timeOrderF_superCommuteF_ne_time hφψ 1 1
 
 lemma timeOrder_superCommute_anPart_ofFieldOp_ne_time {φ ψ : 𝓕.FieldOp}
     (hφψ : ¬ (timeOrderRel φ ψ ∧ timeOrderRel ψ φ)) :
@@ -558,25 +507,16 @@ lemma timeOrder_timeOrder_mid (a b c : 𝓕.WickAlgebra) :
 
 lemma timeOrder_timeOrder_left (b c : 𝓕.WickAlgebra) :
     𝓣(b * c) = 𝓣(𝓣(b) * c) := by
-  trans 𝓣(1 * b * c)
-  simp only [one_mul]
-  rw [timeOrder_timeOrder_mid]
-  simp
+  simpa using timeOrder_timeOrder_mid 1 b c
 
 lemma timeOrder_timeOrder_right (a b : 𝓕.WickAlgebra) :
     𝓣(a * b) = 𝓣(a * 𝓣(b)) := by
-  trans 𝓣(a * b * 1)
-  simp only [mul_one]
-  rw [timeOrder_timeOrder_mid]
-  simp
+  simpa using timeOrder_timeOrder_mid a b 1
 
 /-- Time ordering is a projection. -/
 lemma timeOrder_timeOrder (a : 𝓕.WickAlgebra) :
     𝓣(𝓣(a)) = 𝓣(a) := by
-  trans 𝓣(𝓣(a) * 1)
-  · simp
-  · rw [← timeOrder_timeOrder_left]
-    simp
+  simpa using (timeOrder_timeOrder_left a 1).symm
 
 end WickAlgebra
 end FieldSpecification

--- a/Physlib/QFT/PerturbationTheory/WickContraction/Basic.lean
+++ b/Physlib/QFT/PerturbationTheory/WickContraction/Basic.lean
@@ -284,19 +284,25 @@ lemma sndFieldOfContract_congr {n m : ℕ} (h : n = m) (c : WickContraction n) (
 lemma finset_eq_fstFieldOfContract_sndFieldOfContract (c : WickContraction n) (a : c.1) :
     a.1 = {c.fstFieldOfContract a, c.sndFieldOfContract a} := by
   obtain ⟨x, y, hxy, ha⟩ := Finset.card_eq_two.mp (c.2.1 a.1 a.2)
-  rw [ha]
-  rcases le_or_lt x y with hle | hlt
-  · have hs : a.1.sort (· ≤ ·) = [x, y] := by
-      rw [ha, Finset.sort_insert, Finset.sort_singleton]
-      · simpa using hle
-      · simpa using hxy
-    simp [fstFieldOfContract, hs, sndFieldOfContract]
-  · have hs : a.1.sort (· ≤ ·) = [y, x] := by
-      rw [ha, Finset.pair_comm, Finset.sort_insert, Finset.sort_singleton]
-      · simpa using hlt.le
-      · simpa using hlt.ne
-    simp only [fstFieldOfContract, hs, List.head_cons, sndFieldOfContract, List.tail_cons]
-    rw [Finset.pair_comm]
+  rcases Nat.lt_or_ge x y with hlt | hle
+  · -- hlt : x < y, so sorted is [x, y]
+    have hs : a.1.sort (· ≤ ·) = [x, y] := by
+      rw [ha]
+      rw [Finset.sort_insert (a := x) (s := {y}) (r := (· ≤ ·))
+        (h₁ := by intro b hb; simpa [Finset.mem_singleton.mp hb] using hlt.le)
+        (h₂ := by simpa using hxy)]
+      simp only [Finset.sort_singleton]
+    dsimp [fstFieldOfContract, sndFieldOfContract]
+    simpa [hs] using ha
+  · -- hle : y ≤ x, so sorted is [y, x]
+    have hs : a.1.sort (· ≤ ·) = [y, x] := by
+      rw [ha, Finset.pair_comm]
+      rw [Finset.sort_insert (a := y) (s := {x}) (r := (· ≤ ·))
+        (h₁ := by intro b hb; simpa [Finset.mem_singleton.mp hb] using hle)
+        (h₂ := by simpa using hxy.symm)]
+      simp only [Finset.sort_singleton]
+    dsimp [fstFieldOfContract, sndFieldOfContract]
+    simpa [hs, Finset.pair_comm] using ha
 
 lemma fstFieldOfContract_ne_sndFieldOfContract (c : WickContraction n) (a : c.1) :
     c.fstFieldOfContract a ≠ c.sndFieldOfContract a := by

--- a/Physlib/QFT/PerturbationTheory/WickContraction/Basic.lean
+++ b/Physlib/QFT/PerturbationTheory/WickContraction/Basic.lean
@@ -55,9 +55,7 @@ lemma exists_pair_of_not_eq_empty (c : WickContraction n) (h : c ≠ empty) :
     rw [@Finset.card_eq_two] at hc
     obtain ⟨x, y, hx, rfl⟩ := hc
     exact hn x y hn'
-  apply h
-  apply Subtype.ext_iff.mpr
-  simp [empty, hc]
+  exact h (Subtype.ext (by simp [empty, hc]))
 
 /-- The equivalence between `WickContraction n` and `WickContraction m`
   derived from a propositional equality of `n` and `m`. -/
@@ -120,8 +118,7 @@ lemma congrLift_rfl {n : ℕ} {c : WickContraction n} :
 lemma congrLift_injective {n m : ℕ} {c : WickContraction n} (h : n = m) :
     Function.Injective (c.congrLift h) := by
   subst h
-  simp only [congrLift_rfl]
-  exact fun ⦃a₁ a₂⦄ a => a
+  simpa using Function.injective_id
 
 lemma congrLift_surjective {n m : ℕ} {c : WickContraction n} (h : n = m) :
     Function.Surjective (c.congrLift h) := by
@@ -129,8 +126,8 @@ lemma congrLift_surjective {n m : ℕ} {c : WickContraction n} (h : n = m) :
   simp [Function.surjective_id]
 
 lemma congrLift_bijective {n m : ℕ} {c : WickContraction n} (h : n = m) :
-    Function.Bijective (c.congrLift h) := by
-  exact ⟨c.congrLift_injective h, c.congrLift_surjective h⟩
+    Function.Bijective (c.congrLift h) :=
+  ⟨c.congrLift_injective h, c.congrLift_surjective h⟩
 
 /-- Given a contracted pair in `c : WickContraction n` the contracted pair
   in `congr h c`. -/
@@ -158,8 +155,7 @@ lemma getDual?_congr_get {n m : ℕ} (h : n = m) (c : WickContraction n) (i : Fi
     (hg : ((congr h c).getDual? i).isSome) :
     ((congr h c).getDual? i).get hg =
     (finCongr h ((c.getDual? (finCongr h.symm i)).get (by simpa [getDual?_congr] using hg))) := by
-  simp only [getDual?_congr, finCongr_apply]
-  exact Option.get_map
+  simpa only [getDual?_congr] using Option.get_map
 
 lemma getDual?_eq_some_iff_mem (i j : Fin n) :
     c.getDual? i = some j ↔ {i, j} ∈ c.1 := by
@@ -185,11 +181,7 @@ lemma getDual?_eq_some_iff_mem (i j : Fin n) :
 @[simp]
 lemma getDual?_one_eq_none (c : WickContraction 1) (i : Fin 1) : c.getDual? i = none := by
   by_contra h
-  have hn : (c.getDual? i).isSome := by
-    rw [← Option.not_isSome_iff_eq_none] at h
-    simpa [- Option.not_isSome, -Option.isNone_iff_eq_none] using h
-  rw [@Option.isSome_iff_exists] at hn
-  obtain ⟨a, hn⟩ := hn
+  obtain ⟨a, hn⟩ := Option.ne_none_iff_exists'.mp h
   rw [getDual?_eq_some_iff_mem] at hn
   have hc := c.2.1 {i, a} hn
   fin_cases i
@@ -209,28 +201,18 @@ lemma self_getDual?_get_mem (i : Fin n) (h : (c.getDual? i).isSome) :
 lemma getDual?_eq_some_neq (i j : Fin n) (h : c.getDual? i = some j) :
     ¬ i = j := by
   rw [getDual?_eq_some_iff_mem] at h
-  by_contra hn
-  subst hn
-  have hc := c.2.1 _ h
-  simp at hc
+  rintro rfl
+  simpa using c.2.1 _ h
 
 @[simp]
 lemma self_ne_getDual?_get (i : Fin n) (h : (c.getDual? i).isSome) :
-    ¬ i = (c.getDual? i).get h := by
-  by_contra hn
-  have hx : {i, (c.getDual? i).get h} ∈ c.1 := by simp
-  have hc := c.2.1 _ hx
-  nth_rewrite 1 [hn] at hc
-  simp at hc
+    ¬ i = (c.getDual? i).get h :=
+  c.getDual?_eq_some_neq i _ (Option.some_get h).symm
 
 @[simp]
 lemma getDual?_get_self_neq (i : Fin n) (h : (c.getDual? i).isSome) :
-    ¬ (c.getDual? i).get h = i := by
-  by_contra hn
-  have hx : {i, (c.getDual? i).get h} ∈ c.1 := by simp
-  have hc := c.2.1 _ hx
-  nth_rewrite 1 [hn] at hc
-  simp at hc
+    ¬ (c.getDual? i).get h = i :=
+  fun a => c.self_ne_getDual?_get i h a.symm
 
 lemma getDual?_isSome_iff (i : Fin n) : (c.getDual? i).isSome ↔ ∃ (a : c.1), i ∈ a.1 := by
   apply Iff.intro <;> intro h
@@ -239,26 +221,19 @@ lemma getDual?_isSome_iff (i : Fin n) : (c.getDual? i).isSome ↔ ∃ (a : c.1),
     use ⟨{i, a}, by simpa using ha⟩
     simp
   · obtain ⟨a, ha⟩ := h
-    have ha := c.2.1 a a.2
-    rw [@Finset.card_eq_two] at ha
-    obtain ⟨x, y, hx, hy⟩ := ha
+    rw [getDual?, Fin.isSome_find?_iff]
+    obtain ⟨x, y, hx, hy⟩ := Finset.card_eq_two.mp (c.2.1 a a.2)
     rw [hy] at ha
     simp only [Finset.mem_insert, Finset.mem_singleton] at ha
-    match ha with
-    | Or.inl ha =>
-      subst ha
-      rw [getDual?, Fin.isSome_find?_iff]
-      exact ⟨y, by simpa using hy ▸ a.2⟩
-    | Or.inr ha =>
-      subst ha
-      rw [getDual?, Fin.isSome_find?_iff]
-      use x
+    rcases ha with rfl | rfl
+    · exact ⟨y, by simpa using hy ▸ a.2⟩
+    · refine ⟨x, ?_⟩
       rw [Finset.pair_comm]
       simpa using hy ▸ a.2
 
 lemma getDual?_isSome_of_mem (a : c.1) (i : a.1) : (c.getDual? i).isSome := by
   rw [getDual?_isSome_iff]
-  exact ⟨⟨a.1, a.2⟩, Finset.coe_mem ..⟩
+  exact ⟨a, i.2⟩
 
 @[simp]
 lemma getDual?_getDual?_get_get (i : Fin n) (h : (c.getDual? i).isSome) :
@@ -308,44 +283,26 @@ lemma sndFieldOfContract_congr {n m : ℕ} (h : n = m) (c : WickContraction n) (
 
 lemma finset_eq_fstFieldOfContract_sndFieldOfContract (c : WickContraction n) (a : c.1) :
     a.1 = {c.fstFieldOfContract a, c.sndFieldOfContract a} := by
-  have h1 := c.2.1 a.1 a.2
-  rw [Finset.card_eq_two] at h1
-  obtain ⟨x, y, hxy, ha⟩ := h1
+  obtain ⟨x, y, hxy, ha⟩ := Finset.card_eq_two.mp (c.2.1 a.1 a.2)
   rw [ha]
-  by_cases hxyle : x ≤ y
-  · have ha : a.1.sort (· ≤ ·) = [x, y] := by
-      rw [ha]
-      trans Finset.sort (Finset.cons x {y} (by simp [hxy])) (· ≤ ·)
-      · congr
-        simp
-      rw [Finset.sort_cons]
-      simp only [Finset.sort_singleton]
-      intro b hb
-      simp only [Finset.mem_singleton] at hb
-      subst hb
-      omega
-    simp [fstFieldOfContract, ha, sndFieldOfContract]
-  · have ha : a.1.sort (· ≤ ·) = [y, x] := by
-      rw [ha]
-      trans Finset.sort (Finset.cons y {x} (by simp only [Finset.mem_singleton]; omega)) (· ≤ ·)
-      · congr
-        simp only [Finset.cons_eq_insert]
-        rw [@Finset.pair_comm]
-      rw [Finset.sort_cons]
-      simp only [Finset.sort_singleton]
-      intro b hb
-      simp only [Finset.mem_singleton] at hb
-      subst hb
-      omega
-    simp only [fstFieldOfContract, ha, List.head_cons, sndFieldOfContract, List.tail_cons]
+  rcases le_or_lt x y with hle | hlt
+  · have hs : a.1.sort (· ≤ ·) = [x, y] := by
+      rw [ha, Finset.sort_insert, Finset.sort_singleton]
+      · simpa using hle
+      · simpa using hxy
+    simp [fstFieldOfContract, hs, sndFieldOfContract]
+  · have hs : a.1.sort (· ≤ ·) = [y, x] := by
+      rw [ha, Finset.pair_comm, Finset.sort_insert, Finset.sort_singleton]
+      · simpa using hlt.le
+      · simpa using hlt.ne
+    simp only [fstFieldOfContract, hs, List.head_cons, sndFieldOfContract, List.tail_cons]
     rw [Finset.pair_comm]
 
 lemma fstFieldOfContract_ne_sndFieldOfContract (c : WickContraction n) (a : c.1) :
     c.fstFieldOfContract a ≠ c.sndFieldOfContract a := by
-  have h1 := c.2.1 a.1 a.2
-  have h2 := c.finset_eq_fstFieldOfContract_sndFieldOfContract a
   by_contra hn
-  simp [h2, hn] at h1
+  have h1 := c.2.1 a.1 a.2
+  simp [c.finset_eq_fstFieldOfContract_sndFieldOfContract a, hn] at h1
 
 lemma fstFieldOfContract_le_sndFieldOfContract (c : WickContraction n) (a : c.1) :
     c.fstFieldOfContract a ≤ c.sndFieldOfContract a := by
@@ -401,41 +358,17 @@ lemma eq_fstFieldOfContract_of_mem (c : WickContraction n) (a : c.1) (i j : Fin 
     (hi : i ∈ a.1) (hj : j ∈ a.1) (hij : i < j) :
     c.fstFieldOfContract a = i := by
   rw [finset_eq_fstFieldOfContract_sndFieldOfContract] at hi hj
-  simp_all only [Finset.mem_insert, Finset.mem_singleton]
-  match hi, hj with
-  | Or.inl hi, Or.inl hj =>
-    subst hi hj
-    simp at hij
-  | Or.inl hi, Or.inr hj =>
-    subst hi
-    rfl
-  | Or.inr hi, Or.inl hj =>
-    subst hi hj
-    have hn := fstFieldOfContract_lt_sndFieldOfContract c a
-    omega
-  | Or.inr hi, Or.inr hj =>
-    subst hi hj
-    simp at hij
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hi hj
+  have h := c.fstFieldOfContract_lt_sndFieldOfContract a
+  omega
 
 lemma eq_sndFieldOfContract_of_mem (c : WickContraction n) (a : c.1) (i j : Fin n)
     (hi : i ∈ a.1) (hj : j ∈ a.1) (hij : i < j) :
     c.sndFieldOfContract a = j := by
   rw [finset_eq_fstFieldOfContract_sndFieldOfContract] at hi hj
-  simp_all only [Finset.mem_insert, Finset.mem_singleton]
-  match hi, hj with
-  | Or.inl hi, Or.inl hj =>
-    subst hi hj
-    simp at hij
-  | Or.inl hi, Or.inr hj =>
-    subst hi hj
-    omega
-  | Or.inr hi, Or.inl hj =>
-    subst hi hj
-    have hn := fstFieldOfContract_lt_sndFieldOfContract c a
-    omega
-  | Or.inr hi, Or.inr hj =>
-    subst hi hj
-    simp at hij
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hi hj
+  have h := c.fstFieldOfContract_lt_sndFieldOfContract a
+  omega
 
 /-- As a type, any pair of contractions is equivalent to `Fin 2`
   with `0` being associated with `c.fstFieldOfContract a` and `1` being associated with

--- a/Physlib/QFT/QED/AnomalyCancellation/Even/BasisLinear.lean
+++ b/Physlib/QFT/QED/AnomalyCancellation/Even/BasisLinear.lean
@@ -434,13 +434,17 @@ lemma P'_val (f : Fin n.succ → ℚ) : (P' f).val = P f := by
 theorem basis_linear_independent : LinearIndependent ℚ (@basis n) := by
   apply Fintype.linearIndependent_iff.mpr
   intro f h
-  change P' f = 0 at h
-  have h1 : (P' f).val = 0 :=
-    (AddSemiconjBy.eq_zero_iff (ACCSystemLinear.LinSols.val 0)
-    (congrFun (congrArg HAdd.hAdd (congrArg ACCSystemLinear.LinSols.val (id (Eq.symm h))))
-    (ACCSystemLinear.LinSols.val 0))).mp rfl
-  rw [P'_val] at h1
-  exact P_zero f h1
+  apply P_zero f
+  have hval : (P' f).val = 0 := by
+    have h1 := congrArg (fun (x : (PureU1 (2 * n.succ)).LinSols) => x.val) h
+    -- h1 : (∑ i, f i • basis i).val = ACCSystemLinear.LinSols.val 0
+    -- ACCSystemLinear.LinSols.val 0 is definitionally 0
+    have h2 : (P' f).val = (∑ i, f i • basis i).val := rfl
+    -- h2 : (P' f).val = (∑ i, f i • basis i).val
+    -- Combine: h2.trans h1 gives (P' f).val = 0
+    exact h2.trans h1
+  rw [P'_val] at hval
+  exact hval
 
 /-!
 
@@ -731,13 +735,13 @@ lemma P!'_val (f : Fin n → ℚ) : (P!' f).val = P! f := by
 theorem basis!_linear_independent : LinearIndependent ℚ (@basis! n) := by
   apply Fintype.linearIndependent_iff.mpr
   intro f h
-  change P!' f = 0 at h
-  have h1 : (P!' f).val = 0 :=
-    (AddSemiconjBy.eq_zero_iff (ACCSystemLinear.LinSols.val 0)
-    (congrFun (congrArg HAdd.hAdd (congrArg ACCSystemLinear.LinSols.val (id (Eq.symm h))))
-    (ACCSystemLinear.LinSols.val 0))).mp rfl
-  rw [P!'_val] at h1
-  exact P!_zero f h1
+  apply P!_zero f
+  have hval : (P!' f).val = 0 := by
+    have h1 := congrArg (fun (x : (PureU1 (2 * n.succ)).LinSols) => x.val) h
+    have h2 : (P!' f).val = (∑ i, f i • basis! i).val := rfl
+    exact h2.trans h1
+  rw [P!'_val] at hval
+  exact hval
 
 /-!
 
@@ -929,22 +933,15 @@ lemma Pa'_P'_P!' (f : (Fin n.succ) ⊕ (Fin n) → ℚ) :
 theorem basisa_linear_independent : LinearIndependent ℚ (@basisa n) := by
   apply Fintype.linearIndependent_iff.mpr
   intro f h
-  change Pa' f = 0 at h
-  have h1 : (Pa' f).val = 0 :=
-    (AddSemiconjBy.eq_zero_iff (ACCSystemLinear.LinSols.val 0)
-    (congrFun (congrArg HAdd.hAdd (congrArg ACCSystemLinear.LinSols.val (id (Eq.symm h))))
-    (ACCSystemLinear.LinSols.val 0))).mp rfl
-  rw [Pa'_P'_P!'] at h1
-  change (P' (f ∘ Sum.inl)).val + (P!' (f ∘ Sum.inr)).val = 0 at h1
-  rw [P!'_val, P'_val] at h1
-  change Pa (f ∘ Sum.inl) (f ∘ Sum.inr) = 0 at h1
-  have hf := Pa_zero (f ∘ Sum.inl) (f ∘ Sum.inr) h1
-  have hg := Pa_zero! (f ∘ Sum.inl) (f ∘ Sum.inr) h1
+  have hval : (Pa' f).val = 0 := congrArg (fun (x : (PureU1 (2 * n.succ)).LinSols) => x.val) h
+  have hval' : Pa (f ∘ Sum.inl) (f ∘ Sum.inr) = 0 := by
+    simpa [Pa, Pa'_P'_P!', P!'_val, P'_val, map_add] using hval
+  have hf := Pa_zero (f ∘ Sum.inl) (f ∘ Sum.inr) hval'
+  have hg := Pa_zero! (f ∘ Sum.inl) (f ∘ Sum.inr) hval'
   intro i
-  simp_all
   cases i
-  · simp_all
-  · simp_all
+  · exact hf _
+  · exact hg _
 /-!
 
 ### E.7. Injectivity of the inclusion into linear solutions

--- a/Physlib/Relativity/Tensors/Basic.lean
+++ b/Physlib/Relativity/Tensors/Basic.lean
@@ -719,10 +719,8 @@ lemma permT_basis_repr_symm_apply {n m : ℕ} {c : Fin n → C} {c1 : Fin m → 
       simpa [h'] using (ComponentIdx.congr_right _ _ _
         (IsReindexing.apply_inv_apply σ h x).symm).symm
   · simp
-  · intro r t h
-    simp [h]
-  · intro t1 t2 h1 h2
-    simp [h1, h2]
+  · intro r t' ht; simp [ht, map_smul]
+  · intro t1 t2 ht1 ht2; simp [ht1, ht2, map_add]
 
 lemma permT_basis {n m : ℕ} {c : Fin n → C} {c1 : Fin m → C}
     {σ : Fin m → Fin n} (h : IsReindexing c c1 σ)

--- a/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
@@ -180,53 +180,30 @@ lemma toComplex_repr {n} {c : Fin n → realLorentzTensor.Color}
     (Tensor.basis (S := complexLorentzTensor) (colorToComplex ∘ c)).repr
       (toComplex v) i.complexify =
     ↑((Tensor.basis (S := realLorentzTensor) c).repr v i) := by
-  -- Expand toComplex v in the complexified basis
-  rw [toComplex_eq_sum_basis]
-  -- `repr` commutes with finite sums of tensors; then push the Finsupp evaluation into the sum
-  rw [map_sum]
+  rw [toComplex_eq_sum_basis, map_sum]
   simp only [Finsupp.coe_finsetSum, Finset.sum_apply]
-  -- The sum has only one non-zero term (when k = i.complexify)
   rw [Fintype.sum_eq_single i.complexify]
   · -- Case k = i.complexify: show the term equals ↑(repr v i)
-    have hsmul :
-        ((Tensor.basis (S := realLorentzTensor) c).repr v
-            (ComponentIdx.complexify.symm (ComponentIdx.complexify i))) •
-          Tensor.basis (S := complexLorentzTensor) (colorToComplex ∘ c)
-            (ComponentIdx.complexify i) =
-        (↑((Tensor.basis (S := realLorentzTensor) c).repr v
-            (ComponentIdx.complexify.symm (ComponentIdx.complexify i))) : ℂ) •
-          Tensor.basis (S := complexLorentzTensor) (colorToComplex ∘ c)
-            (ComponentIdx.complexify i) :=
+    simp only [Equiv.symm_apply_apply ComponentIdx.complexify]
+    have hsmul : (((Tensor.basis c).repr v) i : ℂ) •
+        (Tensor.basis (colorToComplex ∘ c)) (ComponentIdx.complexify i) =
+        ((Tensor.basis c).repr v) i •
+        (Tensor.basis (colorToComplex ∘ c)) (ComponentIdx.complexify i) :=
       (Complex.coe_smul _ _).symm
-    rw [hsmul]
-    have hm :=
-      LinearEquiv.map_smul
-        (Tensor.basis (S := complexLorentzTensor) (colorToComplex ∘ c)).repr
-        (↑((Tensor.basis (S := realLorentzTensor) c).repr v
-            (ComponentIdx.complexify.symm (ComponentIdx.complexify i))) : ℂ)
-        (Tensor.basis (S := complexLorentzTensor) (colorToComplex ∘ c)
-          (ComponentIdx.complexify i))
-    simp_rw [hm]
-    simp only [Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul, Basis.repr_self, Finsupp.single_apply]
-    simp only [Equiv.symm_apply_apply ComponentIdx.complexify, ite_true, mul_one]
+    rw [← hsmul, LinearEquiv.map_smul, Finsupp.smul_apply, Basis.repr_self, Finsupp.single_apply,
+      smul_eq_mul]
+    simp
   · -- Case k ≠ i.complexify: show the term equals 0
     intro k hk
-    have hsmul :
-        ((Tensor.basis (S := realLorentzTensor) c).repr v (ComponentIdx.complexify.symm k)) •
-          Tensor.basis (S := complexLorentzTensor) (colorToComplex ∘ c) k =
-        (↑((Tensor.basis (S := realLorentzTensor) c).repr v (ComponentIdx.complexify.symm k)) : ℂ) •
-          Tensor.basis (S := complexLorentzTensor) (colorToComplex ∘ c) k :=
+    have hsmul : (((Tensor.basis c).repr v) (ComponentIdx.complexify.symm k) : ℂ) •
+        (Tensor.basis (colorToComplex ∘ c)) k =
+        ((Tensor.basis c).repr v) (ComponentIdx.complexify.symm k) •
+        (Tensor.basis (colorToComplex ∘ c)) k :=
       (Complex.coe_smul _ _).symm
-    rw [hsmul]
-    have hm :=
-      LinearEquiv.map_smul (Tensor.basis (S := complexLorentzTensor) (colorToComplex ∘ c)).repr
-        (↑((Tensor.basis (S := realLorentzTensor) c).repr v (ComponentIdx.complexify.symm k)) : ℂ)
-        (Tensor.basis (S := complexLorentzTensor) (colorToComplex ∘ c) k)
-    simp_rw [hm]
-    simp only [Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul, Basis.repr_self, Finsupp.single_apply]
+    rw [← hsmul, LinearEquiv.map_smul, Finsupp.smul_apply, Basis.repr_self, smul_eq_mul,
+      Finsupp.single_apply]
     split_ifs with h
-    · exfalso
-      exact hk h
+    · exfalso; exact hk h
     · rw [mul_zero]
 
 /-- `toComplex` sends basis elements to basis elements. -/
@@ -311,34 +288,20 @@ noncomputable def toComplexVector (c : realLorentzTensor.Color) :
     match c with
     | Color.up =>
       simp only [map_add, Finsupp.coe_add, Pi.add_apply, Nat.reduceAdd, ← Finset.sum_add_distrib]
-      congr
-      funext x
-      rw [add_smul]
-      rfl
+      congr; funext x; rw [add_smul]; rfl
     | Color.down =>
       simp only [map_add, Finsupp.coe_add, Pi.add_apply, Nat.reduceAdd, ← Finset.sum_add_distrib]
-      congr
-      funext x
-      rw [add_smul]
-      rfl
+      congr; funext x; rw [add_smul]; rfl
   map_smul' r v := by
     match c with
     | Color.up =>
       simp only [map_smul, Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul, Nat.reduceAdd,
         Complex.ofRealHom_eq_coe, Complex.coe_smul]
-      rw [Finset.smul_sum]
-      congr
-      funext x
-      rw [← smul_smul]
-      rfl
+      rw [Finset.smul_sum]; congr; funext x; rw [← smul_smul]; rfl
     | Color.down =>
       simp only [map_smul, Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul, Nat.reduceAdd,
         Complex.ofRealHom_eq_coe, Complex.coe_smul]
-      rw [Finset.smul_sum]
-      congr
-      funext x
-      rw [← smul_smul]
-      rfl
+      rw [Finset.smul_sum]; congr; funext x; rw [← smul_smul]; rfl
 
 lemma toComplexVector_up_eq_inclCongrRealLorentz (v : Lorentz.ContrMod 3) :
     toComplexVector Color.up v = Lorentz.inclCongrRealLorentz v := by
@@ -576,34 +539,20 @@ lemma permT_toComplex {n m : ℕ}
     permT (S := complexLorentzTensor) σ (isReindexing_colorToComplex (c := c) (c1 := c1) h)
       (toComplex (c := c) t) := by
   classical
-  let h' : IsReindexing (colorToComplex ∘ c) (colorToComplex ∘ c1) σ :=
-    isReindexing_colorToComplex (c := c) (c1 := c1) h
-  let P : ℝT(3, c) → Prop := fun t =>
-    toComplex (permT (S := realLorentzTensor) σ h t)
-      =
-    permT (S := complexLorentzTensor) σ h' (toComplex (c := c) t)
-  change P t
-  apply induction_on_basis
+  apply induction_on_basis (c := c)
+    (P := fun t =>
+      toComplex (permT (S := realLorentzTensor) σ h t) =
+      permT (S := complexLorentzTensor) σ (isReindexing_colorToComplex (c := c) (c1 := c1) h)
+        (toComplex (c := c) t))
   · intro b
-    dsimp [P, h']
-
-    -- permT on (real/complex) basis + toComplex on basis
     simp (config := { failIfUnchanged := false })
       [permT_basis_real, permT_basis_complex, toComplex_basis]
-
-    -- index equality
     apply congrArg (Tensor.basis (S := complexLorentzTensor) (colorToComplex ∘ c1))
     funext j
     simp [TensorSpecies.Tensor.ComponentIdx.complexify, colorToComplex, Function.comp_apply]
-  · simp [P]
-  · intro r t ht
-    dsimp [P] at ht ⊢
-    refine (by
-      simp [map_smul, ht])
-  · intro t1 t2 h1 h2
-    dsimp [P] at h1 h2 ⊢
-    refine (by
-      simp [map_add, h1, h2])
+  · simp
+  · intro r t' ht; simp [map_smul, ht]
+  · intro t1 t2 h1 h2; simp [map_add, h1, h2]
 
 /-!
 
@@ -791,71 +740,27 @@ lemma contrT_toComplex {n : ℕ}
       =
     contrT (S := complexLorentzTensor) n i j (by
         simpa [Function.comp_apply] using
-          And.intro h.1 (by
-            simpa [tau_colorToComplex] using congrArg colorToComplex h.2))
+          And.intro h.1 (by simpa [tau_colorToComplex] using congrArg colorToComplex h.2))
       (toComplex (c := c) t) := by
   classical
-  -- We prove the statement by induction on the tensor `t` using the tensor basis.
-  -- After contracting two indices, the resulting colour function lives on `Fin n`.
-  let c' : Fin n → realLorentzTensor.Color := c ∘ Fin.succSuccAbove i j
-  have hP :
-      ∀ t : ℝT(3, c),
-        toComplex (c := c') (contrT (S := realLorentzTensor) n i j h t) =
-          contrT (S := complexLorentzTensor) n i j
-            (by
-              -- transport the colour relation along `colorToComplex`
-              simpa [Function.comp_apply] using
-                And.intro h.1
-                  (by
-                    simpa [tau_colorToComplex] using congrArg colorToComplex h.2))
-            (toComplex (c := c) t) := by
-    intro t
-    -- Work with the property as a predicate for `induction_on_basis`.
-    let P : ℝT(3, c) → Prop := fun t =>
+  let c' := c ∘ Fin.succSuccAbove i j
+  apply induction_on_basis (c := c)
+    (P := fun t =>
       toComplex (c := c') (contrT (S := realLorentzTensor) n i j h t) =
-        contrT (S := complexLorentzTensor) n i j
-          (by
-            simpa [Function.comp_apply] using
-              And.intro h.1
-                (by
-                  simpa [tau_colorToComplex] using congrArg colorToComplex h.2))
-          (toComplex (c := c) t)
-    have hP' : P t := by
-      -- `induction_on_basis` over the tensor `t`.
-      apply
-        induction_on_basis
-          (c := c)
-          (P := P)
-          (t := t)
-      · -- basis case
-        intro b
-        -- (Tensor.basis c) b = (Pure.basisVector c b).toTensor;
-        -- then equate both sides via toComplex_contrP_basisVector.
-        rw [Tensor.basis_apply (S := realLorentzTensor) c b]
-        show toComplex (c := c')
-            (contrT (S := realLorentzTensor) n i j h ((Pure.basisVector c b).toTensor))
-          = contrT (S := complexLorentzTensor) n i j _
-            (toComplex (c := c) ((Pure.basisVector c b).toTensor))
-        rw [contrT_pure (S := realLorentzTensor) (p := Pure.basisVector c b),
-          toComplex_pure_basisVector (c := c) b,
-          contrT_pure (S := complexLorentzTensor)
-            (p := Pure.basisVector (colorToComplex ∘ c) (ComponentIdx.complexify b))]
-        exact toComplex_contrP_basisVector h b
-      · -- zero tensor
-        dsimp [P]
-        simp
-      · -- scalar multiplication
-        intro r t ht
-        dsimp [P] at ht ⊢
-        refine (by
-          simp [map_smul, ht])
-      · -- addition
-        intro t1 t2 h1 h2
-        dsimp [P] at h1 h2 ⊢
-        refine (by
-          simp [map_add, h1, h2])
-    exact hP'
-  exact hP t
+      contrT (S := complexLorentzTensor) n i j
+        (by simpa [Function.comp_apply] using
+          And.intro h.1 (by simpa [tau_colorToComplex] using congrArg colorToComplex h.2))
+        (toComplex (c := c) t))
+  · intro b
+    rw [Tensor.basis_apply (S := realLorentzTensor) c b]
+    rw [contrT_pure (S := realLorentzTensor) (p := Pure.basisVector c b),
+      toComplex_pure_basisVector (c := c) b,
+      contrT_pure (S := complexLorentzTensor)
+        (p := Pure.basisVector (colorToComplex ∘ c) (ComponentIdx.complexify b))]
+    exact toComplex_contrP_basisVector h b
+  · simp
+  · intro r t' ht; simp [map_smul, ht]
+  · intro t1 t2 h1 h2; simp [map_add, h1, h2]
 
 /-!
 
@@ -938,33 +843,27 @@ lemma evalT_toComplex {n : ℕ}
     evalTColorToComplex (c := c) i b (toComplex (c := c) t) := by
   classical
   let c' := c ∘ i.succAbove
-  let P : ℝT(3, c) → Prop := fun t =>
-    toComplex (c := c')
-      ((TensorSpecies.Tensor.evalT (S := realLorentzTensor) (c := c) i b) t) =
-    evalTColorToComplex (c := c) i b (toComplex (c := c) t)
-  have hP : ∀ t, P t := by
-    intro t
-    apply induction_on_basis (c := c) (P := P) (t := t)
-    · intro b'
-      rw [Tensor.basis_apply (S := realLorentzTensor) c b']
-      simp only [evalTColorToComplex, P]
-      rw [evalT_pure (S := realLorentzTensor) (p := Pure.basisVector c b'),
-        toComplex_pure_basisVector (c := c) b',
-        evalT_pure (S := complexLorentzTensor)
-          (p := Pure.basisVector (colorToComplex ∘ c) (ComponentIdx.complexify b'))]
-      exact toComplex_evalP_basisVector i b b'
-    · dsimp [P]
-      simp only [evalTColorToComplex, map_zero]
-    · intro r t' ht'
-      dsimp [P] at ht' ⊢
-      rw [LinearMap.map_smul, toComplex_map_smul (c ∘ i.succAbove) r
-        ((evalT (S := realLorentzTensor) i b) t'),
-        ht', toComplex_map_smul (c := c) r t']
-      simp only [evalTColorToComplex, LinearMap.map_smul]
-    · intro t1 t2 h1 h2
-      dsimp [P] at h1 h2 ⊢
-      rw [LinearMap.map_add, map_add, h1, h2]
-      simp only [evalTColorToComplex, LinearMap.map_add]
-  exact hP t
+  apply induction_on_basis (c := c)
+    (P := fun t =>
+      toComplex (c := c')
+        ((TensorSpecies.Tensor.evalT (S := realLorentzTensor) (c := c) i b) t) =
+      evalTColorToComplex (c := c) i b (toComplex (c := c) t))
+  · intro b'
+    rw [Tensor.basis_apply (S := realLorentzTensor) c b']
+    simp only [evalTColorToComplex]
+    rw [evalT_pure (S := realLorentzTensor) (p := Pure.basisVector c b'),
+      toComplex_pure_basisVector (c := c) b',
+      evalT_pure (S := complexLorentzTensor)
+        (p := Pure.basisVector (colorToComplex ∘ c) (ComponentIdx.complexify b'))]
+    exact toComplex_evalP_basisVector i b b'
+  · simp only [evalTColorToComplex, map_zero]
+  · intro r t' ht'
+    rw [LinearMap.map_smul, toComplex_map_smul (c ∘ i.succAbove) r
+      ((evalT (S := realLorentzTensor) i b) t'),
+      ht', toComplex_map_smul (c := c) r t']
+    simp only [evalTColorToComplex, LinearMap.map_smul]
+  · intro t1 t2 h1 h2
+    rw [LinearMap.map_add, map_add, h1, h2]
+    simp only [evalTColorToComplex, LinearMap.map_add]
 
 end realLorentzTensor

--- a/Physlib/SpaceAndTime/Space/CrossProduct.lean
+++ b/Physlib/SpaceAndTime/Space/CrossProduct.lean
@@ -101,9 +101,7 @@ lemma fderiv_cross_commute {t : Time} {s : EuclideanSpace ℝ (Fin 3)}
 lemma time_deriv_cross_commute {s : EuclideanSpace ℝ (Fin 3)} {f : Time → EuclideanSpace ℝ (Fin 3)}
     (hf : Differentiable ℝ f) :
     s ⨯ₑ₃ (∂ₜ (fun t => f t) t) = ∂ₜ (fun t => s ⨯ₑ₃ (f t)) t := by
-  repeat rw [Time.deriv]
-  rw [fderiv_cross_commute]
-  fun_prop
+  simpa [Time.deriv] using fderiv_cross_commute hf
 
 /-!
 

--- a/Physlib/SpaceAndTime/Space/CrossProduct.lean
+++ b/Physlib/SpaceAndTime/Space/CrossProduct.lean
@@ -71,7 +71,7 @@ lemma fderiv_cross_commute {t : Time} {s : EuclideanSpace ℝ (Fin 3)}
         Pi.smul_apply, smul_eq_mul]
       rw [Time.fderiv_euclid, Time.fderiv_euclid]
       · intro i
-        repeat fun_prop
+        all_goals fun_prop
       · fun_prop
     · fun_prop
     · fun_prop

--- a/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
@@ -173,7 +173,7 @@ lemma deriv_add [NormedAddCommGroup M] [NormedSpace ℝ M]
   ext x
   rw [fderiv_add]
   rfl
-  repeat fun_prop
+  all_goals fun_prop
 
 /-- Derivatives on space distribute coordinate-wise over addition. -/
 lemma deriv_coord_add (f1 f2 : Space d → EuclideanSpace ℝ (Fin d))
@@ -185,7 +185,7 @@ lemma deriv_coord_add (f1 f2 : Space d → EuclideanSpace ℝ (Fin d))
   ext x
   rw [fderiv_fun_add]
   simp only [_root_.add_apply, Pi.add_apply]
-  repeat fun_prop
+  all_goals fun_prop
 
 /-- Derivatives on space distribute over subtraction. -/
 @[to_fun]
@@ -196,7 +196,7 @@ lemma deriv_sub [NormedAddCommGroup M] [NormedSpace ℝ M]
   ext x
   rw [fderiv_sub]
   rfl
-  repeat fun_prop
+  all_goals fun_prop
 
 /-!
 
@@ -247,7 +247,7 @@ lemma deriv_commute [NormedAddCommGroup M] [NormedSpace ℝ M]
   apply ContDiffAt.isSymmSndFDerivAt
   exact ContDiff.contDiffAt hf
   simp only [minSmoothness_of_isRCLikeNormedField, le_refl]
-  repeat fun_prop
+  all_goals fun_prop
 
 /-!
 

--- a/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
@@ -529,22 +529,21 @@ lemma schwartMap_fderiv_comm {d}
     ((SchwartzMap.evalCLM ℝ (Space d) ℝ (basis ν))
       ((fderivCLM ℝ (Space d) ℝ) ((SchwartzMap.evalCLM ℝ (Space d) ℝ (basis μ))
       ((fderivCLM ℝ (Space d) ℝ) η)))) x := by
-  have h1 := η.smooth
-  have h2 := h1 2
+  have h_symm : IsSymmSndFDerivAt ℝ η x :=
+    ((η.smooth 2).contDiffAt (x := x)).isSymmSndFDerivAt (by norm_num)
+  have h_contDiff : ContDiff ℝ (2 : ℕ∞) η := η.smooth 2
+  have hd : DifferentiableAt ℝ (fderiv ℝ η) x := by
+    have hct := h_contDiff.contDiffAt (x := x)
+    have hderiv : ContDiffAt ℝ 1 (fderiv ℝ η) x := hct.fderiv_right (by norm_num)
+    exact hderiv.differentiableAt one_ne_zero
+  have hconst_μ : DifferentiableAt ℝ (fun (_ : Space d) => basis μ) x := by fun_prop
+  have hconst_ν : DifferentiableAt ℝ (fun (_ : Space d) => basis ν) x := by fun_prop
   change fderiv ℝ (fun x => fderiv ℝ η x (basis ν)) x (basis μ) =
     fderiv ℝ (fun x => fderiv ℝ η x (basis μ)) x (basis ν)
-  rw [fderiv_clm_apply, fderiv_clm_apply]
+  rw [fderiv_clm_apply hd hconst_ν, fderiv_clm_apply hd hconst_μ]
   simp only [fderiv_fun_const, Pi.ofNat_apply, ContinuousLinearMap.comp_zero, zero_add,
     ContinuousLinearMap.flip_apply]
-  rw [IsSymmSndFDerivAt.eq]
-  apply ContDiffAt.isSymmSndFDerivAt (n := 2)
-  · refine ContDiff.contDiffAt ?_
-    exact h2
-  · simp
-  · fun_prop
-  · exact differentiableAt_const (basis μ)
-  · fun_prop
-  · exact differentiableAt_const (basis ν)
+  rw [IsSymmSndFDerivAt.eq h_symm]
 
 lemma distDeriv_commute {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
     (μ ν : Fin d) (f : (Space d) →d[ℝ] M) :

--- a/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
@@ -171,9 +171,8 @@ lemma deriv_add [NormedAddCommGroup M] [NormedSpace ℝ M]
     ∂[u] (f1 + f2) = ∂[u] f1 + ∂[u] f2 := by
   rw [deriv_eq_fderiv_fun]
   ext x
-  rw [fderiv_add]
+  rw [fderiv_add (hf1 x) (hf2 x)]
   rfl
-  all_goals fun_prop
 
 /-- Derivatives on space distribute coordinate-wise over addition. -/
 lemma deriv_coord_add (f1 f2 : Space d → EuclideanSpace ℝ (Fin d))
@@ -181,10 +180,9 @@ lemma deriv_coord_add (f1 f2 : Space d → EuclideanSpace ℝ (Fin d))
     (∂[u] (fun x => f1 x i + f2 x i)) =
       (∂[u] (fun x => f1 x i)) + (∂[u] (fun x => f2 x i)) := by
   rw [deriv_eq_fderiv_fun, deriv_eq_fderiv_fun, deriv_eq_fderiv_fun]
-  simp only
   ext x
-  rw [fderiv_fun_add]
-  simp only [_root_.add_apply, Pi.add_apply]
+  rw [fderiv_fun_add, _root_.add_apply]
+  simp
   all_goals fun_prop
 
 /-- Derivatives on space distribute over subtraction. -/
@@ -194,9 +192,8 @@ lemma deriv_sub [NormedAddCommGroup M] [NormedSpace ℝ M]
     ∂[u] (f1 - f2) = ∂[u] f1 - ∂[u] f2 := by
   rw [deriv_eq_fderiv_fun]
   ext x
-  rw [fderiv_sub]
+  rw [fderiv_sub (hf1 x) (hf2 x)]
   rfl
-  all_goals fun_prop
 
 /-!
 

--- a/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
@@ -93,8 +93,7 @@ lemma deriv_eq_fderiv_basis [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
 lemma fderiv_eq_sum_deriv {M d} [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
     (f : Space d → M) (x y : Space d) :
     fderiv ℝ f x y = ∑ i : Fin d, y i • ∂[i] f x := by
-  have h1 : y = ∑ i, y i • basis i := by
-    exact Eq.symm (OrthonormalBasis.sum_repr basis y)
+  have h1 : y = ∑ i, y i • basis i := (OrthonormalBasis.sum_repr basis y).symm
   conv_lhs => rw [h1]
   simp [deriv_eq_fderiv_basis]
 
@@ -111,13 +110,11 @@ open Manifold in
 lemma mdifferentiable_manifoldStructure_iff_differentiable {M d} [NormedAddCommGroup M]
     [NormedSpace ℝ M] {f : Space d → M} {x : Space d} :
     MDifferentiableAt (𝓡 d) 𝓘(ℝ, M) f x ↔ DifferentiableAt ℝ f x := by
-  constructor
-  · intro h
-    rw [← mdifferentiableAt_iff_differentiableAt]
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · rw [← mdifferentiableAt_iff_differentiableAt]
     apply h.comp (I' := 𝓡 d)
     exact (modelDiffeo.symm.mdifferentiable (WithTop.top_ne_zero)).mdifferentiableAt
-  · intro h
-    apply (mdifferentiableAt_iff_differentiableAt.mpr h).comp (I' := 𝓘(ℝ, Space d))
+  · apply (mdifferentiableAt_iff_differentiableAt.mpr h).comp (I' := 𝓘(ℝ, Space d))
     exact (modelDiffeo.mdifferentiable (WithTop.top_ne_zero)).mdifferentiableAt
 
 TODO "Make the version of the derivative described through
@@ -155,8 +152,7 @@ lemma deriv_eq_mfderiv_manifoldStructure {M d} [NormedAddCommGroup M] [NormedSpa
 @[simp]
 lemma deriv_const [NormedAddCommGroup M] [NormedSpace ℝ M] (m : M) (μ : Fin d) :
     deriv μ (fun _ => m) t = 0 := by
-  rw [deriv]
-  simp
+  simp [deriv]
 
 /-!
 
@@ -180,10 +176,11 @@ lemma deriv_coord_add (f1 f2 : Space d → EuclideanSpace ℝ (Fin d))
     (∂[u] (fun x => f1 x i + f2 x i)) =
       (∂[u] (fun x => f1 x i)) + (∂[u] (fun x => f2 x i)) := by
   rw [deriv_eq_fderiv_fun, deriv_eq_fderiv_fun, deriv_eq_fderiv_fun]
+  simp only
   ext x
-  rw [fderiv_fun_add, _root_.add_apply]
-  simp
-  all_goals fun_prop
+  rw [fderiv_fun_add]
+  simp only [_root_.add_apply, Pi.add_apply]
+  repeat fun_prop
 
 /-- Derivatives on space distribute over subtraction. -/
 @[to_fun]
@@ -215,8 +212,7 @@ lemma deriv_const_smul [NormedAddCommGroup M] [NormedSpace ℝ M] [Semiring R]
     (h : Differentiable ℝ f) : ∂[u] (c • f) = c • ∂[u] f := by
   rw [deriv_eq_fderiv_fun, deriv_eq_fderiv_fun]
   ext x
-  rw [fderiv_const_smul, FunLike.coe_smul, Pi.smul_apply, Pi.smul_apply]
-  fun_prop
+  rw [fderiv_const_smul (h x), FunLike.coe_smul, Pi.smul_apply, Pi.smul_apply]
 
 /-- Coordinate-wise scalar multiplication on space derivatives. -/
 lemma deriv_coord_smul (f : Space d → EuclideanSpace ℝ (Fin d)) (k : ℝ)
@@ -241,10 +237,9 @@ lemma deriv_commute [NormedAddCommGroup M] [NormedSpace ℝ M]
   simp only [fderiv_fun_const, Pi.ofNat_apply, ContinuousLinearMap.comp_zero, zero_add,
     ContinuousLinearMap.flip_apply]
   rw [IsSymmSndFDerivAt.eq]
-  apply ContDiffAt.isSymmSndFDerivAt
-  exact ContDiff.contDiffAt hf
+  refine hf.contDiffAt.isSymmSndFDerivAt ?_
   simp only [minSmoothness_of_isRCLikeNormedField, le_refl]
-  all_goals fun_prop
+  repeat fun_prop
 
 /-!
 
@@ -276,10 +271,8 @@ lemma deriv_component (μ ν : Fin d) (x : Space d) :
   by_cases h' : ν = μ
   · subst h'
     simp
-  · rw [deriv_component_diff ν μ]
-    simp only [right_eq_ite_iff, zero_ne_one, imp_false]
-    simpa using h'
-    simpa using h'
+  · rw [deriv_component_diff ν μ x h']
+    simp [h']
 
 /-!
 
@@ -289,8 +282,7 @@ lemma deriv_component (μ ν : Fin d) (x : Space d) :
 
 lemma deriv_component_sq {d : ℕ} {ν μ : Fin d} (x : Space d) :
     (deriv ν (fun x => (x μ) ^ 2) x) = if ν = μ then 2 * x μ else 0:= by
-  rw [deriv_eq_fderiv_basis]
-  rw [fderiv_fun_pow]
+  rw [deriv_eq_fderiv_basis, fderiv_fun_pow]
   simp only [Nat.add_one_sub_one, pow_one, nsmul_eq_mul, Nat.cast_ofNat,
     FunLike.coe_smul, Pi.smul_apply, smul_eq_mul]
   rw [← deriv_eq_fderiv_basis, deriv_component]
@@ -351,8 +343,7 @@ lemma norm_sq_differentiable : Differentiable ℝ (fun x : Space d => ‖x‖ ^ 
 lemma deriv_norm_sq (x : Space d) (i : Fin d) :
     deriv i (fun x => ‖x‖ ^ 2) x = 2 * x i := by
   simp [Space.norm_sq_eq]
-  rw [deriv_eq_fderiv_basis]
-  rw [fderiv_fun_sum]
+  rw [deriv_eq_fderiv_basis, fderiv_fun_sum]
   simp only [FunLike.coe_sum, Finset.sum_apply]
   conv_lhs =>
     enter [2, j]
@@ -385,8 +376,8 @@ lemma inner_differentiable {d : ℕ} :
 
 @[fun_prop]
 lemma inner_differentiableAt {d : ℕ} (x : Space d) :
-    DifferentiableAt ℝ (fun y : Space d => ⟪y, y⟫_ℝ) x := by
-  apply inner_differentiable.differentiableAt
+    DifferentiableAt ℝ (fun y : Space d => ⟪y, y⟫_ℝ) x :=
+  inner_differentiable.differentiableAt
 
 @[fun_prop]
 lemma inner_apply_differentiableAt {d : ℕ} [NormedAddCommGroup M]
@@ -423,8 +414,7 @@ lemma inner_apply_contDiff {n : WithTop ℕ∞} {d : ℕ} [NormedAddCommGroup M]
 
 lemma deriv_eq_inner_self (x : Space d) (i : Fin d) :
     deriv i (fun x => ⟪x, x⟫_ℝ) x = 2 * x i := by
-  convert deriv_norm_sq x i
-  exact real_inner_self_eq_norm_sq _
+  simpa only [real_inner_self_eq_norm_sq] using deriv_norm_sq x i
 
 /-!
 
@@ -435,8 +425,7 @@ lemma deriv_eq_inner_self (x : Space d) (i : Fin d) :
 @[simp]
 lemma deriv_inner_left {d} (x1 x2 : Space d) (i : Fin d) :
     deriv i (fun x => ⟪x, x2⟫_ℝ) x1 = x2 i := by
-  rw [deriv_eq_fderiv_basis]
-  rw [fderiv_inner_apply]
+  rw [deriv_eq_fderiv_basis, fderiv_inner_apply]
   simp only [fderiv_fun_const, Pi.zero_apply, _root_.zero_apply, inner_zero_right,
     fderiv_fun_id, ContinuousLinearMap.coe_id', id_eq, basis_inner, zero_add]
   · fun_prop
@@ -445,8 +434,7 @@ lemma deriv_inner_left {d} (x1 x2 : Space d) (i : Fin d) :
 @[simp]
 lemma deriv_inner_right {d} (x1 x2 : Space d) (i : Fin d) :
     deriv i (fun x => ⟪x1, x⟫_ℝ) x2 = x1 i := by
-  rw [deriv_eq_fderiv_basis]
-  rw [fderiv_inner_apply]
+  rw [deriv_eq_fderiv_basis, fderiv_inner_apply]
   simp only [fderiv_fun_id, ContinuousLinearMap.coe_id', id_eq, inner_basis, fderiv_fun_const,
     Pi.ofNat_apply, _root_.zero_apply, inner_zero_left, add_zero]
   · fun_prop
@@ -461,7 +449,7 @@ lemma deriv_differentiable {M} [NormedAddCommGroup M]
     [NormedSpace ℝ M] {d : ℕ} {f : Space d → M}
     (hf : ContDiff ℝ 2 f) (i : Fin d) :
     Differentiable ℝ (deriv i f) := by
-  suffices h1 : Differentiable ℝ (fun x => fderiv ℝ f x (basis i)) by exact h1
+  unfold deriv
   fun_prop
 
 open ContDiff
@@ -529,21 +517,19 @@ lemma schwartMap_fderiv_comm {d}
     ((SchwartzMap.evalCLM ℝ (Space d) ℝ (basis ν))
       ((fderivCLM ℝ (Space d) ℝ) ((SchwartzMap.evalCLM ℝ (Space d) ℝ (basis μ))
       ((fderivCLM ℝ (Space d) ℝ) η)))) x := by
-  have h_symm : IsSymmSndFDerivAt ℝ η x :=
-    ((η.smooth 2).contDiffAt (x := x)).isSymmSndFDerivAt (by norm_num)
-  have h_contDiff : ContDiff ℝ (2 : ℕ∞) η := η.smooth 2
-  have hd : DifferentiableAt ℝ (fderiv ℝ η) x := by
-    have hct := h_contDiff.contDiffAt (x := x)
-    have hderiv : ContDiffAt ℝ 1 (fderiv ℝ η) x := hct.fderiv_right (by norm_num)
-    exact hderiv.differentiableAt one_ne_zero
-  have hconst_μ : DifferentiableAt ℝ (fun (_ : Space d) => basis μ) x := by fun_prop
-  have hconst_ν : DifferentiableAt ℝ (fun (_ : Space d) => basis ν) x := by fun_prop
+  have h2 := η.smooth 2
   change fderiv ℝ (fun x => fderiv ℝ η x (basis ν)) x (basis μ) =
     fderiv ℝ (fun x => fderiv ℝ η x (basis μ)) x (basis ν)
-  rw [fderiv_clm_apply hd hconst_ν, fderiv_clm_apply hd hconst_μ]
+  rw [fderiv_clm_apply, fderiv_clm_apply]
   simp only [fderiv_fun_const, Pi.ofNat_apply, ContinuousLinearMap.comp_zero, zero_add,
     ContinuousLinearMap.flip_apply]
-  rw [IsSymmSndFDerivAt.eq h_symm]
+  rw [IsSymmSndFDerivAt.eq]
+  refine h2.contDiffAt.isSymmSndFDerivAt ?_
+  · simp
+  · fun_prop
+  · exact differentiableAt_const (basis μ)
+  · fun_prop
+  · exact differentiableAt_const (basis ν)
 
 lemma distDeriv_commute {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
     (μ ν : Fin d) (f : (Space d) →d[ℝ] M) :

--- a/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
@@ -132,15 +132,13 @@ lemma curl_smul (f : Space → EuclideanSpace ℝ (Fin 3)) (k : ℝ)
 @[to_fun]
 lemma curl_neg (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : Differentiable ℝ f) :
     ∇ ⨯ (-f) = -∇ ⨯ f := by
-  rw [← neg_one_smul ℝ, curl_smul, neg_one_smul]
-  · exact hf
+  simpa using curl_smul f (-1) hf
 
 @[to_fun]
 lemma curl_sub (f1 f2 : Space → EuclideanSpace ℝ (Fin 3))
     (hf1 : Differentiable ℝ f1) (hf2 : Differentiable ℝ f2) :
     ∇ ⨯ (f1 - f2) = ∇ ⨯ f1 - ∇ ⨯ f2 := by
-  rw [sub_eq_add_neg, curl_add, curl_neg, sub_eq_add_neg]
-  repeat fun_prop
+  rw [sub_eq_add_neg, curl_add f1 (-f2) hf1 hf2.neg, curl_neg f2 hf2, sub_eq_add_neg]
 
 /-!
 

--- a/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
@@ -127,7 +127,7 @@ lemma curl_smul (f : Space → EuclideanSpace ℝ (Fin 3)) (k : ℝ)
   ext x i
   simp only [Fin.isValue, Pi.smul_apply, PiLp.smul_apply, smul_eq_mul]
   rw [deriv_coord_smul, deriv_coord_smul, mul_sub]
-  repeat fun_prop
+  all_goals fun_prop
 
 @[to_fun]
 lemma curl_neg (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : Differentiable ℝ f) :
@@ -156,7 +156,7 @@ lemma curl_linear_map (f : W → Space 3 → EuclideanSpace ℝ (Fin 3))
   · intro w w'
     rw [hf'.map_add]
     rw [curl_add]
-    repeat fun_prop
+    all_goals fun_prop
   · intros k w
     rw [hf'.map_smul]
     rw [curl_smul]
@@ -178,7 +178,7 @@ lemma deriv_coord_2nd_add (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
   rw [fderiv_fun_add, fderiv_fun_add]
   simp only [_root_.add_apply, Pi.add_apply]
   ring
-  repeat fun_prop
+  all_goals fun_prop
 
 /-- Second derivatives distribute coordinate-wise over subtraction (two components for curl). -/
 lemma deriv_coord_2nd_sub (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContDiff ℝ 2 f) :
@@ -189,7 +189,7 @@ lemma deriv_coord_2nd_sub (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
   simp only [Pi.sub_apply]
   rw [fderiv_fun_sub]
   simp only [FunLike.coe_sub, Pi.sub_apply]
-  repeat fun_prop
+  all_goals fun_prop
 
 /-!
 

--- a/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
@@ -517,59 +517,28 @@ lemma eq_neg_curl_of_div_zero (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : C
     rw [← hi]
     congr
     funext t
-    have hdiv : div f (t • x) = 0 := by simp [hdiv]
-    rw [div_eq_sum_fderiv _ (by fun_prop)] at hdiv
-    simp [Fin.sum_univ_three] at hdiv
+    have hdiv' : div f (t • x) = 0 := by simp [hdiv]
+    rw [div_eq_sum_fderiv _ (by fun_prop)] at hdiv'
+    simp [Fin.sum_univ_three] at hdiv'
     have hx : x = ∑ i, basis.repr x i • basis i :=
       Eq.symm (OrthonormalBasis.sum_repr basis x)
     conv_rhs =>
       enter [2, 2,1, 1, 2]
       rw [hx]
-  · linear_combination (norm := {simp [Fin.sum_univ_three]; ring}) - t ^ 2 * x 0 * hdiv
-  · linear_combination (norm := {simp [Fin.sum_univ_three]; ring}) - t ^ 2 * x 1 * hdiv
-  · linear_combination (norm := {simp [Fin.sum_univ_three]; ring}) - t ^ 2 * x 2 * hdiv
+  · linear_combination (norm := {simp [Fin.sum_univ_three]; ring}) - t ^ 2 * x 0 * hdiv'
+  · linear_combination (norm := {simp [Fin.sum_univ_three]; ring}) - t ^ 2 * x 1 * hdiv'
+  · linear_combination (norm := {simp [Fin.sum_univ_three]; ring}) - t ^ 2 * x 2 * hdiv'
 
 lemma exists_curl_of_div_zero (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContDiff ℝ 1 f)
     (hdiv : ∇ ⬝ f = 0) :
     ∃ g : Space → EuclideanSpace ℝ (Fin 3), f = curl g ∧ Differentiable ℝ g := by
-  suffices hneg : ∃ g: Space → EuclideanSpace ℝ (Fin 3), f = - curl g ∧ Differentiable ℝ g by
-    obtain ⟨g, hcurl, hdifferentiable⟩ := hneg
-    use -g
-    subst f
-    simp_all
-    rw [curl_neg]
-    fun_prop
-  have f_differentiable : Differentiable ℝ f := hf.differentiable (by simp)
-  have fderiv_f_t (x : Space) (t : ℝ)
-      (i : Fin 3) : (fderiv ℝ (fun t => (f (t • x)).ofLp i) t) 1 = fderiv ℝ f (t • x) x i := by
-    change (fderiv ℝ (EuclideanSpace.proj i ∘ f ∘ fun (t : ℝ) => t • x) t) 1 = _
-    rw [fderiv_comp _ (by fun_prop) (by fun_prop), fderiv_comp _ (by fun_prop) (by fun_prop),
-      fderiv_fun_smul (by fun_prop) (by fun_prop)]
-    simp only [Function.comp_apply, ContinuousLinearMap.fderiv, fderiv_fun_const, Pi.zero_apply,
-      fderiv_fun_id, ContinuousLinearMap.coe_comp, _root_.add_apply,
-      FunLike.coe_smul, Pi.smul_apply, _root_.zero_apply, smul_zero,
-      ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.coe_id', id_eq, one_smul, zero_add,
-      PiLp.proj_apply]
-  have hi (x : Space) (i : Fin 3) : ∫ (t : ℝ) in 0..1, (t * f (t • x) i * 2) -
-        t * (- fderiv ℝ f (t • x) (t • x)) i ∂(volume) = f x i := by
-    trans ∫ (t : ℝ) in 0..1, fderiv ℝ (fun t => t ^ 2 * f (t • x) i) t 1 ∂(volume)
-    · congr
-      funext t
-      rw [fderiv_fun_mul (by fun_prop) (by fun_prop)]
-      simp [fderiv_f_t]
-      ring
-    simp only [fderiv_eq_smul_deriv, smul_eq_mul, one_mul]
-    rw [intervalIntegral.integral_deriv_eq_sub (by fun_prop)]
-    simp only [one_pow, one_smul, one_mul, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow,
-      zero_smul, zero_mul, sub_zero]
-    · apply Continuous.intervalIntegrable
-      fun_prop
-  use fun x => ∫ (t : ℝ) in 0..1, homotopyOperatorIntegrand f x t ∂(volume)
-  apply And.intro
-  swap
-  · intro x
-    exact (hasFDerivAt_intervalIntegral_homotopyOperatorIntegrand (hf) _).differentiableAt
-  · exact eq_neg_curl_of_div_zero f hf hdiv
+  have h := eq_neg_curl_of_div_zero f hf hdiv
+  let g := fun x => ∫ (t : ℝ) in 0..1, homotopyOperatorIntegrand f x t ∂(volume)
+  have hg_diff : Differentiable ℝ g := by
+    intro x
+    exact (hasFDerivAt_intervalIntegral_homotopyOperatorIntegrand hf _).differentiableAt
+  have h_eq : f = curl (-g) := h.trans (curl_neg g hg_diff).symm
+  exact ⟨-g, h_eq, hg_diff.neg⟩
 
 TODO "Generalize the statement that a div-free field is a curl
   to time-dependent fields."

--- a/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
@@ -205,13 +205,11 @@ lemma div_of_curl_eq_zero (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
     Fin.reduceAdd, Fin.succ_one_eq_two, List.ofFn_zero, Multiset.sum_coe, List.sum_cons,
     List.sum_nil, add_zero, Pi.ofNat_apply]
   rw [deriv_coord_2nd_sub, deriv_coord_2nd_sub, deriv_coord_2nd_sub]
-  simp only [Fin.isValue, Pi.sub_apply]
+  simp only [Pi.sub_apply]
   rw [deriv_commute fun x => f x 0, deriv_commute fun x => f x 1,
     deriv_commute fun x => f x 2]
-  simp only [Fin.isValue, sub_add_sub_cancel', sub_self]
-  repeat
-    try apply contDiff_euclidean.mp
-    exact hf
+  simp only [sub_add_sub_cancel', sub_self]
+  all_goals fun_prop
 
 /-!
 
@@ -242,14 +240,13 @@ lemma curl_of_curl (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContDiff ℝ
   ext x i
   fin_cases i <;>
   · simp only [Fin.reduceFinMk, Fin.isValue, Fin.reduceAdd, zero_add, Pi.sub_apply, PiLp.sub_apply]
-    rw [deriv_coord_2nd_sub, deriv_coord_2nd_sub]
+    rw [deriv_coord_2nd_sub, deriv_coord_2nd_sub, deriv_coord_2nd_add]
     simp only [Fin.isValue, Pi.sub_apply]
-    rw [deriv_coord_2nd_add]
     rw [deriv_commute fun x => f x 0, deriv_commute fun x => f x 1,
       deriv_commute fun x => f x 2]
     simp only [Fin.isValue, Pi.add_apply]
     ring
-    repeat fun_prop
+    all_goals fun_prop
 
 /-!
 

--- a/Physlib/SpaceAndTime/Space/Derivatives/Div.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Div.lean
@@ -156,13 +156,9 @@ lemma div_linear_map (f : W → Space 3 → EuclideanSpace ℝ (Fin 3))
     IsLinearMap ℝ (fun w => ∇ ⬝ (f w)) := by
   constructor
   · intro w w'
-    rw [hf'.map_add]
-    rw [div_add]
-    all_goals fun_prop
+    rw [hf'.map_add, div_add (f1 := f w) (f2 := f w') (hf1 := hf w) (hf2 := hf w')]
   · intros k w
-    rw [hf'.map_smul]
-    rw [div_smul]
-    fun_prop
+    rw [hf'.map_smul, div_smul (f := f w) (hf := hf w)]
 
 /-!
 

--- a/Physlib/SpaceAndTime/Space/Derivatives/Div.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Div.lean
@@ -158,7 +158,7 @@ lemma div_linear_map (f : W → Space 3 → EuclideanSpace ℝ (Fin 3))
   · intro w w'
     rw [hf'.map_add]
     rw [div_add]
-    repeat fun_prop
+    all_goals fun_prop
   · intros k w
     rw [hf'.map_smul]
     rw [div_smul]

--- a/Physlib/SpaceAndTime/Space/Norm/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Norm/Basic.lean
@@ -529,11 +529,11 @@ lemma gradient_dist_normPowerSeries_zpow {d : ℕ} {n : ℕ} (m : ℤ) :
       congr
       funext x
       rw [fderiv_normPowerSeries_zpow]
-  congr
-  funext x
+  refine MeasureTheory.integral_congr_ae ?_
+  filter_upwards with x
   simp [inner_smul_left_eq_smul]
   left
-  rw [real_inner_comm, basis_repr_inner_eq]
+  rw [real_inner_comm x (basis.repr.symm y), ← basis_repr_inner_eq x y]
   ring
 
 /-!
@@ -584,7 +584,7 @@ lemma gradient_dist_normPowerSeries_zpow_tendsTo_distGrad_norm {d : ℕ} [NeZero
     simp at hx
     simp
     apply mul_le_mul (by rfl) _ (by positivity) (by positivity)
-    rw [abs_of_nonneg (by simp)]
+    rw [abs_of_nonneg (normPowerSeries_nonneg n x)]
     exact normPowerSeries_zpow_le_norm_sq_add_one n m x hx
   · rw [Filter.eventually_iff_exists_mem]
     use {0}ᶜ
@@ -593,14 +593,7 @@ lemma gradient_dist_normPowerSeries_zpow_tendsTo_distGrad_norm {d : ℕ} [NeZero
     intro x hx
     apply Filter.Tendsto.mul
     · exact tendsto_const_nhds
-    have h1 : Filter.Tendsto (fun x_1 => normPowerSeries x_1 x ^ (m : ℝ))
-      Filter.atTop (𝓝 (‖x‖ ^ (m : ℝ))) := by
-      refine Filter.Tendsto.rpow ?_ ?_ ?_
-      · apply normPowerSeries_tendsto x hx
-      · simp
-      · left
-        simpa using hx
-    simpa using h1
+    exact (normPowerSeries_tendsto x hx).zpow₀ m (Or.inl (norm_ne_zero_iff.mpr hx))
 
 lemma gradient_dist_normPowerSeries_zpow_tendsTo {d : ℕ} [NeZero d] (m : ℤ)
     (hm : - (d - 1 : ℕ) + 1 ≤ m)
@@ -690,35 +683,29 @@ lemma gradient_dist_normPowerSeries_zpow_tendsTo {d : ℕ} [NeZero d] (m : ℤ)
     intro x hx
     simp at hx
     simp [mul_assoc]
-    apply mul_le_mul (by rfl) _ (by positivity) (by positivity)
-    apply mul_le_mul (by rfl) _ (by positivity) (by positivity)
-    apply mul_le_mul (by rfl) _ (by positivity) (by positivity)
-    rw [abs_of_nonneg (by simp)]
+    refine mul_le_mul_of_nonneg_left ?_ (by positivity)
+    refine mul_le_mul_of_nonneg_left ?_ (by positivity)
+    refine mul_le_mul_of_nonneg_left ?_ (by positivity)
+    have h_abs : |normPowerSeries n x| = normPowerSeries n x :=
+      abs_of_nonneg (normPowerSeries_nonneg n x)
+    rw [h_abs]
     exact normPowerSeries_zpow_le_norm_sq_add_one n (m - 2) x hx
   · rw [Filter.eventually_iff_exists_mem]
     use {0}ᶜ
     constructor
     · rw [compl_mem_ae_iff, measure_singleton]
     intro x hx
-    apply Filter.Tendsto.mul
-    · exact tendsto_const_nhds
-    simp [inner_smul_left, mul_assoc]
-    apply Filter.Tendsto.mul
-    · exact tendsto_const_nhds
-    ring_nf
-    apply Filter.Tendsto.mul
-    · exact tendsto_const_nhds
-    have h1 : Filter.Tendsto (fun x_1 => normPowerSeries x_1 x ^ ((m - 2 : ℤ) : ℝ))
-      Filter.atTop (𝓝 (‖x‖ ^ ((m - 2 : ℤ) : ℝ))) := by
-      refine Filter.Tendsto.rpow ?_ ?_ ?_
-      · apply normPowerSeries_tendsto x hx
-      · simp
-      · left
-        simpa using hx
-    simp [-Int.cast_sub, Real.rpow_intCast] at h1
-    convert h1 using 3
-    · ring
-    · ring
+    simp at hx
+    have h1 : Filter.Tendsto (fun n => normPowerSeries n x ^ (m - 2))
+      Filter.atTop (𝓝 (‖x‖ ^ (m - 2))) :=
+      (normPowerSeries_tendsto x hx).zpow₀ (m - 2) (Or.inl (norm_ne_zero_iff.mpr hx))
+    have h_mul : Filter.Tendsto (fun n => (η x * (m : ℝ) * ⟪basis.repr x, y⟫_ℝ) *
+        (normPowerSeries n x ^ (m - 2))) Filter.atTop
+        (𝓝 ((η x * (m : ℝ) * ⟪basis.repr x, y⟫_ℝ) * (‖x‖ ^ (m - 2)))) :=
+      tendsto_const_nhds.mul h1
+    convert h_mul using 1
+    · ring_nf
+    · simp [inner_smul_left, mul_assoc, mul_comm, mul_left_comm]
 
 /-!
 
@@ -754,12 +741,11 @@ lemma gradient_dist_normPowerSeries_log {d : ℕ} {n : ℕ} :
       congr
       funext x
       rw [fderiv_log_normPowerSeries]
-  congr
-  funext x
+  refine MeasureTheory.integral_congr_ae ?_
+  filter_upwards with x
   simp [inner_smul_left_eq_smul]
   left
-  rw [real_inner_comm]
-  rw [basis_repr_inner_eq]
+  rw [real_inner_comm x (basis.repr.symm y), ← basis_repr_inner_eq x y]
   ring
 
 /-!
@@ -808,7 +794,7 @@ lemma gradient_dist_normPowerSeries_log_tendsTo_distGrad_norm {d : ℕ} (hd : 2 
     intro x hx
     simp at hx
     simp
-    apply mul_le_mul (by rfl) _ (by positivity) (by positivity)
+    refine mul_le_mul_of_nonneg_left ?_ (abs_nonneg _)
     exact normPowerSeries_log_le n x hx
   · rw [Filter.eventually_iff_exists_mem]
     use {0}ᶜ
@@ -817,9 +803,7 @@ lemma gradient_dist_normPowerSeries_log_tendsTo_distGrad_norm {d : ℕ} (hd : 2 
     intro x hx
     apply Filter.Tendsto.mul
     · exact tendsto_const_nhds
-    apply Filter.Tendsto.log
-    · exact normPowerSeries_tendsto x hx
-    · simpa using hx
+    exact (normPowerSeries_tendsto x hx).log (norm_ne_zero_iff.mpr hx)
 
 lemma gradient_dist_normPowerSeries_log_tendsTo {d : ℕ} (hd : 2 ≤ d)
     (η : 𝓢(Space d, ℝ)) (y : EuclideanSpace ℝ (Fin d)) :
@@ -882,27 +866,26 @@ lemma gradient_dist_normPowerSeries_log_tendsTo {d : ℕ} (hd : 2 ≤ d)
     simp [mul_assoc]
     apply mul_le_mul (by rfl) _ (by positivity) (by positivity)
     apply mul_le_mul (by rfl) _ (by positivity) (by positivity)
-    rw [abs_of_nonneg (by simp)]
-    exact normPowerSeries_zpow_le_norm_sq_add_one n (- 2 : ℤ) x hx
+    have h_abs : |normPowerSeries n x| = normPowerSeries n x :=
+      abs_of_nonneg (normPowerSeries_nonneg n x)
+    rw [h_abs]
+    exact normPowerSeries_zpow_le_norm_sq_add_one n (-2 : ℤ) x hx
   · rw [Filter.eventually_iff_exists_mem]
     use {0}ᶜ
     constructor
     · rw [compl_mem_ae_iff, measure_singleton]
     intro x hx
-    apply Filter.Tendsto.mul
-    · exact tendsto_const_nhds
-    simp [inner_smul_left, inner_smul_left]
-    rw [mul_comm]
-    apply Filter.Tendsto.mul
-    · exact tendsto_const_nhds
-    have h1 : Filter.Tendsto (fun x_1 => normPowerSeries x_1 x ^ ((- 2 : ℤ) : ℝ))
-      Filter.atTop (𝓝 (‖x‖ ^ ((- 2 : ℤ) : ℝ))) := by
-      refine Filter.Tendsto.rpow ?_ ?_ ?_
-      · apply normPowerSeries_tendsto x hx
-      · simp
-      · left
-        simpa using hx
-    simpa using h1
+    simp at hx
+    have h1 : Filter.Tendsto (fun n => normPowerSeries n x ^ (-2 : ℤ))
+      Filter.atTop (𝓝 (‖x‖ ^ (-2 : ℤ))) :=
+      (normPowerSeries_tendsto x hx).zpow₀ (-2) (Or.inl (norm_ne_zero_iff.mpr hx))
+    have h_mul : Filter.Tendsto (fun n => (η x * ⟪basis.repr x, y⟫_ℝ) *
+        (normPowerSeries n x ^ (-2 : ℤ))) Filter.atTop
+        (𝓝 ((η x * ⟪basis.repr x, y⟫_ℝ) * (‖x‖ ^ (-2 : ℤ)))) :=
+      tendsto_const_nhds.mul h1
+    convert h_mul using 1
+    · ring_nf
+    · simp [inner_smul_left, mul_comm, mul_left_comm]
 
 /-!
 

--- a/Physlib/SpaceAndTime/Space/Norm/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Norm/Basic.lean
@@ -1409,13 +1409,11 @@ lemma distLaplacian_fundamentalSolution_norm_zpow {d : ℕ} :
             (fun x : Space d =>
               ‖x‖ ^ (- (d : ℤ)) • basis.repr x)
             (IsDistBounded.zpow_smul_repr_self (- (d : ℤ)) (by omega)) := by
-      convert distOfFunction_smul_fun
+      simpa [smul_smul] using distOfFunction_smul_fun
         (fun x : Space d =>
           ‖x‖ ^ (- (d : ℤ)) • basis.repr x)
         (IsDistBounded.zpow_smul_repr_self (- (d : ℤ)) (by omega))
-        (2 - (d : ℝ)) using 1
-      ext x
-      simp [smul_smul]
+        (2 - (d : ℝ))
     rw [hdist]
     rw [map_smul]
     have hdiv :

--- a/Physlib/SpaceAndTime/Space/Norm/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Norm/Basic.lean
@@ -382,15 +382,12 @@ lemma IsDistBounded.normPowerSeries_log {d : ℕ} (n : ℕ) :
     IsDistBounded (d := d) (fun x => Real.log (normPowerSeries n x)) := by
   apply IsDistBounded.mono (f := fun x => (normPowerSeries n x)⁻¹ + (normPowerSeries n x))
   · fun_prop
-  · apply AEMeasurable.aestronglyMeasurable
-    fun_prop
+  · apply AEMeasurable.aestronglyMeasurable; fun_prop
   · intro x
-    simp only [Real.norm_eq_abs]
-    conv_rhs => rw [abs_of_nonneg (by
-      apply add_nonneg
-      · simp
-      · simp)]
-    exact normPowerSeries_log_le_normPowerSeries n x
+    have h := normPowerSeries_log_le_normPowerSeries n x
+    have h_nonneg : 0 ≤ (normPowerSeries n x)⁻¹ + (normPowerSeries n x) :=
+      add_nonneg (inv_nonneg.mpr (normPowerSeries_nonneg n x)) (normPowerSeries_nonneg n x)
+    simpa [Real.norm_eq_abs, abs_of_nonneg h_nonneg] using h
 
 /-!
 

--- a/Physlib/SpaceAndTime/Space/Norm/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Norm/Basic.lean
@@ -110,14 +110,8 @@ lemma normPowerSeries_eq_rpow {d} (n : ℕ) :
 lemma normPowerSeries_differentiable {d} (n : ℕ) :
     Differentiable ℝ (fun (x : Space d) => normPowerSeries n x) := by
   rw [normPowerSeries_eq_rpow]
-  refine Differentiable.rpow_const ?_ ?_
-  · refine (Differentiable.fun_add_iff_right ?_).mpr ?_
-    · apply Differentiable.norm_sq ℝ
-      fun_prop
-    · fun_prop
-  · intro x
-    have h1 : 0 < ‖x‖ ^ 2 + 1 / (↑n + 1) := by positivity
-    grind
+  refine Differentiable.rpow_const ?_ (fun x => Or.inl (by positivity))
+  fun_prop
 
 /-!
 

--- a/Physlib/SpaceAndTime/Space/Norm/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Norm/Basic.lean
@@ -739,14 +739,11 @@ lemma gradient_dist_normPowerSeries_log_tendsTo_distGrad_norm {d : ℕ} (hd : 2 
     (IsDistBounded.log_norm)) η, y⟫_ℝ)) := by
   haveI : NeZero d := ⟨by omega⟩
   simp only [distGrad_inner_eq, Distribution.fderivD_apply, distOfFunction_apply]
-  change Filter.Tendsto (fun n => -
-    ∫ (x : Space d), fderiv ℝ η x (basis.repr.symm y) * Real.log (normPowerSeries n x))
-    Filter.atTop (𝓝 (- ∫ (x : Space d), fderiv ℝ η x (basis.repr.symm y) * Real.log ‖x‖))
   apply Filter.Tendsto.neg
-  apply MeasureTheory.tendsto_integral_of_dominated_convergence
-    (bound := fun x => |fderiv ℝ η x (basis.repr.symm y)| * (‖x‖⁻¹ + (‖x‖ + 1)))
+  refine MeasureTheory.tendsto_integral_of_dominated_convergence
+    (bound := fun x => |fderiv ℝ η x (basis.repr.symm y)| * (‖x‖⁻¹ + (‖x‖ + 1))) ?_ ?_ ?_ ?_
   · intro n
-    apply IsDistBounded.aeStronglyMeasurable_fderiv_schwartzMap_smul (F := ℝ) ?_
+    refine IsDistBounded.aeStronglyMeasurable_fderiv_schwartzMap_smul (F := ℝ) ?_ _ _
     fun_prop
   · have h1 : Integrable (fun x => (fderiv ℝ (⇑η) x) (basis.repr.symm y) *
         (‖x‖⁻¹ + (‖x‖ + 1))) volume := by

--- a/Physlib/SpaceAndTime/Space/Norm/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Norm/Basic.lean
@@ -275,22 +275,20 @@ lemma norm_le_normPowerSeries {d} (n : ℕ) (x : Space d) :
 lemma normPowerSeries_zpow_le_norm_sq_add_one {d} (n : ℕ) (m : ℤ) (x : Space d)
     (hx : x ≠ 0) :
     (normPowerSeries n x) ^ m ≤ (‖x‖ + 1) ^ m + ‖x‖ ^ m := by
-  match m with
-  | .ofNat m =>
-    trans (‖x‖ + 1) ^ m
-    · simp
-      refine pow_le_pow_left₀ (by simp) ?_ m
-      exact normPowerSeries_le_norm_sq_add_one n x
-    · simp
-  | .negSucc m =>
-    trans (‖x‖ ^ (m + 1))⁻¹; swap
-    · simp
-      positivity
-    simp only [zpow_negSucc]
-    refine inv_anti₀ ?_ ?_
-    · positivity
-    refine pow_le_pow_left₀ (by simp) ?_ (m + 1)
-    exact norm_le_normPowerSeries n x
+  cases m with
+  | ofNat m =>
+    calc
+      (normPowerSeries n x) ^ m ≤ (‖x‖ + 1) ^ m :=
+        pow_le_pow_left₀ (normPowerSeries_nonneg n x) (normPowerSeries_le_norm_sq_add_one n x) m
+      _ ≤ (‖x‖ + 1) ^ m + ‖x‖ ^ m := le_add_of_nonneg_right (by positivity)
+  | negSucc m =>
+    have hpos' : 0 < ‖x‖ ^ (m + 1) := by positivity
+    calc
+      (normPowerSeries n x) ^ (Int.negSucc m) = ((normPowerSeries n x) ^ (m + 1))⁻¹ := by simp
+      _ ≤ (‖x‖ ^ (m + 1))⁻¹ := inv_anti₀ hpos'
+        (pow_le_pow_left₀ (by simp) (norm_le_normPowerSeries n x) (m + 1))
+      _ ≤ ((‖x‖ + 1) ^ (m + 1))⁻¹ + (‖x‖ ^ (m + 1))⁻¹ := le_add_of_nonneg_left (by positivity)
+      _ = (‖x‖ + 1) ^ (Int.negSucc m) + ‖x‖ ^ (Int.negSucc m) := by simp [zpow_negSucc]
 
 lemma normPowerSeries_inv_le {d} (n : ℕ) (x : Space d) (hx : x ≠ 0) :
     (normPowerSeries n x)⁻¹ ≤ ‖x‖⁻¹ := by

--- a/Physlib/SpaceAndTime/Space/Norm/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Norm/Basic.lean
@@ -361,14 +361,12 @@ lemma IsDistBounded.normPowerSeries_zpow {d : ℕ} {n : ℕ} (m : ℤ) :
 @[fun_prop]
 lemma IsDistBounded.normPowerSeries_single {d : ℕ} {n : ℕ} :
     IsDistBounded (d := d) (fun x => (normPowerSeries n x)) := by
-  convert IsDistBounded.normPowerSeries_zpow (n := n) (m := 1) using 1
-  simp
+  simpa using IsDistBounded.normPowerSeries_zpow (n := n) (m := 1)
 
 @[fun_prop]
 lemma IsDistBounded.normPowerSeries_inv {d : ℕ} {n : ℕ} :
     IsDistBounded (d := d) (fun x => (normPowerSeries n x)⁻¹) := by
-  convert normPowerSeries_zpow (n := n) (-1) using 1
-  simp
+  simpa using normPowerSeries_zpow (n := n) (-1)
 
 @[fun_prop]
 lemma IsDistBounded.normPowerSeries_deriv {d : ℕ} (n : ℕ) (i : Fin d) :
@@ -419,9 +417,7 @@ lemma differentiable_normPowerSeries_zpow {d : ℕ} {n : ℕ} (m : ℤ) :
 @[fun_prop]
 lemma differentiable_normPowerSeries_inv {d : ℕ} {n : ℕ} :
     Differentiable ℝ (fun x : Space d => (normPowerSeries n x)⁻¹) := by
-  convert differentiable_normPowerSeries_zpow (n := n) (m := -1) using 1
-  funext x
-  simp
+  simpa using differentiable_normPowerSeries_zpow (n := n) (m := -1)
 
 @[fun_prop]
 lemma differentiable_log_normPowerSeries {d : ℕ} {n : ℕ} :
@@ -582,10 +578,8 @@ lemma gradient_dist_normPowerSeries_zpow_tendsTo_distGrad_norm {d : ℕ} [NeZero
     · rw [compl_mem_ae_iff, measure_singleton]
     intro x hx
     simp at hx
-    simp
-    apply mul_le_mul (by rfl) _ (by positivity) (by positivity)
-    rw [abs_of_nonneg (normPowerSeries_nonneg n x)]
-    exact normPowerSeries_zpow_le_norm_sq_add_one n m x hx
+    simpa [abs_of_nonneg (normPowerSeries_nonneg n x)] using
+      mul_le_mul_of_nonneg_left (normPowerSeries_zpow_le_norm_sq_add_one n m x hx) (abs_nonneg _)
   · rw [Filter.eventually_iff_exists_mem]
     use {0}ᶜ
     constructor
@@ -682,30 +676,22 @@ lemma gradient_dist_normPowerSeries_zpow_tendsTo {d : ℕ} [NeZero d] (m : ℤ)
     · rw [compl_mem_ae_iff, measure_singleton]
     intro x hx
     simp at hx
-    simp [mul_assoc]
-    refine mul_le_mul_of_nonneg_left ?_ (by positivity)
-    refine mul_le_mul_of_nonneg_left ?_ (by positivity)
-    refine mul_le_mul_of_nonneg_left ?_ (by positivity)
-    have h_abs : |normPowerSeries n x| = normPowerSeries n x :=
-      abs_of_nonneg (normPowerSeries_nonneg n x)
-    rw [h_abs]
-    exact normPowerSeries_zpow_le_norm_sq_add_one n (m - 2) x hx
+    have h := normPowerSeries_zpow_le_norm_sq_add_one n (m - 2) x hx
+    have h_nonneg : 0 ≤ |η x| * |m| * |⟪basis.repr x, y⟫_ℝ| := by positivity
+    simpa [abs_of_nonneg (normPowerSeries_nonneg n x), mul_assoc] using
+      mul_le_mul_of_nonneg_left h h_nonneg
   · rw [Filter.eventually_iff_exists_mem]
     use {0}ᶜ
     constructor
     · rw [compl_mem_ae_iff, measure_singleton]
     intro x hx
-    simp at hx
-    have h1 : Filter.Tendsto (fun n => normPowerSeries n x ^ (m - 2))
-      Filter.atTop (𝓝 (‖x‖ ^ (m - 2))) :=
-      (normPowerSeries_tendsto x hx).zpow₀ (m - 2) (Or.inl (norm_ne_zero_iff.mpr hx))
-    have h_mul : Filter.Tendsto (fun n => (η x * (m : ℝ) * ⟪basis.repr x, y⟫_ℝ) *
-        (normPowerSeries n x ^ (m - 2))) Filter.atTop
-        (𝓝 ((η x * (m : ℝ) * ⟪basis.repr x, y⟫_ℝ) * (‖x‖ ^ (m - 2)))) :=
-      tendsto_const_nhds.mul h1
-    convert h_mul using 1
-    · ring_nf
-    · simp [inner_smul_left, mul_assoc, mul_comm, mul_left_comm]
+    have hx' : x ≠ 0 := by simpa using hx
+    have h : Filter.Tendsto (fun n => (η x * (m : ℝ) * ⟪basis.repr x, y⟫_ℝ) *
+      (normPowerSeries n x ^ (m - 2))) Filter.atTop
+      (𝓝 ((η x * (m : ℝ) * ⟪basis.repr x, y⟫_ℝ) * (‖x‖ ^ (m - 2)))) :=
+      (tendsto_const_nhds.mul ((normPowerSeries_tendsto x hx').zpow₀ (m - 2)
+        (Or.inl (norm_ne_zero_iff.mpr hx'))))
+    simpa [inner_smul_left, mul_assoc, mul_comm, mul_left_comm] using h
 
 /-!
 
@@ -801,9 +787,8 @@ lemma gradient_dist_normPowerSeries_log_tendsTo_distGrad_norm {d : ℕ} (hd : 2 
     constructor
     · rw [compl_mem_ae_iff, measure_singleton]
     intro x hx
-    apply Filter.Tendsto.mul
-    · exact tendsto_const_nhds
-    exact (normPowerSeries_tendsto x hx).log (norm_ne_zero_iff.mpr hx)
+    have hx' : x ≠ 0 := by simpa using hx
+    exact (tendsto_const_nhds.mul ((normPowerSeries_tendsto x hx').log (norm_ne_zero_iff.mpr hx')))
 
 lemma gradient_dist_normPowerSeries_log_tendsTo {d : ℕ} (hd : 2 ≤ d)
     (η : 𝓢(Space d, ℝ)) (y : EuclideanSpace ℝ (Fin d)) :
@@ -815,20 +800,12 @@ lemma gradient_dist_normPowerSeries_log_tendsTo {d : ℕ} (hd : 2 ≤ d)
     refine (IsDistBounded.zpow_smul_repr_self _ ?_)
     omega) η, y⟫_ℝ)) := by
   haveI : NeZero d := ⟨by omega⟩
-  conv =>
-    enter [1, n];
-    rw [gradient_dist_normPowerSeries_log]
-  simp only [distOfFunction_inner]
+  simp only [gradient_dist_normPowerSeries_log, distOfFunction_inner]
   have h1 (n : ℕ) (x : Space d) :
     η x * ⟪(normPowerSeries n x ^ (- 2 : ℤ)) • basis.repr x, y⟫_ℝ =
     η x * ((⟪basis.repr x, y⟫_ℝ * (normPowerSeries n x) ^ (- 2 : ℤ))) := by
-    simp [inner_smul_left]
-    ring_nf
-    left
-    trivial
-  conv =>
-    enter [1, n, 2, x]
-    rw [h1 n x]
+    simp [inner_smul_left, mul_comm, mul_left_comm]
+  conv => enter [1, n, 2, x]; rw [h1 n x]
   apply MeasureTheory.tendsto_integral_of_dominated_convergence
     (bound := fun x => |η x| * |⟪basis.repr x, y⟫_ℝ| * ((‖x‖ + 1) ^ (- 2 : ℤ) + ‖x‖ ^ (- 2 : ℤ)))
   · intro n
@@ -863,29 +840,22 @@ lemma gradient_dist_normPowerSeries_log_tendsTo {d : ℕ} (hd : 2 ≤ d)
     · rw [compl_mem_ae_iff, measure_singleton]
     intro x hx
     simp at hx
-    simp [mul_assoc]
-    apply mul_le_mul (by rfl) _ (by positivity) (by positivity)
-    apply mul_le_mul (by rfl) _ (by positivity) (by positivity)
-    have h_abs : |normPowerSeries n x| = normPowerSeries n x :=
-      abs_of_nonneg (normPowerSeries_nonneg n x)
-    rw [h_abs]
-    exact normPowerSeries_zpow_le_norm_sq_add_one n (-2 : ℤ) x hx
+    have h := normPowerSeries_zpow_le_norm_sq_add_one n (-2 : ℤ) x hx
+    have h_nonneg : 0 ≤ |η x| * |⟪basis.repr x, y⟫_ℝ| := by positivity
+    simpa [abs_of_nonneg (normPowerSeries_nonneg n x), mul_assoc] using
+      mul_le_mul_of_nonneg_left h h_nonneg
   · rw [Filter.eventually_iff_exists_mem]
     use {0}ᶜ
     constructor
     · rw [compl_mem_ae_iff, measure_singleton]
     intro x hx
-    simp at hx
-    have h1 : Filter.Tendsto (fun n => normPowerSeries n x ^ (-2 : ℤ))
-      Filter.atTop (𝓝 (‖x‖ ^ (-2 : ℤ))) :=
-      (normPowerSeries_tendsto x hx).zpow₀ (-2) (Or.inl (norm_ne_zero_iff.mpr hx))
-    have h_mul : Filter.Tendsto (fun n => (η x * ⟪basis.repr x, y⟫_ℝ) *
-        (normPowerSeries n x ^ (-2 : ℤ))) Filter.atTop
-        (𝓝 ((η x * ⟪basis.repr x, y⟫_ℝ) * (‖x‖ ^ (-2 : ℤ)))) :=
-      tendsto_const_nhds.mul h1
-    convert h_mul using 1
-    · ring_nf
-    · simp [inner_smul_left, mul_comm, mul_left_comm]
+    have hx' : x ≠ 0 := by simpa using hx
+    have hlim : Filter.Tendsto (fun n => (η x * ⟪basis.repr x, y⟫_ℝ) *
+      (normPowerSeries n x ^ (-2 : ℤ))) Filter.atTop
+      (𝓝 ((η x * ⟪basis.repr x, y⟫_ℝ) * (‖x‖ ^ (-2 : ℤ)))) :=
+      tendsto_const_nhds.mul ((normPowerSeries_tendsto x hx').zpow₀ (-2)
+        (Or.inl (norm_ne_zero_iff.mpr hx')))
+    simpa [inner_smul_left, mul_comm, mul_left_comm] using hlim
 
 /-!
 
@@ -1200,10 +1170,7 @@ lemma distLaplacian_distOfFunction_norm_zpow {d : ℕ} [NeZero d] (m : ℤ)
       (((m : ℝ) * (((m - 2 + d : ℤ) : ℝ))) •
         distOfFunction (fun x : Space d => ‖x‖ ^ (m - 2))
           (IsDistBounded.pow (m - 2) (by omega))) := by
-  rw [distLaplacian]
-  change ∇ᵈ ⬝ (∇ᵈ (distOfFunction (fun x : Space d => ‖x‖ ^ m)
-    (IsDistBounded.pow m (by omega)))) = _
-  rw [distGrad_distOfFunction_norm_zpow m (by omega)]
+  rw [distLaplacian, LinearMap.comp_apply, distGrad_distOfFunction_norm_zpow m (by omega)]
   have hdist :
       distOfFunction (fun x : Space d => (m * ‖x‖ ^ (m - 2)) • basis.repr x)
           (by
@@ -1217,11 +1184,7 @@ lemma distLaplacian_distOfFunction_norm_zpow {d : ℕ} [NeZero d] (m : ℤ)
     simpa [smul_smul] using distOfFunction_smul_fun
       (fun x : Space d => ‖x‖ ^ (m - 2) • basis.repr x)
       (IsDistBounded.zpow_smul_repr_self (m - 2) (by omega)) (m : ℝ)
-  rw [hdist]
-  rw [map_smul]
-  rw [distDiv_norm_zpow_smul_repr_self_eq_smul (m - 2) hdiv]
-  rw [smul_smul]
-
+  rw [hdist, map_smul, distDiv_norm_zpow_smul_repr_self_eq_smul (m - 2) hdiv, smul_smul]
 /-!
 
 ### B.5. Divergence equal dirac delta
@@ -1354,7 +1317,7 @@ lemma distDiv_inv_pow_eq_dim {d : ℕ} [NeZero d] :
       _ = η 0 * (d * (volume (α := Space d)).real (Metric.ball 0 1)) := by
           simp only [integral_const, Measure.toSphere_real_apply_univ, finrank_eq_dim, smul_eq_mul,
             mul_neg, neg_neg]
-          ring
+          ring_nf
   simp only [_root_.smul_apply, diracDelta_apply, smul_eq_mul]
   ring
 
@@ -1389,43 +1352,24 @@ lemma distLaplacian_fundamentalSolution_norm_zpow {d : ℕ} :
       linarith
     simp [hzero]
   · haveI : NeZero d := ⟨by omega⟩
-    rw [distLaplacian]
-    change ∇ᵈ ⬝ (∇ᵈ (distOfFunction
-      (fun x : Space d => ‖x‖ ^ (- ((d : ℤ) - 2)))
-      (IsDistBounded.pow (- ((d : ℤ) - 2)) (by omega)))) = _
-    rw [distGrad_distOfFunction_norm_zpow (- ((d : ℤ) - 2)) (by omega)]
+    rw [distLaplacian, LinearMap.comp_apply, distGrad_distOfFunction_norm_zpow (- ((d : ℤ) - 2)) (by omega)]
     simp only [neg_sub, Int.cast_sub, Int.cast_ofNat, Int.cast_natCast, sub_sub_cancel_left]
-    have hdist :
-        distOfFunction
-          (fun x : Space d =>
-            ((2 - (d : ℝ)) * ‖x‖ ^ (- (d : ℤ))) • basis.repr x)
-          (by
-            simpa [smul_smul] using
-              (IsDistBounded.const_fun_smul
-                (F := EuclideanSpace ℝ (Fin d))
-                (IsDistBounded.zpow_smul_repr_self (- (d : ℤ)) (by omega))
-                (2 - (d : ℝ)))) =
-          (2 - (d : ℝ)) • distOfFunction
-            (fun x : Space d =>
-              ‖x‖ ^ (- (d : ℤ)) • basis.repr x)
-            (IsDistBounded.zpow_smul_repr_self (- (d : ℤ)) (by omega)) := by
+    have hdist : distOfFunction
+        (fun x : Space d => ((2 - (d : ℝ)) * ‖x‖ ^ (- (d : ℤ))) • basis.repr x)
+        (by
+          simpa [smul_smul] using
+            (IsDistBounded.const_fun_smul
+              (F := EuclideanSpace ℝ (Fin d))
+              (IsDistBounded.zpow_smul_repr_self (- (d : ℤ)) (by omega))
+              (2 - (d : ℝ)))) =
+      (2 - (d : ℝ)) • distOfFunction
+        (fun x : Space d => ‖x‖ ^ (- (d : ℤ)) • basis.repr x)
+        (IsDistBounded.zpow_smul_repr_self (- (d : ℤ)) (by omega)) := by
       simpa [smul_smul] using distOfFunction_smul_fun
-        (fun x : Space d =>
-          ‖x‖ ^ (- (d : ℤ)) • basis.repr x)
+        (fun x : Space d => ‖x‖ ^ (- (d : ℤ)) • basis.repr x)
         (IsDistBounded.zpow_smul_repr_self (- (d : ℤ)) (by omega))
         (2 - (d : ℝ))
-    rw [hdist]
-    rw [map_smul]
-    have hdiv :
-        ∇ᵈ ⬝ (distOfFunction
-          (fun x : Space d =>
-            ‖x‖ ^ (- (d : ℤ)) • basis.repr x)
-          (IsDistBounded.zpow_smul_repr_self (- (d : ℤ)) (by omega))) =
-          (d * (volume (α := Space d)).real
-            (Metric.ball 0 1)) • diracDelta ℝ 0 := by
-      exact distDiv_inv_pow_eq_dim (d := d)
-    rw [hdiv]
-    rw [smul_smul]
+    rw [hdist, map_smul, distDiv_inv_pow_eq_dim (d := d), smul_smul]
     ring_nf
 
 /-- In dimension two the fundamental solution of the Laplacian is the logarithm: the
@@ -1434,10 +1378,7 @@ delta at the origin. -/
 lemma distLaplacian_fundamentalSolution_log_norm :
     Δᵈ (distOfFunction (fun x : Space 2 => Real.log ‖x‖) IsDistBounded.log_norm) =
       (2 * (volume (α := Space 2)).real (Metric.ball 0 1)) • diracDelta ℝ 0 := by
-  rw [distLaplacian]
-  change ∇ᵈ ⬝ (∇ᵈ (distOfFunction (fun x : Space 2 => Real.log ‖x‖)
-    IsDistBounded.log_norm)) = _
-  rw [distGrad_distOfFunction_log_norm (by norm_num)]
-  simpa only [Nat.cast_ofNat] using distDiv_inv_pow_eq_dim (d := 2)
+  rw [distLaplacian, LinearMap.comp_apply, distGrad_distOfFunction_log_norm (by norm_num)]
+  simpa using distDiv_inv_pow_eq_dim (d := 2)
 
 end Space

--- a/Physlib/SpaceAndTime/Space/Norm/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Norm/Basic.lean
@@ -1185,10 +1185,7 @@ lemma distDiv_norm_zpow_smul_repr_self_eq_smul
     _ = (((q + (d : ℤ) : ℤ) : ℝ) •
         distOfFunction (fun x : Space d => ‖x‖ ^ q)
           (IsDistBounded.pow q (by omega))) η := by
-          simp [distOfFunction_apply, mul_comm]
-          left
-          rw [← hcoef]
-          norm_num
+          simp [distOfFunction_apply, mul_comm, hcoef]
 
 /-!
 
@@ -1217,11 +1214,9 @@ lemma distLaplacian_distOfFunction_norm_zpow {d : ℕ} [NeZero d] (m : ℤ)
         (m : ℝ) • distOfFunction
           (fun x : Space d => ‖x‖ ^ (m - 2) • basis.repr x)
           (IsDistBounded.zpow_smul_repr_self (m - 2) (by omega)) := by
-    convert distOfFunction_smul_fun
+    simpa [smul_smul] using distOfFunction_smul_fun
       (fun x : Space d => ‖x‖ ^ (m - 2) • basis.repr x)
-      (IsDistBounded.zpow_smul_repr_self (m - 2) (by omega)) (m : ℝ) using 1
-    ext x
-    simp [smul_smul]
+      (IsDistBounded.zpow_smul_repr_self (m - 2) (by omega)) (m : ℝ)
   rw [hdist]
   rw [map_smul]
   rw [distDiv_norm_zpow_smul_repr_self_eq_smul (m - 2) hdiv]

--- a/Physlib/SpaceAndTime/Space/Slice.lean
+++ b/Physlib/SpaceAndTime/Space/Slice.lean
@@ -182,7 +182,7 @@ lemma fderiv_slice_symm_left_apply {d : ℕ} (i : Fin d.succ) (x : Space d) (r1 
     ContinuousLinearMap.coe_comp, ContinuousLinearEquiv.coe_coe, Function.comp_apply,
     ContinuousLinearMap.prod_apply, ContinuousLinearMap.coe_id', id_eq,
     _root_.zero_apply]
-  repeat' fun_prop
+  all_goals fun_prop
 
 @[simp]
 lemma fderiv_slice_symm_right_apply {d : ℕ} (i : Fin d.succ) (r : ℝ)
@@ -193,7 +193,7 @@ lemma fderiv_slice_symm_right_apply {d : ℕ} (i : Fin d.succ) (r : ℝ)
     ContinuousLinearMap.coe_comp, ContinuousLinearEquiv.coe_coe, Function.comp_apply,
     ContinuousLinearMap.prod_apply, _root_.zero_apply, ContinuousLinearMap.coe_id',
     id_eq]
-  repeat' fun_prop
+  all_goals fun_prop
 
 lemma fderiv_fun_slice_symm_right_apply {d : ℕ} (i : Fin d.succ) (r : ℝ)
     (x1 x2 : Space d) (f : Space d.succ → F) (hf : DifferentiableAt ℝ f ((slice i).symm (r, x1))) :

--- a/Physlib/SpaceAndTime/SpaceTime/Derivatives.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Derivatives.lean
@@ -238,19 +238,20 @@ lemma deriv_commute {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M] {d : �
     (μ ν : Fin 1 ⊕ Fin d) (f : SpaceTime d → M) (hf : ContDiff ℝ 2 f) :
     ∂_ μ (∂_ ν f) = ∂_ ν (∂_ μ f) := by
   ext x
-  show fderiv ℝ (fun y => fderiv ℝ f y (Lorentz.Vector.basis ν)) x (Lorentz.Vector.basis μ) =
+  have h_symm : IsSymmSndFDerivAt ℝ f x :=
+    (hf.contDiffAt (x := x)).isSymmSndFDerivAt (by norm_num)
+  change fderiv ℝ (fun y => fderiv ℝ f y (Lorentz.Vector.basis ν)) x (Lorentz.Vector.basis μ) =
     fderiv ℝ (fun y => fderiv ℝ f y (Lorentz.Vector.basis μ)) x (Lorentz.Vector.basis ν)
-  rw [fderiv_clm_apply, fderiv_clm_apply]
+  have hc : DifferentiableAt ℝ (fderiv ℝ f) x := by
+    have hct := hf.contDiffAt (x := x)
+    have hderiv : ContDiffAt ℝ 1 (fderiv ℝ f) x := hct.fderiv_right (by norm_num)
+    exact hderiv.differentiableAt one_ne_zero
+  have hu_μ : DifferentiableAt ℝ (fun (_ : SpaceTime d) => Lorentz.Vector.basis μ) x := by fun_prop
+  have hu_ν : DifferentiableAt ℝ (fun (_ : SpaceTime d) => Lorentz.Vector.basis ν) x := by fun_prop
+  rw [fderiv_clm_apply hc hu_ν, fderiv_clm_apply hc hu_μ]
   simp only [fderiv_fun_const, Pi.ofNat_apply, ContinuousLinearMap.comp_zero, zero_add,
     ContinuousLinearMap.flip_apply]
-  rw [IsSymmSndFDerivAt.eq]
-  · apply ContDiffAt.isSymmSndFDerivAt
-    exact hf.contDiffAt
-    simp only [minSmoothness_of_isRCLikeNormedField, le_refl]
-  · have h1 := hf.differentiable (by norm_cast); fun_prop
-  · fun_prop
-  · have h1 := hf.differentiable (by norm_cast); fun_prop
-  · fun_prop
+  rw [IsSymmSndFDerivAt.eq h_symm]
 
 /-!
 

--- a/Physlib/SpaceAndTime/SpaceTime/Derivatives.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Derivatives.lean
@@ -327,7 +327,7 @@ lemma deriv_sum_inr {d : ℕ} {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ
   · rw [← toTimeAndSpace_basis_inr (c := c)]
     simp
   · rfl
-  repeat' fun_prop
+  all_goals fun_prop
 
 lemma deriv_sum_inl {d : ℕ} {M : Type} [NormedAddCommGroup M]
     [NormedSpace ℝ M] (c : SpeedOfLight) (f : SpaceTime d → M)
@@ -357,7 +357,7 @@ lemma deriv_sum_inl {d : ℕ} {M : Type} [NormedAddCommGroup M]
   rw [← map_smul]
   rw [← toTimeAndSpace_basis_inl' (c := c)]
   simp only [Fin.isValue, ContinuousLinearEquiv.symm_apply_apply]
-  repeat' fun_prop
+  all_goals fun_prop
 
 /-!
 

--- a/Physlib/SpaceAndTime/TimeAndSpace/Basic.lean
+++ b/Physlib/SpaceAndTime/TimeAndSpace/Basic.lean
@@ -264,10 +264,7 @@ lemma time_deriv_curl_commute (fₜ : Time → Space → EuclideanSpace ℝ (Fin
        rw [Time.deriv_euclid]
        have h1 := hf.differentiable (by simp)
        fun_prop)
-    repeat' fun_prop
-    all_goals
-      apply Differentiable.differentiableAt
-      fun_prop
+    all_goals (first | fun_prop | (apply Differentiable.differentiableAt; fun_prop))
   · fun_prop
 
 /-!

--- a/Physlib/SpaceAndTime/TimeAndSpace/Basic.lean
+++ b/Physlib/SpaceAndTime/TimeAndSpace/Basic.lean
@@ -128,7 +128,7 @@ lemma fderiv_space_eq_fderiv_curry {M} [NormedAddCommGroup M] [NormedSpace ℝ M
   rw [DifferentiableAt.fderiv_prodMk]
   simp only [fderiv_fun_const, Pi.zero_apply, fderiv_fun_id, ContinuousLinearMap.prod_apply,
     _root_.zero_apply, ContinuousLinearMap.coe_id', id_eq]
-  repeat' fun_prop
+  all_goals fun_prop
 
 lemma fderiv_time_eq_fderiv_curry {M} [NormedAddCommGroup M] [NormedSpace ℝ M]
     (f : Time → Space d → M) (t dt : Time) (x : Space d)
@@ -140,7 +140,7 @@ lemma fderiv_time_eq_fderiv_curry {M} [NormedAddCommGroup M] [NormedSpace ℝ M]
   rw [DifferentiableAt.fderiv_prodMk]
   simp only [fderiv_fun_id, fderiv_fun_const, Pi.zero_apply, ContinuousLinearMap.prod_apply,
     ContinuousLinearMap.coe_id', id_eq, _root_.zero_apply]
-  repeat' fun_prop
+  all_goals fun_prop
 
 /-!
 

--- a/Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean
+++ b/Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean
@@ -425,10 +425,7 @@ lemma mathematicalPartitionFunction_add {T : Temperature} :
 @[simp]
 lemma mathematicalPartitionFunction_congr (e : ι1 ≃ᵐ ι) (T : Temperature) :
     (𝓒.congr e).mathematicalPartitionFunction T = 𝓒.mathematicalPartitionFunction T := by
-  rw [mathematicalPartitionFunction_eq_integral, mathematicalPartitionFunction_eq_integral]
-  simp only [congr]
-  rw [integral_map_equiv]
-  simp
+  simp [mathematicalPartitionFunction_eq_integral, congr, integral_map_equiv]
 
 /-- The `mathematicalPartitionFunction_nsmul` function of `n` copies of a canonical ensemble. -/
 lemma mathematicalPartitionFunction_nsmul (n : ℕ) (T : Temperature) :
@@ -719,29 +716,17 @@ lemma differentialEntropy_nonneg_of_prob_le_one
     (hInt : Integrable (fun i => Real.log (𝓒.probability T i)) (𝓒.μProd T))
     (hP_le_one : ∀ i, 𝓒.probability T i ≤ 1) :
     0 ≤ 𝓒.differentialEntropy T := by
-  have hPoint :
-      (fun i => Real.log (𝓒.probability T i)) ≤ᵐ[𝓒.μProd T] fun _ => 0 := by
-    refine Filter.Eventually.of_forall ?_
-    intro i
-    have hpos := probability_pos (𝓒:=𝓒) (T:=T) i
-    have hle := hP_le_one i
-    have hle' : 𝓒.probability T i ≤ Real.exp 0 := by
-      simpa [Real.exp_zero] using hle
-    exact (log_le_iff_le_exp hpos).mpr hle'
-  have hInt0 : Integrable (fun _ : ι => (0 : ℝ)) (𝓒.μProd T) := integrable_const _
-  have hIntLe : (∫ i, Real.log (𝓒.probability T i) ∂𝓒.μProd T)
-      ≤ (∫ _i, (0 : ℝ) ∂𝓒.μProd T) :=
-    integral_mono_ae hInt hInt0 hPoint
-  have hent :
-      𝓒.differentialEntropy T
-        = - kB * (∫ i, Real.log (𝓒.probability T i) ∂𝓒.μProd T) := rfl
+  have hPoint : (fun i => Real.log (𝓒.probability T i)) ≤ᵐ[𝓒.μProd T] fun _ => 0 :=
+    Filter.Eventually.of_forall fun i => by
+      have hpos := probability_pos (𝓒:=𝓒) (T:=T) i
+      have hle' : 𝓒.probability T i ≤ Real.exp 0 := by
+        simpa [Real.exp_zero] using hP_le_one i
+      exact (log_le_iff_le_exp hpos).mpr hle'
   have hkB : 0 ≤ kB := kB_nonneg
   have hIle0 : (∫ i, Real.log (𝓒.probability T i) ∂𝓒.μProd T) ≤ 0 := by
-    simpa [integral_const] using hIntLe
-  have hProd :
-      0 ≤ - kB * (∫ i, Real.log (𝓒.probability T i) ∂𝓒.μProd T) :=
+    simpa [integral_const] using integral_mono_ae hInt (integrable_const _) hPoint
+  simpa [differentialEntropy] using
     mul_nonneg_of_nonpos_of_nonpos (neg_nonpos.mpr hkB) hIle0
-  simpa [hent] using hProd
 
 /-!
 

--- a/Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean
+++ b/Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean
@@ -346,7 +346,7 @@ lemma μBolt_congr (e : ι1 ≃ᵐ ι) (T : Temperature) : (𝓒.congr e).μBolt
   congr
   funext i
   simp only [Pi.mul_apply, MeasurableEquiv.apply_symm_apply]
-  repeat fun_prop
+  all_goals fun_prop
 
 lemma μBolt_nsmul [SigmaFinite 𝓒.μ] (n : ℕ) (T : Temperature) :
     (nsmul n 𝓒).μBolt T = MeasureTheory.Measure.pi fun _ => (𝓒.μBolt T) := by

--- a/Physlib/StringTheory/FTheory/SU5/Quanta/TenQuanta.lean
+++ b/Physlib/StringTheory/FTheory/SU5/Quanta/TenQuanta.lean
@@ -214,16 +214,11 @@ lemma reduce_filter (x : TenQuanta 𝓩) (q : 𝓩) (h : q ∈ x.toCharges) :
   rw [Multiset.filter_map]
   simp only [Function.comp_apply]
   have hx : (Multiset.filter (fun x => x = q) x.toCharges.dedup) = {q} := by
-    refine (Multiset.Nodup.ext ?_ ?_).mpr ?_
-    · refine Multiset.Nodup.filter (fun x => x = q) ?_
-      exact Multiset.nodup_dedup x.toCharges
-    · exact Multiset.nodup_singleton q
-    intro a
-    simp only [Multiset.mem_filter, Multiset.mem_dedup, Multiset.mem_singleton,
-      and_iff_right_iff_imp]
-    intro h'
-    subst h'
-    exact h
+    refine Multiset.ext.mpr (fun a => ?_)
+    simp only [Multiset.count_filter, Multiset.count_dedup, Multiset.count_singleton]
+    by_cases ha : a = q
+    · subst ha; simp [h]
+    · simp [ha]
   rw [hx]
   simp
 
@@ -246,9 +241,8 @@ lemma reduce_reduce (x : TenQuanta 𝓩) :
   intro hp
   have h1 (a b c : Fluxes) (h : b = c) : a = b ↔ a = c := by subst h; rfl
   apply h1
-  rw [reduce_filter]
-  simp only [Multiset.map_singleton, Multiset.sum_singleton]
-  exact hp
+  rw [reduce_filter x p.1 hp]
+  simp
 
 /-!
 
@@ -386,8 +380,7 @@ lemma mem_powerset_sum_of_mem_reduce_toFluxesTen {F : TenQuanta 𝓩}
   use (Multiset.map (fun x => x.2) (Multiset.filter (fun x => x.1 = q) F))
   simp only [and_true]
   rw [toFluxesTen]
-  refine Multiset.map_le_map ?_
-  exact Multiset.filter_le (fun x => x.1 = q) F
+  exact Multiset.map_le_map (Multiset.filter_le (fun x => x.1 = q) F)
 
 lemma mem_powerset_sum_of_mem_reduce_toFluxesTen_filter {F : TenQuanta 𝓩}
     {f : Fluxes} (hf : f ∈ F.reduce.toFluxesTen) :
@@ -403,8 +396,7 @@ lemma mem_powerset_sum_of_mem_reduce_toFluxesTen_filter {F : TenQuanta 𝓩}
     Multiset.filter_eq_nil, Prod.forall, not_forall, Decidable.not_not, and_true]
   apply And.intro
   rw [toFluxesTen]
-  refine Multiset.map_le_map ?_
-  exact Multiset.filter_le (fun x => x.1 = q) F
+  exact Multiset.map_le_map (Multiset.filter_le (fun x => x.1 = q) F)
   simpa [toCharges] using hq
 
 /-!

--- a/Physlib/StringTheory/FTheory/SU5/Quanta/TenQuanta.lean
+++ b/Physlib/StringTheory/FTheory/SU5/Quanta/TenQuanta.lean
@@ -734,9 +734,8 @@ lemma decompose_reduce (x : TenQuanta 𝓩) [DecidableEq 𝓩]
   apply Multiset.map_congr
   · rw [decompose_toCharges_dedup x hx]
   · intro q hx'
-    simp only [Prod.mk.injEq, true_and]
-    change x.decompose.toChargeMap q = x.toChargeMap q
-    rw [decompose_toChargeMap x hx]
+    have h := decompose_toChargeMap x hx
+    simpa [toChargeMap] using congrFun h q
 
 /-!
 

--- a/Physlib/StringTheory/FTheory/SU5/Quanta/TenQuanta.lean
+++ b/Physlib/StringTheory/FTheory/SU5/Quanta/TenQuanta.lean
@@ -662,12 +662,10 @@ lemma decompose_filter_charge [DecidableEq 𝓩] (x : TenQuanta 𝓩) (q : 𝓩)
     simp only [Multiset.cons_bind, Multiset.filter_add]
     rw [Multiset.filter_cons, decompose_add, ih]
     congr
-    match a with
-    | (q', f) =>
+    rcases a with ⟨q', f⟩
     simp [decomposeFluxes]
     by_cases h : q' = q
-    · subst h
-      simp [decompose, decomposeFluxes]
+    · subst h; simp [decompose, decomposeFluxes]
     · simp [h, decompose]
 
 /-!
@@ -681,9 +679,8 @@ lemma decompose_toChargeMap [DecidableEq 𝓩] (x : TenQuanta 𝓩)
     x.decompose.toChargeMap = x.toChargeMap := by
   ext q
   rw [toChargeMap, decompose_filter_charge]
-  simp [decompose]
-  rw [Multiset.map_bind]
-  simp only [Multiset.map_map, Function.comp_apply, Multiset.map_id', Multiset.sum_bind]
+  simp [decompose, Multiset.map_bind, Multiset.map_map, Function.comp_apply,
+    Multiset.map_id', Multiset.sum_bind]
   rw [toChargeMap]
   congr 1
   apply Multiset.map_congr

--- a/Physlib/Thermodynamics/Temperature/Basic.lean
+++ b/Physlib/Thermodynamics/Temperature/Basic.lean
@@ -205,7 +205,7 @@ lemma deriv_beta_wrt_T (T : Temperature) (hT_pos : 0 < T.val) :
     have h := (hasDerivAt_const (T.val : ℝ) (1 : ℝ)).div hg (mul_ne_zero kB_ne_zero (ne_of_gt hT_pos))
     have hval : (-1 : ℝ) / (kB * (T.val : ℝ) ^ 2)
         = (0 * (kB * (T.val : ℝ)) - 1 * kB) / (kB * (T.val : ℝ)) ^ 2 := by
-      rw [mul_pow]; field_simp; ring
+      field_simp; ring
     rw [hval]; exact h
   exact (h_deriv.hasDerivWithinAt).congr beta_fun_T_eq_on_Ioi (beta_fun_T_eq_on_Ioi hT_pos)
 
@@ -215,14 +215,12 @@ lemma chain_rule_T_beta {F : ℝ → ℝ} {F' : ℝ}
     (hF_deriv : HasDerivWithinAt F F' (Set.Ioi 0) (T.β : ℝ)) :
     HasDerivWithinAt (fun t : ℝ => F (betaFromReal t))
       (F' * (-1 / (kB * (T.val : ℝ)^2))) (Set.Ioi 0) (T.val : ℝ) := by
-  have h_map : Set.MapsTo betaFromReal (Set.Ioi 0) (Set.Ioi 0) := by
-    intro t ht
-    rw [beta_fun_T_eq_on_Ioi ht]
-    exact one_div_pos.mpr (mul_pos kB_pos ht)
+  have h_map : Set.MapsTo betaFromReal (Set.Ioi 0) (Set.Ioi 0) :=
+    fun t ht => by
+      rw [beta_fun_T_eq_on_Ioi ht]
+      exact one_div_pos.mpr (mul_pos kB_pos ht)
   have h_beta_at_T : betaFromReal (T.val : ℝ) = (T.β : ℝ) := by
     simpa [β_toReal, Temperature.toReal] using beta_fun_T_eq_on_Ioi hT_pos
-  have hF_deriv' : HasDerivWithinAt F F' (Set.Ioi 0) (betaFromReal (T.val : ℝ)) := by
-    rwa [h_beta_at_T]
-  exact hF_deriv'.comp (T.val : ℝ) (deriv_beta_wrt_T (T := T) hT_pos) h_map
+  exact (h_beta_at_T ▸ hF_deriv).comp (T.val : ℝ) (deriv_beta_wrt_T (T := T) hT_pos) h_map
 
 end Temperature

--- a/Physlib/Thermodynamics/Temperature/Basic.lean
+++ b/Physlib/Thermodynamics/Temperature/Basic.lean
@@ -126,8 +126,7 @@ open Filter Topology
 /-- Eventually, `ofβ β` is positive as β → ∞`. -/
 lemma eventually_pos_ofβ : ∀ᶠ b : ℝ≥0 in atTop, ((Temperature.ofβ b : Temperature) : ℝ) > 0 := by
   filter_upwards [eventually_gt_atTop 0] with b hb
-  have : 0 < (1 : ℝ) / (kB * (b : ℝ)) := one_div_pos.mpr (mul_pos kB_pos (by exact_mod_cast hb))
-  simpa [ofβ_toReal] using this
+  simpa [ofβ_toReal] using one_div_pos.mpr (mul_pos kB_pos (by exact_mod_cast hb))
 
 /-- General helper: for any `a > 0`, we have `1 / (a * b) → 0` as `b → ∞` in `ℝ≥0`. -/
 private lemma tendsto_const_inv_mul_atTop (a : ℝ) (ha : 0 < a) :

--- a/Physlib/Thermodynamics/Temperature/Basic.lean
+++ b/Physlib/Thermodynamics/Temperature/Basic.lean
@@ -116,8 +116,8 @@ lemma ofβ_differentiableOn :
     · intro x hx
       exact mul_ne_zero kB_ne_zero (ne_of_gt hx)
   · intro x hx
-    rw [show ((ofβ (Real.toNNReal x)).val : ℝ) = (ofβ (Real.toNNReal x)).toReal from rfl,
-        ofβ_toReal, Real.coe_toNNReal x hx.le]
+    rw [show ((ofβ x.toNNReal).val : ℝ) = (ofβ x.toNNReal).toReal from rfl,
+      ofβ_toReal x.toNNReal, Real.coe_toNNReal x hx.le]
 
 /-! ### Convergence -/
 
@@ -198,19 +198,15 @@ lemma beta_fun_T_eq_on_Ioi :
 
 lemma deriv_beta_wrt_T (T : Temperature) (hT_pos : 0 < T.val) :
     HasDerivWithinAt betaFromReal (-1 / (kB * (T.val : ℝ)^2)) (Set.Ioi 0) (T.val : ℝ) := by
-  have hTne : (T.val : ℝ) ≠ 0 := ne_of_gt hT_pos
-  have hg : HasDerivAt (fun t : ℝ => kB * t) kB (T.val : ℝ) := by
-    simpa using (hasDerivAt_id (T.val : ℝ)).const_mul kB
   have h_deriv : HasDerivAt (fun t : ℝ => 1 / (kB * t))
       (-1 / (kB * (T.val : ℝ) ^ 2)) (T.val : ℝ) := by
-    have h := (hasDerivAt_const (T.val : ℝ) (1 : ℝ)).div hg (mul_ne_zero kB_ne_zero hTne)
+    have hg : HasDerivAt (fun t : ℝ => kB * t) kB (T.val : ℝ) := by
+      simpa using (hasDerivAt_id (T.val : ℝ)).const_mul kB
+    have h := (hasDerivAt_const (T.val : ℝ) (1 : ℝ)).div hg (mul_ne_zero kB_ne_zero (ne_of_gt hT_pos))
     have hval : (-1 : ℝ) / (kB * (T.val : ℝ) ^ 2)
         = (0 * (kB * (T.val : ℝ)) - 1 * kB) / (kB * (T.val : ℝ)) ^ 2 := by
-      rw [mul_pow]
-      field_simp
-      ring
-    rw [hval]
-    exact h
+      rw [mul_pow]; field_simp; ring
+    rw [hval]; exact h
   exact (h_deriv.hasDerivWithinAt).congr beta_fun_T_eq_on_Ioi (beta_fun_T_eq_on_Ioi hT_pos)
 
 /-- Chain rule for β(T) : d/dT F(β(T)) = F'(β(T)) * (-1 / (kB * T^2)), within `Ioi 0`. -/
@@ -221,15 +217,12 @@ lemma chain_rule_T_beta {F : ℝ → ℝ} {F' : ℝ}
       (F' * (-1 / (kB * (T.val : ℝ)^2))) (Set.Ioi 0) (T.val : ℝ) := by
   have h_map : Set.MapsTo betaFromReal (Set.Ioi 0) (Set.Ioi 0) := by
     intro t ht
-    show 0 < betaFromReal t
     rw [beta_fun_T_eq_on_Ioi ht]
     exact one_div_pos.mpr (mul_pos kB_pos ht)
   have h_beta_at_T : betaFromReal (T.val : ℝ) = (T.β : ℝ) := by
-    rw [beta_fun_T_eq_on_Ioi (show (T.val : ℝ) ∈ Set.Ioi 0 from hT_pos), β_toReal]
-    rfl
+    simpa [β_toReal, Temperature.toReal] using beta_fun_T_eq_on_Ioi hT_pos
   have hF_deriv' : HasDerivWithinAt F F' (Set.Ioi 0) (betaFromReal (T.val : ℝ)) := by
-    rw [h_beta_at_T]
-    exact hF_deriv
+    rwa [h_beta_at_T]
   exact hF_deriv'.comp (T.val : ℝ) (deriv_beta_wrt_T (T := T) hT_pos) h_map
 
 end Temperature

--- a/Physlib/Units/UnitDependent.lean
+++ b/Physlib/Units/UnitDependent.lean
@@ -204,15 +204,11 @@ lemma UnitChoices.scaleUnit_apply_fst (u1 u2 : UnitChoices) :
 @[simp]
 lemma UnitChoices.dimScale_scaleUnit {u1 u2 u : UnitChoices} (d : Dimension) :
     u.dimScale (scaleUnit u1 u2 u) d = u1.dimScale u2 d := by
-  simp [dimScale]
-  congr 1
-  congr 1
-  congr 1
-  congr 1
-  all_goals
-    congr 1
-    simp [scaleUnit, LengthUnit.div_eq_val, TimeUnit.div_eq_val, MassUnit.div_eq_val,
-      ChargeUnit.div_eq_val, TemperatureUnit.div_eq_val, toReal]
+  dsimp [dimScale, scaleUnit, LengthUnit.scale, TimeUnit.scale, MassUnit.scale,
+    ChargeUnit.scale, TemperatureUnit.scale]
+  simp only [LengthUnit.div_eq_val, TimeUnit.div_eq_val, MassUnit.div_eq_val,
+    ChargeUnit.div_eq_val, TemperatureUnit.div_eq_val, toReal]
+  congr 1 <;> field_simp
 
 lemma Dimensionful.of_scaleUnit {M : Type} [CarriesDimension M] {u1 u2 u : UnitChoices}
     (c : Dimensionful M) :

--- a/Physlib/Units/UnitDependent.lean
+++ b/Physlib/Units/UnitDependent.lean
@@ -93,11 +93,8 @@ lemma UnitDependent.scaleUnit_injective {M : Type} [UnitDependent M]
     scaleUnit u1 u2 m1 = scaleUnit u1 u2 m2 ↔ m1 = m2 := by
   constructor
   · intro h1
-    have h2 : scaleUnit u2 u1 (scaleUnit u1 u2 m1) =
-        scaleUnit u2 u1 (scaleUnit u1 u2 m2) := by rw [h1]
-    simpa using h2
-  · intro h
-    subst h
+    simpa using congrArg (scaleUnit u2 u1) h1
+  · rintro rfl
     rfl
 
 /-!
@@ -199,13 +196,10 @@ noncomputable instance : UnitDependent UnitChoices where
 @[simp]
 lemma UnitChoices.scaleUnit_apply_fst (u1 u2 : UnitChoices) :
     (scaleUnit u1 u2 u1) = u2 := by
-  simp [scaleUnit]
-  apply UnitChoices.ext
-  · simp [LengthUnit.scale, LengthUnit.div_eq_val, toReal]
-  · simp [TimeUnit.scale, TimeUnit.div_eq_val, toReal]
-  · simp [MassUnit.scale, MassUnit.div_eq_val, toReal]
-  · simp [ChargeUnit.scale, ChargeUnit.div_eq_val, toReal]
-  · simp [TemperatureUnit.scale, TemperatureUnit.div_eq_val, toReal]
+  apply UnitChoices.ext <;>
+    simp [scaleUnit, LengthUnit.scale, TimeUnit.scale, MassUnit.scale, ChargeUnit.scale,
+      TemperatureUnit.scale, LengthUnit.div_eq_val, TimeUnit.div_eq_val, MassUnit.div_eq_val,
+      ChargeUnit.div_eq_val, TemperatureUnit.div_eq_val, toReal]
 
 @[simp]
 lemma UnitChoices.dimScale_scaleUnit {u1 u2 u : UnitChoices} (d : Dimension) :
@@ -215,42 +209,27 @@ lemma UnitChoices.dimScale_scaleUnit {u1 u2 u : UnitChoices} (d : Dimension) :
   congr 1
   congr 1
   congr 1
-  · congr 1
-    simp [scaleUnit]
-    simp [LengthUnit.div_eq_val, toReal]
-  · congr 1
-    simp [scaleUnit]
-    simp [TimeUnit.div_eq_val, toReal]
-  · congr 1
-    simp [scaleUnit]
-    simp [MassUnit.div_eq_val, toReal]
-  · congr 1
-    simp [scaleUnit]
-    simp [ChargeUnit.div_eq_val, toReal]
-  · congr 1
-    simp [scaleUnit]
-    simp [TemperatureUnit.div_eq_val, toReal]
+  all_goals
+    congr 1
+    simp [scaleUnit, LengthUnit.div_eq_val, TimeUnit.div_eq_val, MassUnit.div_eq_val,
+      ChargeUnit.div_eq_val, TemperatureUnit.div_eq_val, toReal]
 
 lemma Dimensionful.of_scaleUnit {M : Type} [CarriesDimension M] {u1 u2 u : UnitChoices}
     (c : Dimensionful M) :
     c.1 (scaleUnit u1 u2 u) =
     u1.dimScale u2 (dim M) • c.1 (u) := by
-  rw [c.2 u (scaleUnit u1 u2 u)]
-  congr 1
-  simp
+  rw [c.2 u (scaleUnit u1 u2 u), UnitChoices.dimScale_scaleUnit]
 
 noncomputable instance {M1 : Type} [CarriesDimension M1] : MulUnitDependent M1 where
   scaleUnit u1 u2 m := (toDimensionful u1 m).1 u2
   scaleUnit_trans u1 u2 u3 m := by
-    simp [toDimensionful]
-    rw [smul_smul, mul_comm, UnitChoices.dimScale_transitive]
+    simp [toDimensionful, smul_smul, mul_comm, UnitChoices.dimScale_transitive]
   scaleUnit_trans' u1 u2 u3 m := by
     simp [toDimensionful, smul_smul, UnitChoices.dimScale_transitive]
   scaleUnit_id u m := by
     simp [toDimensionful, UnitChoices.dimScale_self]
   scaleUnit_mul u1 u2 r m := by
-    simp [toDimensionful]
-    exact smul_comm (u1.dimScale u2 (dim M1)) r m
+    simpa [toDimensionful] using smul_comm (u1.dimScale u2 (dim M1)) r m
 
 lemma HasDim.scaleUnit_apply {M : Type} [CarriesDimension M]
     (u1 u2 : UnitChoices) (m : M) :
@@ -260,15 +239,10 @@ lemma HasDim.scaleUnit_apply {M : Type} [CarriesDimension M]
 noncomputable instance {M : Type} [AddCommMonoid M] [Module ℝ M] [HasDim M] :
     LinearUnitDependent M where
   scaleUnit_add u1 u2 m1 m2 := by
-    change (toDimensionful u1 (m1 + m2)).1 u2 = _
-    rw [toDimensionful_apply_apply]
-    simp
-    rfl
+    simp only [HasDim.scaleUnit_apply, smul_add]
   scaleUnit_smul u1 u2 r m := by
-    change (toDimensionful u1 (r • m)).1 u2 = _
-    rw [toDimensionful_apply_apply]
+    simp only [HasDim.scaleUnit_apply]
     rw [smul_comm]
-    rfl
 
 noncomputable instance {M : Type} [AddCommMonoid M] [Module ℝ M]
     [HasDim M] [TopologicalSpace M]
@@ -279,8 +253,7 @@ noncomputable instance {M : Type} [AddCommMonoid M] [Module ℝ M]
       enter [1, m]
       rw [toDimensionful_apply_apply]
     change Continuous fun m => (u1.dimScale u2 (dim M)).1 • m
-    apply Continuous.const_smul
-    exact continuous_id'
+    exact continuous_id'.const_smul _
 
 /-!
 
@@ -472,24 +445,21 @@ lemma isDimensionallyCorrect_fun_iff {M1 M2 : Type} [UnitDependent M1] [UnitDepe
     {f : M1 → M2} :
     IsDimensionallyCorrect f ↔
     ∀ u1 u2 : UnitChoices, ∀ m, scaleUnit u1 u2 (f (scaleUnit u2 u1 m)) = f m := by
-  simp only [IsDimensionallyCorrect, funext_iff]
-  rfl
+  simp only [IsDimensionallyCorrect, funext_iff, scaleUnit_apply_fun]
 
 @[simp]
 lemma isDimensionallyCorrect_fun_left {M1 M2 : Type} [UnitDependent M1]
     {f : M1 → M2} :
     IsDimensionallyCorrect f ↔
     ∀ u1 u2 : UnitChoices, ∀ m, (f (scaleUnit u2 u1 m)) = f m := by
-  simp only [IsDimensionallyCorrect, funext_iff]
-  rfl
+  simp only [IsDimensionallyCorrect, funext_iff, scaleUnit_apply_fun_left]
 
 @[simp]
 lemma isDimensionallyCorrect_fun_right {M1 M2 : Type} [UnitDependent M2]
     {f : M1 → M2} :
     IsDimensionallyCorrect f ↔
     ∀ u1 u2 : UnitChoices, ∀ m, scaleUnit u1 u2 (f m) = f m := by
-  simp only [IsDimensionallyCorrect, funext_iff]
-  rfl
+  simp only [IsDimensionallyCorrect, funext_iff, scaleUnit_apply_fun_right]
 /-!
 
 ## Some type classes to help track dimensions

--- a/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/BlockDiagonal.lean
+++ b/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/BlockDiagonal.lean
@@ -194,35 +194,17 @@ theorem blockDiagonal_nonneg {A B : L ℋ} (hA : 0 ≤ A) (hB : 0 ≤ B) :
   intro z
   have hAz := (ContinuousLinearMap.isPositive_iff_complex A).mp hApos (hsumProj ℋ 0 z)
   have hBz := (ContinuousLinearMap.isPositive_iff_complex B).mp hBpos (hsumProj ℋ 1 z)
-  have hz0 :
-      inner ℂ ((hsumIncl ℋ 0) (A (hsumProj ℋ 0 z))) z =
-        inner ℂ (A (hsumProj ℋ 0 z)) (hsumProj ℋ 0 z) := by
+  have hsum0 : inner ℂ ((hsumIncl ℋ 0) (A (hsumProj ℋ 0 z))) z =
+      inner ℂ (A (hsumProj ℋ 0 z)) (hsumProj ℋ 0 z) := by
     simp [hsumProj, hsumIncl, hsumEquiv, PiLp.inner_apply]
-  have hz1 :
-      inner ℂ ((hsumIncl ℋ 1) (B (hsumProj ℋ 1 z))) z =
-        inner ℂ (B (hsumProj ℋ 1 z)) (hsumProj ℋ 1 z) := by
+  have hsum1 : inner ℂ ((hsumIncl ℋ 1) (B (hsumProj ℋ 1 z))) z =
+      inner ℂ (B (hsumProj ℋ 1 z)) (hsumProj ℋ 1 z) := by
     simp [hsumProj, hsumIncl, hsumEquiv, PiLp.inner_apply]
+  dsimp [blockDiagonal]
+  erw [inner_add_left, hsum0, hsum1]
   constructor
+  · simpa [map_add] using congrArg₂ (· + ·) hAz.1 hBz.1
   · dsimp [blockDiagonal]
-    erw [inner_add_left, hz0, hz1]
-    calc
-      ↑(RCLike.re
-          (inner ℂ (A (hsumProj ℋ 0 z)) (hsumProj ℋ 0 z) +
-            inner ℂ (B (hsumProj ℋ 1 z)) (hsumProj ℋ 1 z))) =
-          ↑(RCLike.re (inner ℂ (A (hsumProj ℋ 0 z)) (hsumProj ℋ 0 z)) +
-            RCLike.re (inner ℂ (B (hsumProj ℋ 1 z)) (hsumProj ℋ 1 z))) := by
-            simp
-      _ = inner ℂ (A (hsumProj ℋ 0 z)) (hsumProj ℋ 0 z) +
-          inner ℂ (B (hsumProj ℋ 1 z)) (hsumProj ℋ 1 z) := by
-            have hsumre :
-                (↑(RCLike.re (inner ℂ (A (hsumProj ℋ 0 z)) (hsumProj ℋ 0 z)) +
-                    RCLike.re (inner ℂ (B (hsumProj ℋ 1 z)) (hsumProj ℋ 1 z))) : ℂ) =
-                  ((RCLike.re (inner ℂ (A (hsumProj ℋ 0 z)) (hsumProj ℋ 0 z)) : ℂ) +
-                    (RCLike.re (inner ℂ (B (hsumProj ℋ 1 z)) (hsumProj ℋ 1 z)) : ℂ)) := by
-                  simp
-            rw [hsumre, hAz.1, hBz.1]
-  · dsimp [blockDiagonal]
-    erw [inner_add_left, hz0, hz1]
     exact add_nonneg hAz.2 hBz.2
 
 omit [CompleteSpace ℋ] [Nontrivial ℋ] in


### PR DESCRIPTION
## Golfed proofs

This PR golfs proofs without changing statements or definitions, using more powerful tactics, increasing mathlib usage, and streamlining arguments.

### Proofs golfed (134 commits)

Key areas: HarmonicOscillator (Basic, Solution), IsExtrema, TotalDerivativeEquivalence, KineticTerm, WickAlgebra/TimeOrder, WickContraction, Space/Norm, Units, PhysHermite, StatisticalMechanics, QFT/PerturbationTheory

### Fixes in this commit

- Restored working `unfold`/`change`/`rw` proofs for `kineticEnergy_deriv`, `potentialEnergy_deriv`, `energy_deriv`, and `gradient_inner_self` in Basic.lean
- Restored working proofs for `trajectories_unique` and `return_time` in Solution.lean
- Golfed `physHermite_orthogonal` and `physHermite_norm_cons` with `simp` in PhysHermite.lean
- Golfed `finset_eq_fstFieldOfContract_sndFieldOfContract` using `Finset.sort_insert` with explicit proofs in WickContraction/Basic.lean
- Golfed `gradient_dist_normPowerSeries_log_tendsTo_distGrad_norm` in Space/Norm/Basic.lean
- Golfed `UnitChoices.dimScale_scaleUnit` with `field_simp` in Units/UnitDependent.lean

### Tactics used

- `simp only`, `exact`, `refine`, `rw`, `simp`, `fun_prop`
- `unfold`/`change`/`rw` for derivative computations
- `Finset.sort_insert` with explicit `h₁`/`h₂` proofs
- `field_simp` for unit scaling
- `Nat.lt_or_ge` for case analysis

### Notes

- All proofs verified via `lake build`
- PR will be updated with more golfed proofs periodically

---

*Model: Mistral Large (via Mistral Vibe CLI agent)*
*Duration: ~2 hours, ~30,000 tokens*
*Branch: claude/golf-proofs-more*
*PR: https://github.com/leanprover-community/physlib/pull/1373*