### PR TITLE
fix: /check-golf --measure crash (def_body_changed -> def_value_changed)

### DIFF
--- a/scripts/check_golf.py
+++ b/scripts/check_golf.py
@@ -743,7 +743,7 @@ def measure_files(base: str, head: str, reports: List[FileReport],
     itself verifies -- because only proof/body text then differs.
     """
     paths = [r.path for r in reports
-             if r.proof_golfed or r.embedded_proof_changed or r.def_body_changed]
+             if r.proof_golfed or r.embedded_proof_changed or r.def_value_changed]
     if limit is not None:
         paths = paths[:limit]
     out: List[Measurement] = []


### PR DESCRIPTION
The measure-path file selection in `scripts/check_golf.py` (added in #1356) references a nonexistent `FileReport` attribute `def_body_changed`; the field is named `def_value_changed`. As a result every `/check-golf` run since #1356 crashes with an `AttributeError` after building the head, so the report comment is never posted/updated (see e.g. [this run](https://github.com/leanprover-community/physlib/actions/runs/28951786476) on #1364).

One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)