### PR TITLE
feat(QuantumMechanics): generalize `SpaceDHilbertSpace`

### DIFF
--- a/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
@@ -109,7 +109,7 @@ lemma mulOperator_hasDenseDomain {f : Space d → ℂ} (hf : AEStronglyMeasurabl
   obtain ⟨u, hu, hfu⟩ := AEStronglyMeasurable.aemeasurable hf
   let s : ℕ → Set (Space d) := fun n ↦ u ⁻¹' (Metric.closedBall 0 n)
   let φ : ℕ → SpaceDHilbertSpace d := fun n ↦
-    mk ((memHS_coe ψ).indicator (s := s n) (by measurability))
+    mk ((memHS_coe ψ).indicator (Ω := s n) (by measurability))
   have hφ : ∀ n, φ n =ᵐ[volume] (s n).indicator ψ := fun n ↦ coeFn_mk _
   use φ
   constructor

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
@@ -44,30 +44,30 @@ open Function InnerProductSpace MeasureTheory Measure Set
 /-- The Hilbert space for single-particle quantum mechanics on `Space d` is defined to be
   `L²(Space d, ℂ)`, the space of almost-everywhere equal equivalence classes of square-integrable
   functions from `Space d` to `ℂ`. -/
-abbrev SpaceDHilbertSpace (d : ℕ) := Lp (α := Space d) ℂ 2 volume
+abbrev SpaceDHilbertSpace (d : ℕ) (μ : Measure (Space d) := volume) := Lp ℂ 2 μ
 
 namespace SpaceDHilbertSpace
 
-variable {d : ℕ} {f g : Space d → ℂ} (ψ φ : SpaceDHilbertSpace d)
+variable {d : ℕ} {μ : Measure (Space d)} {f g : Space d → ℂ} (ψ φ : SpaceDHilbertSpace d μ)
 
 variable {ψ φ} in
-lemma ext_iff : ψ = φ ↔ ψ =ᵐ[volume] φ := Lp.ext_iff
+lemma ext_iff : ψ = φ ↔ ψ =ᵐ[μ] φ := Lp.ext_iff
 
 /-!
 ## B. Dual space
 -/
 
-/-- The anti-linear equivalence between `SpaceDHilbertSpace d` and its dual.
+/-- The anti-linear equivalence between `SpaceDHilbertSpace d μ` and its dual.
 
   This is the map that takes a ket to its corresponding bra and _vice versa_. -/
-def toBra : SpaceDHilbertSpace d ≃ₛₗ[starRingEnd ℂ] StrongDual ℂ (SpaceDHilbertSpace d) :=
-  toDual ℂ (SpaceDHilbertSpace d)
+def toBra : SpaceDHilbertSpace d μ ≃ₛₗ[starRingEnd ℂ] StrongDual ℂ (SpaceDHilbertSpace d μ) :=
+  toDual ℂ (SpaceDHilbertSpace d μ)
 
 @[simp]
 lemma toBra_apply_apply : toBra ψ φ = ⟪ψ, φ⟫_ℂ := rfl
 
 @[simp]
-lemma toBra_symm_apply (f : StrongDual ℂ (SpaceDHilbertSpace d)) : ⟪toBra.symm f, ψ⟫_ℂ = f ψ :=
+lemma toBra_symm_apply (f : StrongDual ℂ (SpaceDHilbertSpace d μ)) : ⟪toBra.symm f, ψ⟫_ℂ = f ψ :=
   toDual_symm_apply
 
 /-!
@@ -76,29 +76,29 @@ lemma toBra_symm_apply (f : StrongDual ℂ (SpaceDHilbertSpace d)) : ⟪toBra.sy
 
 /-- The proposition `MemHS f` for a function `f : Space d → ℂ` is defined
   to be true if the function `f` can be lifted to the Hilbert space. -/
-def MemHS (f : Space d → ℂ) : Prop := MemLp f 2 volume
+def MemHS (f : Space d → ℂ) (μ : Measure (Space d) := volume) : Prop := MemLp f 2 μ
 
-lemma memHS_coe : MemHS ψ := Lp.memLp ψ
+lemma memHS_coe : MemHS ψ μ := Lp.memLp ψ
 
-/-- A function `f` satisfies `MemHS f` if and only if it is a.e. strongly measurable
+/-- A function `f` satisfies `MemHS f μ` if and only if it is `μ`-a.e. strongly measurable
   and square integrable. -/
-lemma memHS_iff : MemHS f ↔ AEStronglyMeasurable f ∧ Integrable (fun x ↦ ‖f x‖ ^ 2) :=
+lemma memHS_iff : MemHS f μ ↔ AEStronglyMeasurable f μ ∧ Integrable (fun x ↦ ‖f x‖ ^ 2) μ :=
   and_congr_right fun h ↦ (and_iff_right h).symm.trans (memLp_two_iff_integrable_sq_norm h)
 
-lemma mem_iff {f : Space d →ₘ[volume] ℂ} : f ∈ SpaceDHilbertSpace d ↔ MemHS f := Lp.mem_Lp_iff_memLp
+lemma mem_iff {f : Space d →ₘ[μ] ℂ} : f ∈ SpaceDHilbertSpace d μ ↔ MemHS f μ := Lp.mem_Lp_iff_memLp
 
 @[simp]
-lemma MemHS.zero : MemHS (0 : Space d → ℂ) := MemLp.zero
+lemma MemHS.zero : MemHS (0 : Space d → ℂ) μ := MemLp.zero
 
-lemma MemHS.neg (hf : MemHS f) : MemHS (-f) := MemLp.neg hf
+lemma MemHS.neg (hf : MemHS f μ) : MemHS (-f) μ := MemLp.neg hf
 
-lemma MemHS.add (hf : MemHS f) (hg : MemHS g) : MemHS (f + g) := MemLp.add hf hg
+lemma MemHS.add (hf : MemHS f μ) (hg : MemHS g μ) : MemHS (f + g) μ := MemLp.add hf hg
 
-lemma MemHS.sub (hf : MemHS f) (hg : MemHS g) : MemHS (f - g) := MemLp.sub hf hg
+lemma MemHS.sub (hf : MemHS f μ) (hg : MemHS g μ) : MemHS (f - g) μ := MemLp.sub hf hg
 
-lemma MemHS.const_smul (c : ℂ) (hf : MemHS f) : MemHS (c • f) := MemLp.const_smul hf c
+lemma MemHS.const_smul (c : ℂ) (hf : MemHS f μ) : MemHS (c • f) μ := MemLp.const_smul hf c
 
-lemma MemHS.ae_eq (hfg : f =ᵐ[volume] g) (hf : MemHS f) : MemHS g := MemLp.ae_eq hfg hf
+lemma MemHS.ae_eq (hfg : f =ᵐ[μ] g) (hf : MemHS f μ) : MemHS g μ := MemLp.ae_eq hfg hf
 
 /-!
 ## D. Construction of elements
@@ -106,11 +106,11 @@ lemma MemHS.ae_eq (hfg : f =ᵐ[volume] g) (hf : MemHS f) : MemHS g := MemLp.ae_
 
 section
 
-variable (hf : MemHS f) (hg : MemHS g)
+variable (hf : MemHS f μ) (hg : MemHS g μ)
 
-/-- Given a function `f : Space d → ℂ` such that `MemHS f` is true via `hf`,
+/-- Given a function `f : Space d → ℂ` such that `MemHS f μ` is true via `hf`,
   `mk hf` is the element of the Hilbert space defined by `f`. -/
-def mk : SpaceDHilbertSpace d :=
+def mk : SpaceDHilbertSpace d μ :=
   ⟨AEEqFun.mk f hf.1, mem_iff.mpr <| hf.ae_eq (AEEqFun.coeFn_mk f hf.1).symm⟩
 
 @[simp]
@@ -125,14 +125,14 @@ lemma mk_sub : mk (hf.sub hg) = mk hf - mk hg := rfl
 @[simp]
 lemma mk_const_smul (c : ℂ) : mk (hf.const_smul c) = c • mk hf := rfl
 
-lemma coeFn_mk : mk hf =ᵐ[volume] f := AEEqFun.coeFn_mk f hf.1
+lemma coeFn_mk : mk hf =ᵐ[μ] f := AEEqFun.coeFn_mk f hf.1
 
-lemma mk_eq_iff : mk hf = mk hg ↔ f =ᵐ[volume] g := by simp [mk]
+lemma mk_eq_iff : mk hf = mk hg ↔ f =ᵐ[μ] g := by simp [mk]
 
-lemma mk_surjective : ∃ (f : Space d → ℂ) (hf : MemHS f), mk hf = ψ :=
+lemma mk_surjective : ∃ (f : Space d → ℂ) (hf : MemHS f μ), mk hf = ψ :=
   ⟨ψ, memHS_coe ψ, by simp [mk]⟩
 
-lemma inner_mk_mk : ⟪mk hf, mk hg⟫_ℂ = ∫ x, starRingEnd ℂ (f x) * g x := by
+lemma inner_mk_mk : ⟪mk hf, mk hg⟫_ℂ = ∫ x, starRingEnd ℂ (f x) * g x ∂μ := by
   apply integral_congr_ae
   filter_upwards [coeFn_mk hf, coeFn_mk hg]
   simp_all [mul_comm]
@@ -145,15 +145,15 @@ end
 
 section
 
-variable (c : ℂ) (ψ φ : SpaceDHilbertSpace d)
+variable (c : ℂ) (ψ φ : SpaceDHilbertSpace d μ)
 
-lemma coeFn_neg : ⇑(-ψ) =ᵐ[volume] -ψ := Lp.coeFn_neg _
+lemma coeFn_neg : ⇑(-ψ) =ᵐ[μ] -ψ := Lp.coeFn_neg _
 
-lemma coeFn_add : ⇑(ψ.val + φ.val) =ᵐ[volume] ψ + φ := Lp.coeFn_add _ _
+lemma coeFn_add : ⇑(ψ.val + φ.val) =ᵐ[μ] ψ + φ := Lp.coeFn_add _ _
 
-lemma coeFn_sub : ⇑(ψ.val - φ.val) =ᵐ[volume] ψ - φ := Lp.coeFn_sub _ _
+lemma coeFn_sub : ⇑(ψ.val - φ.val) =ᵐ[μ] ψ - φ := Lp.coeFn_sub _ _
 
-lemma coeFn_smul : ⇑(c • ψ) =ᵐ[volume] c • ψ := Lp.coeFn_smul _ _
+lemma coeFn_smul : ⇑(c • ψ) =ᵐ[μ] c • ψ := Lp.coeFn_smul _ _
 
 end
 
@@ -164,9 +164,9 @@ end
 open Filter
 
 lemma tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq
-    {α : Type*} {l : Filter α} {ψ : α → SpaceDHilbertSpace d} :
-    Tendsto ψ l (nhds 0) ↔ Tendsto (fun a ↦ ∫⁻ x, ‖ψ a x‖ₑ ^ 2) l (nhds 0) := by
-  trans Tendsto (fun a ↦ (∫⁻ x, ‖ψ a x‖ₑ ^ 2) ^ (2⁻¹ : ℝ)) l (nhds 0)
+    {α : Type*} {l : Filter α} {ψ : α → SpaceDHilbertSpace d μ} :
+    Tendsto ψ l (nhds 0) ↔ Tendsto (fun a ↦ ∫⁻ x, ‖ψ a x‖ₑ ^ 2 ∂μ) l (nhds 0) := by
+  trans Tendsto (fun a ↦ (∫⁻ x, ‖ψ a x‖ₑ ^ 2 ∂μ) ^ (2⁻¹ : ℝ)) l (nhds 0)
   · simp [tendsto_iff_edist_tendsto_0, edist_zero_right, Lp.enorm_def, eLpNorm, eLpNorm']
   constructor <;> intro h
   · apply Tendsto.ennrpow_const 2 at h

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
@@ -14,7 +14,36 @@ public import Physlib.SpaceAndTime.Space.Module
 
 ## i. Overview
 
+The Hilbert spaces appropriate for doing quantum mechanics on `Space d` are the $$L^2$$-spaces
+`SpaceDHilbertSpace d μ := Lp ℂ 2 μ`, where `μ` is some measure on `Space d`.
+Elements of `SpaceDHilbertSpace d μ` are _equivalence classes_ of functions `Space d → ℂ` which are
+square-integrable with respect to `μ`, i.e. `∫ x, ‖f x‖ ^ 2 ∂μ` is finite, and where `f` and `g` are
+in the same equivalence class if they are `μ`-a.e. equal.
+
+Given `SpaceDHilbertSpace d μ` and `Ω : Set (Space d)`, the Hilbert space
+`SpaceDHilbertSpace d (μ.restrict Ω)` may be interpreted as the sub-Hilbert space
+consisting of those vectors with domain contained in `Ω`.
+The reason is that for each `f` in `SpaceDHilbertSpace d (μ.restrict Ω)` we have
+`f =ᵐ[μ.restrict Ω] Ω.indicator f`, namely the equivalence class of `f` always
+contains a representative which vanishes on the complement of `Ω`.
+The linear map `restrictIncl Ω` defined below describes this sub-Hilbert space relationship by
+mapping each `f` to this special representative in its equivalence class.
+
+Similarly, we may project `SpaceDHilbertSpace d μ` onto the sub-Hilbert space
+`SpaceDHilbertSpace d (μ.restrict Ω)` by enlarging the equivalence classes, essentially dropping
+information about the functions on the complement of `Ω`.
+
 ## ii. Key results
+
+- `SpaceDHilbertSpace d μ` : The $$L^2$$-space on `Space d` with respect to the measure `μ`.
+- `toBra` : The linear equivalence between the Hilbert space and its dual. This is the map which
+    sends each ket to its corresponding bra and _vice versa_.
+- `MemHS f μ` : The proposition capturing exactly when the function `f : Space d → ℂ` can be lifted
+    to an element of the Hilbert space.
+- `subspaceProjection` : The projection of `SpaceDHilbertSpace d μ` onto a sub-Hilbert space
+    `SpaceDHilbertSpace d (μ.restrict Ω)`.
+- `restrictIncl Ω` : The linear map including `SpaceDHilbertSpace d (μ.restrict Ω)`
+    as a sub-Hilbert space of `SpaceDHilbertspace d μ`.
 
 ## iii. Table of contents
 
@@ -42,9 +71,9 @@ open Function InnerProductSpace MeasureTheory Measure Set
 ## A. Definition
 -/
 
-/-- The Hilbert space for single-particle quantum mechanics on `Space d` is defined to be
-  `L²(Space d, ℂ)`, the space of almost-everywhere equal equivalence classes of square-integrable
-  functions from `Space d` to `ℂ`. -/
+/-- The Hilbert space for single-particle quantum mechanics on `Space d` with measure `μ`
+  is defined to be `L²(Space d, ℂ; μ)`, the space of `μ`-a.e. equal equivalence classes
+  of functions `f : Space d → ℂ` for which `∫ x, ‖f x‖² ∂μ` is finite. -/
 abbrev SpaceDHilbertSpace (d : ℕ) (μ : Measure (Space d) := volume) := Lp ℂ 2 μ
 
 namespace SpaceDHilbertSpace
@@ -52,6 +81,8 @@ namespace SpaceDHilbertSpace
 variable {d : ℕ} {μ μ' : Measure (Space d)} {f g : Space d → ℂ} (ψ φ : SpaceDHilbertSpace d μ)
 
 variable {ψ φ} in
+/-- Elements of `SpaceDHilbertSpace d μ` are equivalence classes
+  of `μ`-a.e. equal functions `Space d → ℂ`. -/
 lemma ext_iff : ψ = φ ↔ ψ =ᵐ[μ] φ := Lp.ext_iff
 
 /-!
@@ -75,14 +106,15 @@ lemma toBra_symm_apply (f : StrongDual ℂ (SpaceDHilbertSpace d μ)) : ⟪toBra
 ## C. Membership
 -/
 
-/-- The proposition `MemHS f` for a function `f : Space d → ℂ` is defined
-  to be true if the function `f` can be lifted to the Hilbert space. -/
+/-- For a function `f : Space d → ℂ`, the proposition `MemHS f μ` means that the function `f`
+  can be lifted to an element of the Hilbert space. -/
 def MemHS (f : Space d → ℂ) (μ : Measure (Space d) := volume) : Prop := MemLp f 2 μ
 
+/-- Elements of the Hilbert space satisfy the property `MemHS`. -/
 lemma memHS_coe : MemHS ψ μ := Lp.memLp ψ
 
-/-- A function `f` satisfies `MemHS f μ` if and only if it is `μ`-a.e. strongly measurable
-  and square integrable. -/
+/-- A function `f : Space d → ℂ` satisfies `MemHS f μ` if and only if
+  it is `μ`-a.e. strongly measurable and `∫ x, ‖f x‖ ^ 2 ∂μ` is finite. -/
 lemma memHS_iff : MemHS f μ ↔ AEStronglyMeasurable f μ ∧ Integrable (fun x ↦ ‖f x‖ ^ 2) μ :=
   and_congr_right fun h ↦ (and_iff_right h).symm.trans (memLp_two_iff_integrable_sq_norm h)
 
@@ -114,6 +146,9 @@ lemma MemHS.indicator {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (hf : MemHS 
     MemHS (Ω.indicator f) μ :=
   MemLp.indicator hΩ hf
 
+/-- If `f` is a member of the sub-Hilbert space `SpaceDHilbertSpace d (μ.restrict Ω)`
+  of `SpaceDHilbertSpace d μ` then the representative `Ω.indicator f` which vanishes outside `Ω`
+  is a member of the full Hilbert space. -/
 lemma MemHS.indicator_of_restrict
     {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (hf : MemHS f (μ.restrict Ω)) :
     MemHS (Ω.indicator f) μ := by

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
@@ -219,7 +219,7 @@ end
 -/
 
 /-- The linear map projecting `SpaceDHilbertSpace d μ` onto the sub-Hilbert space
-  of functions which vanish `μ`-a.e. outside of `Ω`. -/
+  `SpaceDHilbertSpace d (μ.restrict Ω)`. -/
 def subspaceProjection (Ω : Set (Space d)) :
     SpaceDHilbertSpace d μ →ₗ[ℂ] SpaceDHilbertSpace d (μ.restrict Ω) where
   toFun ψ := mk ((memHS_coe ψ).restrict Ω)
@@ -242,7 +242,7 @@ lemma subspaceProjection_norm_le (Ω : Set (Space d)) (ψ : SpaceDHilbertSpace d
 
 /-- The linear isometry including `SpaceDHilbertSpace d (μ.restrict Ω)` as a sub-Hilbert space of
   `SpaceDHilbertSpace d μ` defined by mapping `ψ` to `Ω.indicator ψ`. -/
-def restrictIncl {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
+def subspaceIncl {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
     SpaceDHilbertSpace d (μ.restrict Ω) →ₗᵢ[ℂ] SpaceDHilbertSpace d μ where
   toFun ψ := mk ((memHS_coe ψ).indicator_of_restrict hΩ)
   map_add' ψ φ := by
@@ -257,24 +257,24 @@ def restrictIncl {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
       _ = (eLpNorm (Ω.indicator ψ) 2 μ).toReal := congrArg _ (eLpNorm_congr_ae (coeFn_mk _))
       _ = ‖ψ‖ := congrArg _ (eLpNorm_indicator_eq_eLpNorm_restrict hΩ)
 
-lemma restrictIncl_apply
+lemma subspaceIncl_apply
     {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (ψ : SpaceDHilbertSpace d (μ.restrict Ω)) :
-    restrictIncl hΩ ψ =ᵐ[μ] Ω.indicator ψ :=
+    subspaceIncl hΩ ψ =ᵐ[μ] Ω.indicator ψ :=
   coeFn_mk ((memHS_coe ψ).indicator_of_restrict hΩ)
 
 lemma leftInverse_subspaceProjection {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
-    LeftInverse (subspaceProjection (μ := μ) Ω) (restrictIncl hΩ) := by
+    LeftInverse (subspaceProjection (μ := μ) Ω) (subspaceIncl hΩ) := by
   intro ψ
   apply ext_iff.mpr
-  have h := subspaceProjection_apply Ω (restrictIncl hΩ ψ)
+  have h := subspaceProjection_apply Ω (subspaceIncl hΩ ψ)
   rw [ae_eq_restrict_iff_indicator_ae_eq hΩ] at *
-  filter_upwards [restrictIncl_apply hΩ ψ, h] with x
+  filter_upwards [subspaceIncl_apply hΩ ψ, h] with x
   by_cases x ∈ Ω <;> simp_all
 
 @[simp]
-lemma subspaceProjection_restrictIncl_apply
+lemma subspaceProjection_subspaceIncl_apply
     {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (ψ : SpaceDHilbertSpace d (μ.restrict Ω)) :
-    subspaceProjection Ω (restrictIncl hΩ ψ) = ψ :=
+    subspaceProjection Ω (subspaceIncl hΩ ψ) = ψ :=
   leftInverse_subspaceProjection hΩ ψ
 
 lemma subspaceProjection_surjective {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
@@ -26,8 +26,8 @@ consisting of those vectors with domain contained in `Ω`.
 The reason is that for each `f` in `SpaceDHilbertSpace d (μ.restrict Ω)` we have
 `f =ᵐ[μ.restrict Ω] Ω.indicator f`, namely the equivalence class of `f` always
 contains a representative which vanishes on the complement of `Ω`.
-The linear map `restrictIncl Ω` defined below describes this sub-Hilbert space relationship by
-mapping each `f` to this special representative in its equivalence class.
+The linear isometry `restrictIncl Ω` defined below describes this sub-Hilbert space relationship
+by mapping each `f` to this special representative in its equivalence class.
 
 Similarly, we may project `SpaceDHilbertSpace d μ` onto the sub-Hilbert space
 `SpaceDHilbertSpace d (μ.restrict Ω)` by enlarging the equivalence classes, essentially dropping
@@ -42,7 +42,7 @@ information about the functions on the complement of `Ω`.
     to an element of the Hilbert space.
 - `subspaceProjection` : The projection of `SpaceDHilbertSpace d μ` onto a sub-Hilbert space
     `SpaceDHilbertSpace d (μ.restrict Ω)`.
-- `restrictIncl Ω` : The linear map including `SpaceDHilbertSpace d (μ.restrict Ω)`
+- `restrictIncl Ω` : The linear isometry including `SpaceDHilbertSpace d (μ.restrict Ω)`
     as a sub-Hilbert space of `SpaceDHilbertspace d μ`.
 
 ## iii. Table of contents
@@ -240,10 +240,10 @@ lemma subspaceProjection_norm_le (Ω : Set (Space d)) (ψ : SpaceDHilbertSpace d
   refine (eLpNorm_congr_ae (subspaceProjection_apply Ω ψ)).trans_le ?_
   exact eLpNorm_mono_measure ψ restrict_le_self
 
-/-- The linear map including `SpaceDHilbertSpace d (μ.restrict Ω)` as a sub-Hilbert space of
+/-- The linear isometry including `SpaceDHilbertSpace d (μ.restrict Ω)` as a sub-Hilbert space of
   `SpaceDHilbertSpace d μ` defined by mapping `ψ` to `Ω.indicator ψ`. -/
 def restrictIncl {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
-    SpaceDHilbertSpace d (μ.restrict Ω) →ₗ[ℂ] SpaceDHilbertSpace d μ where
+    SpaceDHilbertSpace d (μ.restrict Ω) →ₗᵢ[ℂ] SpaceDHilbertSpace d μ where
   toFun ψ := mk ((memHS_coe ψ).indicator_of_restrict hΩ)
   map_add' ψ φ := by
     rw [← mk_add, mk_eq_iff, ← indicator_add']
@@ -251,19 +251,16 @@ def restrictIncl {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
   map_smul' c ψ := by
     rw [← mk_const_smul, mk_eq_iff, Pi.smul_def, ← indicator_const_smul]
     exact (ae_eq_restrict_iff_indicator_ae_eq hΩ).mp (coeFn_smul c ψ)
+  norm_map' ψ := by
+    calc
+      _ = (eLpNorm (mk ((memHS_coe ψ).indicator_of_restrict hΩ)) 2 μ).toReal := rfl
+      _ = (eLpNorm (Ω.indicator ψ) 2 μ).toReal := congrArg _ (eLpNorm_congr_ae (coeFn_mk _))
+      _ = ‖ψ‖ := congrArg _ (eLpNorm_indicator_eq_eLpNorm_restrict hΩ)
 
 lemma restrictIncl_apply
     {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (ψ : SpaceDHilbertSpace d (μ.restrict Ω)) :
     restrictIncl hΩ ψ =ᵐ[μ] Ω.indicator ψ :=
   coeFn_mk ((memHS_coe ψ).indicator_of_restrict hΩ)
-
-@[simp]
-lemma restrictIncl_norm
-    {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (ψ : SpaceDHilbertSpace d (μ.restrict Ω)) :
-    ‖restrictIncl hΩ ψ‖ = ‖ψ‖ := by
-  trans (eLpNorm (Ω.indicator ψ) 2 μ).toReal
-  · simp only [norm, eLpNorm_congr_ae (restrictIncl_apply hΩ ψ)]
-  exact congrArg _ (eLpNorm_indicator_eq_eLpNorm_restrict hΩ)
 
 lemma leftInverse_subspaceProjection {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
     LeftInverse (subspaceProjection (μ := μ) Ω) (restrictIncl hΩ) := by

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
@@ -23,7 +23,8 @@ public import Physlib.SpaceAndTime.Space.Module
 - C. Membership
 - D. Construction of elements
 - E. Coersions
-- F. Misc.
+- F. Sub-Hilbert spaces
+- G. Misc.
 
 ## iv. References
 
@@ -179,7 +180,77 @@ lemma coeFn_smul : ⇑(c • ψ) =ᵐ[μ] c • ψ := Lp.coeFn_smul _ _
 end
 
 /-!
-## F. Misc.
+## F. Sub-Hilbert spaces
+-/
+
+/-- The linear map projecting `SpaceDHilbertSpace d μ` onto the sub-Hilbert space
+  of functions which vanish `μ`-a.e. outside of `Ω`. -/
+def subspaceProjection (Ω : Set (Space d)) :
+    SpaceDHilbertSpace d μ →ₗ[ℂ] SpaceDHilbertSpace d (μ.restrict Ω) where
+  toFun ψ := mk ((memHS_coe ψ).restrict Ω)
+  map_add' ψ φ := by
+    rw [← mk_add, mk_eq_iff]
+    exact (coeFn_add ψ φ).filter_mono ae_restrict_le
+  map_smul' c ψ := by
+    rw [← mk_const_smul, mk_eq_iff]
+    exact (coeFn_smul c ψ).filter_mono ae_restrict_le
+
+lemma subspaceProjection_apply (Ω : Set (Space d)) (ψ : SpaceDHilbertSpace d μ) :
+    subspaceProjection Ω ψ =ᵐ[μ.restrict Ω] ψ :=
+  coeFn_mk ((memHS_coe ψ).restrict Ω)
+
+lemma subspaceProjection_norm_le (Ω : Set (Space d)) (ψ : SpaceDHilbertSpace d μ) :
+    ‖subspaceProjection Ω ψ‖ ≤ ‖ψ‖ := by
+  refine ENNReal.toReal_mono (Lp.eLpNorm_ne_top ψ) ?_
+  refine (eLpNorm_congr_ae (subspaceProjection_apply Ω ψ)).trans_le ?_
+  exact eLpNorm_mono_measure ψ restrict_le_self
+
+/-- The linear map including `SpaceDHilbertSpace d (μ.restrict Ω)` as a sub-Hilbert space of
+  `SpaceDHilbertSpace d μ` defined by mapping `ψ` to `Ω.indicator ψ`. -/
+def restrictIncl {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
+    SpaceDHilbertSpace d (μ.restrict Ω) →ₗ[ℂ] SpaceDHilbertSpace d μ where
+  toFun ψ := mk ((memHS_coe ψ).indicator_of_restrict hΩ)
+  map_add' ψ φ := by
+    rw [← mk_add, mk_eq_iff, ← indicator_add']
+    exact (ae_eq_restrict_iff_indicator_ae_eq hΩ).mp (coeFn_add ψ φ)
+  map_smul' c ψ := by
+    rw [← mk_const_smul, mk_eq_iff, Pi.smul_def, ← indicator_const_smul]
+    exact (ae_eq_restrict_iff_indicator_ae_eq hΩ).mp (coeFn_smul c ψ)
+
+lemma restrictIncl_apply
+    {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (ψ : SpaceDHilbertSpace d (μ.restrict Ω)) :
+    restrictIncl hΩ ψ =ᵐ[μ] Ω.indicator ψ :=
+  coeFn_mk ((memHS_coe ψ).indicator_of_restrict hΩ)
+
+@[simp]
+lemma restrictIncl_norm
+    {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (ψ : SpaceDHilbertSpace d (μ.restrict Ω)) :
+    ‖restrictIncl hΩ ψ‖ = ‖ψ‖ := by
+  trans (eLpNorm (Ω.indicator ψ) 2 μ).toReal
+  · simp only [norm, eLpNorm_congr_ae (restrictIncl_apply hΩ ψ)]
+  exact congrArg _ (eLpNorm_indicator_eq_eLpNorm_restrict hΩ)
+
+lemma leftInverse_subspaceProjection {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
+    LeftInverse (subspaceProjection (μ := μ) Ω) (restrictIncl hΩ) := by
+  intro ψ
+  apply ext_iff.mpr
+  have h := subspaceProjection_apply Ω (restrictIncl hΩ ψ)
+  rw [ae_eq_restrict_iff_indicator_ae_eq hΩ] at *
+  filter_upwards [restrictIncl_apply hΩ ψ, h] with x
+  by_cases x ∈ Ω <;> simp_all
+
+@[simp]
+lemma subspaceProjection_restrictIncl_apply
+    {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (ψ : SpaceDHilbertSpace d (μ.restrict Ω)) :
+    subspaceProjection Ω (restrictIncl hΩ ψ) = ψ :=
+  leftInverse_subspaceProjection hΩ ψ
+
+lemma subspaceProjection_surjective {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
+    Surjective (subspaceProjection (μ := μ) Ω) :=
+  (leftInverse_subspaceProjection hΩ).surjective
+
+/-!
+## G. Misc.
 -/
 
 open Filter

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/Basic.lean
@@ -48,7 +48,7 @@ abbrev SpaceDHilbertSpace (d : ℕ) (μ : Measure (Space d) := volume) := Lp ℂ
 
 namespace SpaceDHilbertSpace
 
-variable {d : ℕ} {μ : Measure (Space d)} {f g : Space d → ℂ} (ψ φ : SpaceDHilbertSpace d μ)
+variable {d : ℕ} {μ μ' : Measure (Space d)} {f g : Space d → ℂ} (ψ φ : SpaceDHilbertSpace d μ)
 
 variable {ψ φ} in
 lemma ext_iff : ψ = φ ↔ ψ =ᵐ[μ] φ := Lp.ext_iff
@@ -99,6 +99,27 @@ lemma MemHS.sub (hf : MemHS f μ) (hg : MemHS g μ) : MemHS (f - g) μ := MemLp.
 lemma MemHS.const_smul (c : ℂ) (hf : MemHS f μ) : MemHS (c • f) μ := MemLp.const_smul hf c
 
 lemma MemHS.ae_eq (hfg : f =ᵐ[μ] g) (hf : MemHS f μ) : MemHS g μ := MemLp.ae_eq hfg hf
+
+lemma MemHS.mono_measure (h : μ' ≤ μ) (hf : MemHS f μ) : MemHS f μ' := MemLp.mono_measure h hf
+
+lemma MemHS.restrict (Ω : Set (Space d)) (hf : MemHS f μ) : MemHS f (μ.restrict Ω) :=
+  hf.mono_measure restrict_le_self
+
+lemma MemHS.mono_restrict {Ω Ω' : Set (Space d)} (h : Ω' ≤ Ω) (hf : MemHS f (μ.restrict Ω)) :
+    MemHS f (μ.restrict Ω') :=
+  hf.mono_measure (μ.restrict_mono_set h)
+
+lemma MemHS.indicator {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (hf : MemHS f μ) :
+    MemHS (Ω.indicator f) μ :=
+  MemLp.indicator hΩ hf
+
+lemma MemHS.indicator_of_restrict
+    {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (hf : MemHS f (μ.restrict Ω)) :
+    MemHS (Ω.indicator f) μ := by
+  refine memHS_iff.mpr ⟨(aestronglyMeasurable_indicator_iff hΩ).mpr hf.1, ?_⟩
+  refine (IntegrableOn.integrable_indicator (memHS_iff.mp hf).2 hΩ).congr ?_
+  filter_upwards with x
+  by_cases x ∈ Ω <;> simp_all
 
 /-!
 ## D. Construction of elements


### PR DESCRIPTION
Generalizes `SpaceDHilbertSpace` to allow for general `Space d` measures.

Also adds some new `MemHS` lemmas and the linear maps `subspaceProjection` and `restrictIncl` which describe the relationship between `SpaceDHilbertSpace d (μ.restrict Ω)` and `SpaceDHilbertSpace d μ` for a set `Ω` of `Space d`.
The former can be interpreted as the sub-Hilbert space of the latter consisting of functions with support contained in `Ω`, as described in the module docstring.