### PR TITLE
feat(ClassicalMechanics): add the total kinetic energy and prove the König decomposition

### DIFF
--- a/Physlib/ClassicalMechanics/RigidBody/API-map.yaml
+++ b/Physlib/ClassicalMechanics/RigidBody/API-map.yaml
@@ -13,7 +13,9 @@ Overview: |
     centre-of-mass velocity and linear momentum, the rigid displacement and the moved mass
     distribution, and the angular velocity — as the skew-symmetric tensor `Ω = Ṙ Rᵀ` in any
     dimension and, in three dimensions, as the dual vector `ω` obtained from `Ω` via the hat
-    map.
+    map. The total kinetic energy of the motion is defined and shown to split into a
+    translational part `½ M V · V` and a rotational part about the centre of mass — in three
+    dimensions `½ ∫ |ω × r|² dm` — the König decomposition.
 
 ParentAPIs:
   - Space (Physlib/SpaceAndTime/Space)
@@ -72,8 +74,10 @@ Requirements:
     location: Physlib/ClassicalMechanics/RigidBody/Motion.lean (RigidBodyMotion.centerOfMassVelocity)
 
   - description: The API contains the definition of the kinetic energy of the rigid body.
-    done: false
-    location: N/A
+    done: true
+    location: >
+      Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
+      (RigidBody.rotationalKineticEnergy, RigidBodyMotion.kineticEnergy)
 
   - description: The API contains the definition of Euler angles for a rigid body.
     done: false

--- a/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
@@ -116,6 +116,17 @@ lemma angularVelocityTensor_mul_orientation (M : RigidBodyMotion d) (t : Time) :
   rw [angularVelocityTensor_eq, mul_assoc,
     mul_eq_one_comm.mp (M.orientation_mul_transpose t), mul_one]
 
+/-- The rotational part of the velocity of the body point `y` is the cross product of the
+angular velocity with the point's position relative to the centre of mass:
+`Ṙ(t) (y − c) = ω(t) × (displacement t y − comTrajectory t)`. -/
+lemma deriv_orientation_mulVec_eq_angularVelocity_cross (M : RigidBodyMotion 3) (y : Space 3)
+    (t : Time) (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t) :
+    ∂ₜ (fun s => (M.orientation s).1) t *ᵥ (fun j => y j - M.centerOfMass j)
+      = M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j := by
+  rw [← M.angularVelocityTensor_mul_orientation t, ← Matrix.mulVec_mulVec,
+    M.orientation_mulVec_sub_centerOfMass t y,
+    ← M.crossProductMatrix_angularVelocity t hR, Matrix.crossProductMatrix_mulVec]
+
 /-- The Landau–Lifshitz velocity decomposition `v = V + ω × r` for a rigid body in three
 dimensions: the velocity of a body point is the centre-of-mass velocity plus the cross product of
 the angular velocity with the point's position relative to the centre of mass. -/
@@ -123,16 +134,7 @@ theorem velocity_eq_angularVelocity (M : RigidBodyMotion 3) (y : Space 3) (t : T
     (hR : Differentiable ℝ (fun s => (M.orientation s).1)) (hX : Differentiable ℝ M.comTrajectory) :
     M.velocity y t i = M.centerOfMassVelocity t i
         + (M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j) i := by
-  have hRw : (M.orientation t).1 *ᵥ (fun j => y j - M.centerOfMass j)
-      = fun j => M.displacement t y j - M.comTrajectory t j := by
-    funext k
-    show ((M.orientation t).1 *ᵥ fun j => y j - M.centerOfMass j) k
-      = M.displacement t y k - M.comTrajectory t k
-    rw [eq_sub_iff_add_eq, displacement_apply]
-    rfl
-  rw [M.velocity_eq_deriv_orientation y t i hR hX, add_comm]
-  congr 1
-  rw [← M.angularVelocityTensor_mul_orientation t, ← Matrix.mulVec_mulVec, hRw,
-    ← M.crossProductMatrix_angularVelocity t (hR t), Matrix.crossProductMatrix_mulVec]
+  rw [M.velocity_eq_deriv_orientation y t i hR hX, add_comm,
+    M.deriv_orientation_mulVec_eq_angularVelocity_cross y t (hR t)]
 
 end RigidBodyMotion

--- a/Physlib/ClassicalMechanics/RigidBody/Basic.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Basic.lean
@@ -42,6 +42,11 @@ namespace RigidBody
 /-- The total mass of the rigid body. -/
 noncomputable def mass {d : ℕ} (R : RigidBody d) : ℝ := R.ρ ⟨fun _ => 1, contMDiff_const⟩
 
+/-- The mass distribution applied to the constant function `1` is the total mass. -/
+@[simp]
+lemma rho_one {d : ℕ} (R : RigidBody d) :
+    R.ρ (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) = R.mass := rfl
+
 /-- The center of mass of the rigid body. -/
 noncomputable def centerOfMass {d : ℕ} (R : RigidBody d) : Space d := ⟨fun i =>
   (1 / R.mass) • R.ρ ⟨fun x => x i, ContDiff.contMDiff <| by fun_prop⟩⟩
@@ -62,10 +67,31 @@ lemma inertiaTensor_symmetric {d : ℕ} (R : RigidBody d) (i j : Fin d) :
     exact Eq.propIntro (fun a => id (Eq.symm a)) fun a => id (Eq.symm a)
   · ring
 
-/-- The kinetic energy of a rigid body. -/
-informal_definition kineticEnergy where
-  tag := "MEYBM"
-  deps := [``RigidBody]
+/-- Bundle a smooth real-valued function on `Space d` as an element of the space of test
+functions. Keeping this as a named constructor ensures the resulting type head stays
+`ContMDiffMap`, so the module/ring operations and `comp` resolve correctly. -/
+def cmap {d : ℕ} (f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f) :
+    C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯ := ⟨f, hf.contMDiff⟩
+
+@[simp]
+lemma cmap_apply {d : ℕ} (f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f) (y : Space d) :
+    cmap f hf y = f y := rfl
+
+/-- The first moment of the mass distribution about its own centre of mass vanishes:
+for nonzero mass, `ρ` of the centred `j`-th coordinate function is zero. -/
+lemma rho_coord_sub_centerOfMass {d : ℕ} (R : RigidBody d) (h : R.mass ≠ 0) (j : Fin d) :
+    R.ρ (cmap (fun y => y j - R.centerOfMass j) (by fun_prop)) = 0 := by
+  have hsplit : cmap (fun y => y j - R.centerOfMass j) (by fun_prop)
+        = cmap (fun y => y j) (by fun_prop)
+          - R.centerOfMass j • (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) := by
+    ext y
+    simp only [cmap_apply, ContMDiffMap.coe_sub, ContMDiffMap.coe_smul,
+      ContMDiffMap.coe_one, Pi.sub_apply, Pi.smul_apply, Pi.one_apply, smul_eq_mul, mul_one]
+  have hcoord : R.ρ (cmap (fun y => y j) (by fun_prop)) = R.mass * R.centerOfMass j := by
+    have hc : R.centerOfMass j = (1 / R.mass) • R.ρ (cmap (fun y => y j) (by fun_prop)) := rfl
+    rw [hc, smul_eq_mul, one_div, ← mul_assoc, mul_inv_cancel₀ h, one_mul]
+  rw [hsplit, map_sub, map_smul, R.rho_one, hcoord, smul_eq_mul]
+  ring
 
 /-- One can describe the motion of rigid body with a fixed (inertial) coordinate system (X,Y,Z)
     and a moving system (x₁,x₂,x₃) rigidly attached to the body. -/

--- a/Physlib/ClassicalMechanics/RigidBody/Basic.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Basic.lean
@@ -67,6 +67,10 @@ lemma inertiaTensor_symmetric {d : ℕ} (R : RigidBody d) (i j : Fin d) :
     exact Eq.propIntro (fun a => id (Eq.symm a)) fun a => id (Eq.symm a)
   · ring
 
+TODO "Move `cmap` and `cmap_apply` to a more general location, such as a file in
+  `SpaceAndTime/Space/` or `Mathematics/`. Alternatively, define a version of `ρ` taking an
+  unbundled `(f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f)` in place of a `ContMDiffMap`."
+
 /-- Bundle a smooth real-valued function on `Space d` as an element of the space of test
 functions. Keeping this as a named constructor ensures the resulting type head stays
 `ContMDiffMap`, so the module/ring operations and `comp` resolve correctly. -/

--- a/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
@@ -24,6 +24,11 @@ mass distribution about its centre of mass is zero. In three dimensions the rota
 `½ ∫ |ω × r|² dm`, with `ω` the angular velocity vector and `r` the position of the body point
 relative to the centre of mass.
 
+The total kinetic energy is defined with the point velocity taken in the closed form
+`Ṙ(t) (y − c) + V(t)` (`velocityClosedForm`), which is polynomial in the body point and hence
+smooth for any motion; for differentiable motions it agrees with the honest point velocity
+`∂ₜ (displacement · y)`, recovering `T = ½ ∫ ⟪v, v⟫ dm` (`kineticEnergy_eq_integral_velocity`).
+
 ## References
 - Landau and Lifshitz, Mechanics, Section 32.
 -/
@@ -40,19 +45,19 @@ namespace RigidBody
 /-- The rotational kinetic energy of a rigid body rotating with angular velocity `ω` about its
 reference point: half the contraction of `ω` with the inertia tensor, `T = ½ ω · (I ω)`. -/
 noncomputable def rotationalKineticEnergy (R : RigidBody 3) (ω : Fin 3 → ℝ) : ℝ :=
-  (1 / 2) * (ω ⬝ᵥ R.inertiaTensor *ᵥ ω)
+  (1 / (2 : ℝ)) * (ω ⬝ᵥ R.inertiaTensor *ᵥ ω)
 
 /-- The rotational kinetic energy is half the contraction of the angular velocity with the angular
 momentum: `T = ½ ω · L`. -/
 lemma rotationalKineticEnergy_eq_angularMomentum (R : RigidBody 3) (ω : Fin 3 → ℝ) :
-    R.rotationalKineticEnergy ω = (1 / 2) * (ω ⬝ᵥ R.angularMomentum ω) := by
+    R.rotationalKineticEnergy ω = (1 / (2 : ℝ)) * (ω ⬝ᵥ R.angularMomentum ω) := by
   rw [rotationalKineticEnergy, angularMomentum_eq_inertiaTensor_mulVec]
 
 /-- The rotational kinetic energy equals the mass integral of the local rotational speed squared:
 `T = ½ ∫ |ω × r|² dm`. -/
 theorem rotationalKineticEnergy_eq_integral (R : RigidBody 3) (ω : Fin 3 → ℝ) :
     R.rotationalKineticEnergy ω
-      = (1 / 2) * R.ρ ⟨fun x => (ω ⨯₃ (x : Fin 3 → ℝ)) ⬝ᵥ (ω ⨯₃ (x : Fin 3 → ℝ)),
+      = (1 / (2 : ℝ)) * R.ρ ⟨fun x => (ω ⨯₃ (x : Fin 3 → ℝ)) ⬝ᵥ (ω ⨯₃ (x : Fin 3 → ℝ)),
         ContDiff.contMDiff <| (contDiff_cross_dotProduct_cross ω).comp
           (contDiff_pi.mpr fun i => Space.eval_contDiff i)⟩ := by
   rw [rotationalKineticEnergy_eq_angularMomentum]
@@ -70,21 +75,18 @@ end RigidBody
 namespace RigidBodyMotion
 
 /-- The total kinetic energy of a rigid body in motion at time `t`: half the mass integral of the
-squared speed of the body points, `T = ½ ∫ ⟪v, v⟫ dm`, with the velocity of the point `y` written
-in the closed form `Ṙ(t) (y − c) + V(t)`, which is polynomial in `y` for any motion. For
-differentiable motions this is the honest point velocity `∂ₜ (displacement · y)`; see
-`kineticEnergy_eq_integral_velocity`. -/
+squared speed of the body points, `T = ½ ∫ ⟪v, v⟫ dm`, with the point velocity taken in the
+closed form `velocityClosedForm`. -/
 noncomputable def kineticEnergy {d : ℕ} (M : RigidBodyMotion d) (t : Time) : ℝ :=
-  (1 / 2) * M.ρ (cmap (fun y => (⟪M.velocityClosedForm t y, M.velocityClosedForm t y⟫_ℝ))
+  (1 / (2 : ℝ)) * M.ρ (cmap (fun y => (⟪M.velocityClosedForm t y, M.velocityClosedForm t y⟫_ℝ))
     (M.contDiff_velocityClosedForm_inner t))
 
-/-- For a differentiable motion the total kinetic energy is the mass integral of half the squared
-speed of the body points, `T = ½ ∫ ⟪v, v⟫ dm` with `v` the honest point velocity
-`∂ₜ (displacement · y)`: the closed-form integrand of `kineticEnergy` agrees with the velocity. -/
+/-- For a differentiable motion the integrand of `kineticEnergy` is the squared speed of the
+honest point velocity: `T = ½ ∫ ⟪v, v⟫ dm` with `v = ∂ₜ (displacement · y)`. -/
 lemma kineticEnergy_eq_integral_velocity {d : ℕ} (M : RigidBodyMotion d) (t : Time)
     (hR : Differentiable ℝ (fun s => (M.orientation s).1))
     (hX : Differentiable ℝ M.comTrajectory) :
-    M.kineticEnergy t = (1 / 2) * M.ρ (cmap
+    M.kineticEnergy t = (1 / (2 : ℝ)) * M.ρ (cmap
       (fun y => (⟪M.velocity y t, M.velocity y t⟫_ℝ))
       (by
         simp only [← M.velocityClosedForm_eq_velocity t hR hX]
@@ -94,11 +96,9 @@ lemma kineticEnergy_eq_integral_velocity {d : ℕ} (M : RigidBodyMotion d) (t : 
   ext y
   simp only [cmap_apply, M.velocityClosedForm_eq_velocity t hR hX]
 
-/-- The squared-speed integrand of the total kinetic energy, viewed as a smooth function of the
-body point, splits into the squared rotational speed `|Ṙ (y − c)|²`, a term linear in the
-body-frame coordinate `y − c`, and the constant squared centre-of-mass speed `⟪V, V⟫`. This is the
-algebraic heart of König's theorem: once `ρ` is applied, the linear term integrates to zero
-because the first moment of the mass distribution about its centre of mass vanishes. -/
+/-- The squared-speed integrand of `kineticEnergy` splits into the squared rotational speed
+`|Ṙ (y − c)|²`, a term linear in the body-frame coordinate `y − c`, and the constant squared
+centre-of-mass speed `⟪V, V⟫`. -/
 lemma kineticEnergy_integrand_split {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
     cmap (fun y => (⟪M.velocityClosedForm t y, M.velocityClosedForm t y⟫_ℝ))
         (M.contDiff_velocityClosedForm_inner t)
@@ -134,13 +134,12 @@ lemma kineticEnergy_integrand_split {d : ℕ} (M : RigidBodyMotion d) (t : Time)
 
 /-- **König's theorem**, general form: the total kinetic energy of a rigid body in motion splits
 into the kinetic energy of the centre of mass plus the rotational energy about the centre of
-mass, `T = ½ M ⟪V, V⟫ + ½ ∫ |Ṙ (y − c)|² dm`. The cross term vanishes because the first moment of
-the mass distribution about its centre of mass is zero. -/
+mass, `T = ½ M ⟪V, V⟫ + ½ ∫ |Ṙ (y − c)|² dm`. -/
 theorem kineticEnergy_eq_translational_add_rotational {d : ℕ} (M : RigidBodyMotion d) (t : Time)
     (h : M.mass ≠ 0) :
     M.kineticEnergy t
-      = (1 / 2) * M.mass * (⟪M.centerOfMassVelocity t, M.centerOfMassVelocity t⟫_ℝ)
-        + (1 / 2) * M.ρ (cmap (fun y =>
+      = (1 / (2 : ℝ)) * M.mass * (⟪M.centerOfMassVelocity t, M.centerOfMassVelocity t⟫_ℝ)
+        + (1 / (2 : ℝ)) * M.ρ (cmap (fun y =>
             (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) ⬝ᵥ
             (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j))
           (by simp only [dotProduct, Matrix.mulVec]; fun_prop)) := by
@@ -150,15 +149,14 @@ theorem kineticEnergy_eq_translational_add_rotational {d : ℕ} (M : RigidBodyMo
   ring
 
 /-- **König's theorem** in three dimensions: the total kinetic energy of a rigid body in motion
-splits as `T = ½ M ⟪V, V⟫ + ½ ∫ |ω × r|² dm`, the kinetic energy of the centre of mass plus the
-rotational energy of the spinning about it, where `ω` is the angular velocity vector and
-`r = displacement − comTrajectory` is the position of the body point relative to the centre of
+splits as `T = ½ M ⟪V, V⟫ + ½ ∫ |ω × r|² dm`, with `ω` the angular velocity vector and
+`r = displacement − comTrajectory` the position of the body point relative to the centre of
 mass. -/
 theorem kineticEnergy_eq_translational_add_angularVelocity (M : RigidBodyMotion 3) (t : Time)
     (h : M.mass ≠ 0) (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t) :
     M.kineticEnergy t
-      = (1 / 2) * M.mass * (⟪M.centerOfMassVelocity t, M.centerOfMassVelocity t⟫_ℝ)
-        + (1 / 2) * M.ρ (cmap (fun y =>
+      = (1 / (2 : ℝ)) * M.mass * (⟪M.centerOfMassVelocity t, M.centerOfMassVelocity t⟫_ℝ)
+        + (1 / (2 : ℝ)) * M.ρ (cmap (fun y =>
             (M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j) ⬝ᵥ
             (M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j))
           (by

--- a/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
@@ -17,9 +17,9 @@ position `r` has velocity `ω × r`, so its kinetic energy is `T = ½ ∫ |ω ×
 kinetic energy is the quadratic form `T = ½ ω · L = ½ ω · I ω` in the inertia tensor.
 
 For a rigid body in motion the total kinetic energy is the mass integral of half the squared
-speed of its points, `T = ½ ∫ v · v dm`. König's theorem splits it into the kinetic energy of
+speed of its points, `T = ½ ∫ ⟪v, v⟫ dm`. König's theorem splits it into the kinetic energy of
 the centre of mass plus the rotational energy about the centre of mass,
-`T = ½ M V · V + ½ ∫ |Ṙ (y − c)|² dm`: the cross term vanishes because the first moment of the
+`T = ½ M ⟪V, V⟫ + ½ ∫ |Ṙ (y − c)|² dm`: the cross term vanishes because the first moment of the
 mass distribution about its centre of mass is zero. In three dimensions the rotational term is
 `½ ∫ |ω × r|² dm`, with `ω` the angular velocity vector and `r` the position of the body point
 relative to the centre of mass.
@@ -30,7 +30,7 @@ relative to the centre of mass.
 
 @[expose] public section
 
-open Time Manifold Matrix RigidBody
+open Time Manifold Matrix RigidBody InnerProductSpace
 
 attribute [local instance] Matrix.linftyOpNormedAddCommGroup Matrix.linftyOpNormedSpace
   Matrix.linftyOpNormedRing Matrix.linftyOpNormedAlgebra
@@ -69,69 +69,39 @@ end RigidBody
 
 namespace RigidBodyMotion
 
-/-- The closed form `Ṙ(t) (y − c) + V(t)` of the velocity of the body point `y` at time `t`:
-the rate of change of the orientation acting on the body-frame position, plus the centre-of-mass
-velocity. It is polynomial in `y` for any motion, and for differentiable motions it agrees with
-the honest point velocity `∂ₜ (displacement · y)`; see `velocityClosedForm_eq_velocity`. -/
-noncomputable def velocityClosedForm {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d) :
-    Fin d → ℝ :=
-  (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j)
-    + (M.centerOfMassVelocity t : Fin d → ℝ)
-
-/-- For a differentiable motion the closed-form velocity is the honest point velocity. -/
-lemma velocityClosedForm_eq_velocity {d : ℕ} (M : RigidBodyMotion d) (t : Time)
-    (hR : Differentiable ℝ (fun s => (M.orientation s).1))
-    (hX : Differentiable ℝ M.comTrajectory) (y : Space d) :
-    M.velocityClosedForm t y = (M.velocity y t : Fin d → ℝ) := by
-  funext i
-  rw [velocityClosedForm, Pi.add_apply, ← M.velocity_eq_deriv_orientation y t i hR hX]
-
-/-- The squared speed of a body point, in closed form, is a smooth function of the point. -/
-lemma contDiff_velocityClosedForm_dotProduct {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
-    ContDiff ℝ ⊤ fun y : Space d => M.velocityClosedForm t y ⬝ᵥ M.velocityClosedForm t y := by
-  simp only [velocityClosedForm, dotProduct, Matrix.mulVec, Pi.add_apply]
-  fun_prop
-
 /-- The total kinetic energy of a rigid body in motion at time `t`: half the mass integral of the
-squared speed of the body points, `T = ½ ∫ v · v dm`, with the velocity of the point `y` written
+squared speed of the body points, `T = ½ ∫ ⟪v, v⟫ dm`, with the velocity of the point `y` written
 in the closed form `Ṙ(t) (y − c) + V(t)`, which is polynomial in `y` for any motion. For
 differentiable motions this is the honest point velocity `∂ₜ (displacement · y)`; see
 `kineticEnergy_eq_integral_velocity`. -/
 noncomputable def kineticEnergy {d : ℕ} (M : RigidBodyMotion d) (t : Time) : ℝ :=
-  (1 / 2) * M.ρ (cmap (fun y => M.velocityClosedForm t y ⬝ᵥ M.velocityClosedForm t y)
-    (M.contDiff_velocityClosedForm_dotProduct t))
+  (1 / 2) * M.ρ (cmap (fun y => (⟪M.velocityClosedForm t y, M.velocityClosedForm t y⟫_ℝ))
+    (M.contDiff_velocityClosedForm_inner t))
 
 /-- For a differentiable motion the total kinetic energy is the mass integral of half the squared
-speed of the body points, `T = ½ ∫ v · v dm` with `v` the honest point velocity
+speed of the body points, `T = ½ ∫ ⟪v, v⟫ dm` with `v` the honest point velocity
 `∂ₜ (displacement · y)`: the closed-form integrand of `kineticEnergy` agrees with the velocity. -/
 lemma kineticEnergy_eq_integral_velocity {d : ℕ} (M : RigidBodyMotion d) (t : Time)
     (hR : Differentiable ℝ (fun s => (M.orientation s).1))
     (hX : Differentiable ℝ M.comTrajectory) :
     M.kineticEnergy t = (1 / 2) * M.ρ (cmap
-      (fun y => (M.velocity y t : Fin d → ℝ) ⬝ᵥ (M.velocity y t : Fin d → ℝ))
+      (fun y => (⟪M.velocity y t, M.velocity y t⟫_ℝ))
       (by
         simp only [← M.velocityClosedForm_eq_velocity t hR hX]
-        exact M.contDiff_velocityClosedForm_dotProduct t)) := by
+        exact M.contDiff_velocityClosedForm_inner t)) := by
   rw [kineticEnergy]
   congr 2
   ext y
   simp only [cmap_apply, M.velocityClosedForm_eq_velocity t hR hX]
 
-/-- **König's theorem**, general form: the total kinetic energy of a rigid body in motion splits
-into the kinetic energy of the centre of mass plus the rotational energy about the centre of
-mass, `T = ½ M V · V + ½ ∫ |Ṙ (y − c)|² dm`. The cross term vanishes because the first moment of
-the mass distribution about its centre of mass is zero. -/
-theorem kineticEnergy_eq_translational_add_rotational {d : ℕ} (M : RigidBodyMotion d) (t : Time)
-    (h : M.mass ≠ 0) :
-    M.kineticEnergy t
-      = (1 / 2) * M.mass * ((M.centerOfMassVelocity t : Fin d → ℝ) ⬝ᵥ
-          (M.centerOfMassVelocity t : Fin d → ℝ))
-        + (1 / 2) * M.ρ (cmap (fun y =>
-            (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) ⬝ᵥ
-            (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j))
-          (by simp only [dotProduct, Matrix.mulVec]; fun_prop)) := by
-  have hsplit : cmap (fun y => M.velocityClosedForm t y ⬝ᵥ M.velocityClosedForm t y)
-        (M.contDiff_velocityClosedForm_dotProduct t)
+/-- The squared-speed integrand of the total kinetic energy, viewed as a smooth function of the
+body point, splits into the squared rotational speed `|Ṙ (y − c)|²`, a term linear in the
+body-frame coordinate `y − c`, and the constant squared centre-of-mass speed `⟪V, V⟫`. This is the
+algebraic heart of König's theorem: once `ρ` is applied, the linear term integrates to zero
+because the first moment of the mass distribution about its centre of mass vanishes. -/
+lemma kineticEnergy_integrand_split {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
+    cmap (fun y => (⟪M.velocityClosedForm t y, M.velocityClosedForm t y⟫_ℝ))
+        (M.contDiff_velocityClosedForm_inner t)
       = cmap (fun y =>
             (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) ⬝ᵥ
             (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j))
@@ -139,36 +109,55 @@ theorem kineticEnergy_eq_translational_add_rotational {d : ℕ} (M : RigidBodyMo
         + ∑ j, (2 * (((M.centerOfMassVelocity t : Fin d → ℝ) ᵥ*
               ∂ₜ (fun s => (M.orientation s).1) t) j)) •
             cmap (fun y => y j - M.centerOfMass j) (by fun_prop)
-        + ((M.centerOfMassVelocity t : Fin d → ℝ) ⬝ᵥ (M.centerOfMassVelocity t : Fin d → ℝ)) •
+        + (⟪M.centerOfMassVelocity t, M.centerOfMassVelocity t⟫_ℝ) •
             (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) := by
-    ext y
-    simp only [cmap_apply, ContMDiffMap.coe_add, ContMDiffMap.coe_smul, ContMDiffMap.coe_one,
-      Pi.add_apply, Pi.smul_apply, Pi.one_apply, smul_eq_mul, mul_one, velocityClosedForm]
-    rw [← ContMDiffMap.coeFnAddMonoidHom_apply, map_sum, Finset.sum_apply]
-    simp only [ContMDiffMap.coeFnAddMonoidHom_apply, ContMDiffMap.coe_smul, Pi.smul_apply,
-      cmap_apply, smul_eq_mul]
-    rw [add_dotProduct, dotProduct_add, dotProduct_add,
-      dotProduct_comm (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j)
-        (M.centerOfMassVelocity t : Fin d → ℝ),
-      dotProduct_mulVec (M.centerOfMassVelocity t : Fin d → ℝ)
-        (∂ₜ (fun s => (M.orientation s).1) t) (fun j => y j - M.centerOfMass j)]
-    simp only [dotProduct, two_mul, add_mul, Finset.sum_add_distrib]
-    ring
-  rw [kineticEnergy, hsplit, map_add, map_add, map_sum]
+  ext y
+  simp only [cmap_apply, ContMDiffMap.coe_add, ContMDiffMap.coe_smul, ContMDiffMap.coe_one,
+    Pi.add_apply, Pi.smul_apply, Pi.one_apply, smul_eq_mul, mul_one]
+  rw [← ContMDiffMap.coeFnAddMonoidHom_apply, map_sum, Finset.sum_apply]
+  simp only [ContMDiffMap.coeFnAddMonoidHom_apply, ContMDiffMap.coe_smul, Pi.smul_apply,
+    cmap_apply, smul_eq_mul]
+  rw [show (⟪M.velocityClosedForm t y, M.velocityClosedForm t y⟫_ℝ)
+        = (M.velocityClosedForm t y : Fin d → ℝ) ⬝ᵥ (M.velocityClosedForm t y : Fin d → ℝ) from
+      Space.inner_eq_sum _ _,
+    velocityClosedForm_val,
+    show (⟪M.centerOfMassVelocity t, M.centerOfMassVelocity t⟫_ℝ)
+        = (M.centerOfMassVelocity t : Fin d → ℝ) ⬝ᵥ (M.centerOfMassVelocity t : Fin d → ℝ) from
+      Space.inner_eq_sum _ _,
+    add_dotProduct, dotProduct_add, dotProduct_add,
+    dotProduct_comm (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j)
+      (M.centerOfMassVelocity t : Fin d → ℝ),
+    dotProduct_mulVec (M.centerOfMassVelocity t : Fin d → ℝ)
+      (∂ₜ (fun s => (M.orientation s).1) t) (fun j => y j - M.centerOfMass j)]
+  simp only [dotProduct, two_mul, add_mul, Finset.sum_add_distrib]
+  ring
+
+/-- **König's theorem**, general form: the total kinetic energy of a rigid body in motion splits
+into the kinetic energy of the centre of mass plus the rotational energy about the centre of
+mass, `T = ½ M ⟪V, V⟫ + ½ ∫ |Ṙ (y − c)|² dm`. The cross term vanishes because the first moment of
+the mass distribution about its centre of mass is zero. -/
+theorem kineticEnergy_eq_translational_add_rotational {d : ℕ} (M : RigidBodyMotion d) (t : Time)
+    (h : M.mass ≠ 0) :
+    M.kineticEnergy t
+      = (1 / 2) * M.mass * (⟪M.centerOfMassVelocity t, M.centerOfMassVelocity t⟫_ℝ)
+        + (1 / 2) * M.ρ (cmap (fun y =>
+            (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) ⬝ᵥ
+            (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j))
+          (by simp only [dotProduct, Matrix.mulVec]; fun_prop)) := by
+  rw [kineticEnergy, kineticEnergy_integrand_split, map_add, map_add, map_sum]
   simp only [map_smul, M.rho_coord_sub_centerOfMass h, smul_eq_mul, mul_zero,
     Finset.sum_const_zero, add_zero, M.rho_one]
   ring
 
 /-- **König's theorem** in three dimensions: the total kinetic energy of a rigid body in motion
-splits as `T = ½ M V · V + ½ ∫ |ω × r|² dm`, the kinetic energy of the centre of mass plus the
+splits as `T = ½ M ⟪V, V⟫ + ½ ∫ |ω × r|² dm`, the kinetic energy of the centre of mass plus the
 rotational energy of the spinning about it, where `ω` is the angular velocity vector and
 `r = displacement − comTrajectory` is the position of the body point relative to the centre of
 mass. -/
 theorem kineticEnergy_eq_translational_add_angularVelocity (M : RigidBodyMotion 3) (t : Time)
     (h : M.mass ≠ 0) (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t) :
     M.kineticEnergy t
-      = (1 / 2) * M.mass * ((M.centerOfMassVelocity t : Fin 3 → ℝ) ⬝ᵥ
-          (M.centerOfMassVelocity t : Fin 3 → ℝ))
+      = (1 / 2) * M.mass * (⟪M.centerOfMassVelocity t, M.centerOfMassVelocity t⟫_ℝ)
         + (1 / 2) * M.ρ (cmap (fun y =>
             (M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j) ⬝ᵥ
             (M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j))

--- a/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
@@ -6,14 +6,23 @@ Authors: Giuseppe Sorge
 module
 
 public import Physlib.ClassicalMechanics.RigidBody.AngularMomentum
+public import Physlib.ClassicalMechanics.RigidBody.AngularVelocity
 /-!
 
-# Rotational kinetic energy of a rigid body
+# Kinetic energy of a rigid body
 
 For a rigid body rotating with angular velocity `ω` about its reference point the point at
 position `r` has velocity `ω × r`, so its kinetic energy is `T = ½ ∫ |ω × r|² dm`. Since
 `|ω × r|² = ω · (r × (ω × r))` and the angular momentum is `L = ∫ r × (ω × r) dm = I ω`, the
 kinetic energy is the quadratic form `T = ½ ω · L = ½ ω · I ω` in the inertia tensor.
+
+For a rigid body in motion the total kinetic energy is the mass integral of half the squared
+speed of its points, `T = ½ ∫ v · v dm`. König's theorem splits it into the kinetic energy of
+the centre of mass plus the rotational energy about the centre of mass,
+`T = ½ M V · V + ½ ∫ |Ṙ (y − c)|² dm`: the cross term vanishes because the first moment of the
+mass distribution about its centre of mass is zero. In three dimensions the rotational term is
+`½ ∫ |ω × r|² dm`, with `ω` the angular velocity vector and `r` the position of the body point
+relative to the centre of mass.
 
 ## References
 - Landau and Lifshitz, Mechanics, Section 32.
@@ -21,7 +30,10 @@ kinetic energy is the quadratic form `T = ½ ω · L = ½ ω · I ω` in the ine
 
 @[expose] public section
 
-open Manifold Matrix
+open Time Manifold Matrix RigidBody
+
+attribute [local instance] Matrix.linftyOpNormedAddCommGroup Matrix.linftyOpNormedSpace
+  Matrix.linftyOpNormedRing Matrix.linftyOpNormedAlgebra
 
 namespace RigidBody
 
@@ -54,3 +66,121 @@ theorem rotationalKineticEnergy_eq_integral (R : RigidBody 3) (ω : Fin 3 → �
   exact dotProduct_cross_cross_self (x : Fin 3 → ℝ) ω
 
 end RigidBody
+
+namespace RigidBodyMotion
+
+/-- The closed form `Ṙ(t) (y − c) + V(t)` of the velocity of the body point `y` at time `t`:
+the rate of change of the orientation acting on the body-frame position, plus the centre-of-mass
+velocity. It is polynomial in `y` for any motion, and for differentiable motions it agrees with
+the honest point velocity `∂ₜ (displacement · y)`; see `velocityClosedForm_eq_velocity`. -/
+noncomputable def velocityClosedForm {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d) :
+    Fin d → ℝ :=
+  (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j)
+    + (M.centerOfMassVelocity t : Fin d → ℝ)
+
+/-- For a differentiable motion the closed-form velocity is the honest point velocity. -/
+lemma velocityClosedForm_eq_velocity {d : ℕ} (M : RigidBodyMotion d) (t : Time)
+    (hR : Differentiable ℝ (fun s => (M.orientation s).1))
+    (hX : Differentiable ℝ M.comTrajectory) (y : Space d) :
+    M.velocityClosedForm t y = (M.velocity y t : Fin d → ℝ) := by
+  funext i
+  rw [velocityClosedForm, Pi.add_apply, ← M.velocity_eq_deriv_orientation y t i hR hX]
+
+/-- The squared speed of a body point, in closed form, is a smooth function of the point. -/
+lemma contDiff_velocityClosedForm_dotProduct {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
+    ContDiff ℝ ⊤ fun y : Space d => M.velocityClosedForm t y ⬝ᵥ M.velocityClosedForm t y := by
+  simp only [velocityClosedForm, dotProduct, Matrix.mulVec, Pi.add_apply]
+  fun_prop
+
+/-- The total kinetic energy of a rigid body in motion at time `t`: half the mass integral of the
+squared speed of the body points, `T = ½ ∫ v · v dm`, with the velocity of the point `y` written
+in the closed form `Ṙ(t) (y − c) + V(t)`, which is polynomial in `y` for any motion. For
+differentiable motions this is the honest point velocity `∂ₜ (displacement · y)`; see
+`kineticEnergy_eq_integral_velocity`. -/
+noncomputable def kineticEnergy {d : ℕ} (M : RigidBodyMotion d) (t : Time) : ℝ :=
+  (1 / 2) * M.ρ (cmap (fun y => M.velocityClosedForm t y ⬝ᵥ M.velocityClosedForm t y)
+    (M.contDiff_velocityClosedForm_dotProduct t))
+
+/-- For a differentiable motion the total kinetic energy is the mass integral of half the squared
+speed of the body points, `T = ½ ∫ v · v dm` with `v` the honest point velocity
+`∂ₜ (displacement · y)`: the closed-form integrand of `kineticEnergy` agrees with the velocity. -/
+lemma kineticEnergy_eq_integral_velocity {d : ℕ} (M : RigidBodyMotion d) (t : Time)
+    (hR : Differentiable ℝ (fun s => (M.orientation s).1))
+    (hX : Differentiable ℝ M.comTrajectory) :
+    M.kineticEnergy t = (1 / 2) * M.ρ (cmap
+      (fun y => (M.velocity y t : Fin d → ℝ) ⬝ᵥ (M.velocity y t : Fin d → ℝ))
+      (by
+        simp only [← M.velocityClosedForm_eq_velocity t hR hX]
+        exact M.contDiff_velocityClosedForm_dotProduct t)) := by
+  rw [kineticEnergy]
+  congr 2
+  ext y
+  simp only [cmap_apply, M.velocityClosedForm_eq_velocity t hR hX]
+
+/-- **König's theorem**, general form: the total kinetic energy of a rigid body in motion splits
+into the kinetic energy of the centre of mass plus the rotational energy about the centre of
+mass, `T = ½ M V · V + ½ ∫ |Ṙ (y − c)|² dm`. The cross term vanishes because the first moment of
+the mass distribution about its centre of mass is zero. -/
+theorem kineticEnergy_eq_translational_add_rotational {d : ℕ} (M : RigidBodyMotion d) (t : Time)
+    (h : M.mass ≠ 0) :
+    M.kineticEnergy t
+      = (1 / 2) * M.mass * ((M.centerOfMassVelocity t : Fin d → ℝ) ⬝ᵥ
+          (M.centerOfMassVelocity t : Fin d → ℝ))
+        + (1 / 2) * M.ρ (cmap (fun y =>
+            (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) ⬝ᵥ
+            (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j))
+          (by simp only [dotProduct, Matrix.mulVec]; fun_prop)) := by
+  have hsplit : cmap (fun y => M.velocityClosedForm t y ⬝ᵥ M.velocityClosedForm t y)
+        (M.contDiff_velocityClosedForm_dotProduct t)
+      = cmap (fun y =>
+            (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) ⬝ᵥ
+            (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j))
+          (by simp only [dotProduct, Matrix.mulVec]; fun_prop)
+        + ∑ j, (2 * (((M.centerOfMassVelocity t : Fin d → ℝ) ᵥ*
+              ∂ₜ (fun s => (M.orientation s).1) t) j)) •
+            cmap (fun y => y j - M.centerOfMass j) (by fun_prop)
+        + ((M.centerOfMassVelocity t : Fin d → ℝ) ⬝ᵥ (M.centerOfMassVelocity t : Fin d → ℝ)) •
+            (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) := by
+    ext y
+    simp only [cmap_apply, ContMDiffMap.coe_add, ContMDiffMap.coe_smul, ContMDiffMap.coe_one,
+      Pi.add_apply, Pi.smul_apply, Pi.one_apply, smul_eq_mul, mul_one, velocityClosedForm]
+    rw [← ContMDiffMap.coeFnAddMonoidHom_apply, map_sum, Finset.sum_apply]
+    simp only [ContMDiffMap.coeFnAddMonoidHom_apply, ContMDiffMap.coe_smul, Pi.smul_apply,
+      cmap_apply, smul_eq_mul]
+    rw [add_dotProduct, dotProduct_add, dotProduct_add,
+      dotProduct_comm (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j)
+        (M.centerOfMassVelocity t : Fin d → ℝ),
+      dotProduct_mulVec (M.centerOfMassVelocity t : Fin d → ℝ)
+        (∂ₜ (fun s => (M.orientation s).1) t) (fun j => y j - M.centerOfMass j)]
+    simp only [dotProduct, two_mul, add_mul, Finset.sum_add_distrib]
+    ring
+  rw [kineticEnergy, hsplit, map_add, map_add, map_sum]
+  simp only [map_smul, M.rho_coord_sub_centerOfMass h, smul_eq_mul, mul_zero,
+    Finset.sum_const_zero, add_zero, M.rho_one]
+  ring
+
+/-- **König's theorem** in three dimensions: the total kinetic energy of a rigid body in motion
+splits as `T = ½ M V · V + ½ ∫ |ω × r|² dm`, the kinetic energy of the centre of mass plus the
+rotational energy of the spinning about it, where `ω` is the angular velocity vector and
+`r = displacement − comTrajectory` is the position of the body point relative to the centre of
+mass. -/
+theorem kineticEnergy_eq_translational_add_angularVelocity (M : RigidBodyMotion 3) (t : Time)
+    (h : M.mass ≠ 0) (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t) :
+    M.kineticEnergy t
+      = (1 / 2) * M.mass * ((M.centerOfMassVelocity t : Fin 3 → ℝ) ⬝ᵥ
+          (M.centerOfMassVelocity t : Fin 3 → ℝ))
+        + (1 / 2) * M.ρ (cmap (fun y =>
+            (M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j) ⬝ᵥ
+            (M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j))
+          (by
+            exact (contDiff_cross_dotProduct_cross (M.angularVelocity t)).comp
+              (contDiff_pi.mpr fun j =>
+                ((Space.eval_contDiff j).comp (M.displacement_contDiff t)).sub
+                  contDiff_const))) := by
+  rw [M.kineticEnergy_eq_translational_add_rotational t h]
+  congr 1
+  congr 2
+  ext y
+  simp only [cmap_apply, M.deriv_orientation_mulVec_eq_angularVelocity_cross y t hR]
+
+end RigidBodyMotion

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -246,8 +246,10 @@ lemma velocity_eq_deriv_orientation {d : ℕ} (M : RigidBodyMotion d) (y : Space
   rw [hmv, Time.deriv_space hX t i, ← centerOfMassVelocity_eq]
 
 /-- The closed form `Ṙ(t) (y − c) + V(t)` of the velocity of the body point `y` at time `t`.
-It is polynomial in `y` for any motion; for differentiable motions it agrees with the point
-velocity `∂ₜ (displacement · y)`, see `velocityClosedForm_eq_velocity`. -/
+Unlike `velocity` — whose junk values on non-differentiable motions need not vary continuously
+with `y` — it is polynomial in `y` for any motion, so its squared speed can be bundled as the
+smooth integrand of the total kinetic energy; for differentiable motions the two agree, see
+`velocityClosedForm_eq_velocity`. -/
 noncomputable def velocityClosedForm {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d) :
     Space d :=
   ⟨∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j⟩

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -27,7 +27,7 @@ a rigid motion into a translation of the centre of mass plus a rotation about it
 
 @[expose] public section
 
-open Time Manifold Matrix RigidBody
+open Time Manifold Matrix RigidBody InnerProductSpace
 
 attribute [local instance] Matrix.linftyOpNormedAddCommGroup Matrix.linftyOpNormedSpace
   Matrix.linftyOpNormedRing Matrix.linftyOpNormedAlgebra
@@ -244,5 +244,45 @@ lemma velocity_eq_deriv_orientation {d : ℕ} (M : RigidBodyMotion d) (y : Space
         (y j - M.centerOfMass j) ((hentry i j) t))]
   simp only [Time.deriv_matrix_apply (fun s => (M.orientation s).1) t (hR t)]
   rw [hmv, Time.deriv_space hX t i, ← centerOfMassVelocity_eq]
+
+/-- The closed form `Ṙ(t) (y − c) + V(t)` of the velocity of the body point `y` at time `t`:
+the rate of change of the orientation acting on the body-frame position, plus the centre-of-mass
+velocity. It is polynomial in `y` for any motion, and for differentiable motions it agrees with
+the honest point velocity `∂ₜ (displacement · y)`; see `velocityClosedForm_eq_velocity`. -/
+noncomputable def velocityClosedForm {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d) :
+    Space d :=
+  ⟨∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j⟩
+    + M.centerOfMassVelocity t
+
+/-- The `i`-th coordinate of the closed-form velocity. -/
+lemma velocityClosedForm_apply {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d)
+    (i : Fin d) :
+    M.velocityClosedForm t y i
+      = (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) i
+        + M.centerOfMassVelocity t i := by
+  simp only [velocityClosedForm, Space.add_apply]
+
+/-- The closed-form velocity as a plain vector-valued function of the coordinates of `y`. -/
+lemma velocityClosedForm_val {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d) :
+    (M.velocityClosedForm t y : Fin d → ℝ)
+      = (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j)
+        + (M.centerOfMassVelocity t : Fin d → ℝ) := by
+  funext i
+  rw [Pi.add_apply]
+  exact M.velocityClosedForm_apply t y i
+
+/-- For a differentiable motion the closed-form velocity is the honest point velocity. -/
+lemma velocityClosedForm_eq_velocity {d : ℕ} (M : RigidBodyMotion d) (t : Time)
+    (hR : Differentiable ℝ (fun s => (M.orientation s).1))
+    (hX : Differentiable ℝ M.comTrajectory) (y : Space d) :
+    M.velocityClosedForm t y = M.velocity y t := by
+  ext i
+  rw [velocityClosedForm_apply, ← M.velocity_eq_deriv_orientation y t i hR hX]
+
+/-- The squared speed of a body point, in closed form, is a smooth function of the point. -/
+lemma contDiff_velocityClosedForm_inner {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
+    ContDiff ℝ ⊤ fun y : Space d => (⟪M.velocityClosedForm t y, M.velocityClosedForm t y⟫_ℝ) := by
+  simp only [Space.inner_eq_sum, velocityClosedForm_apply, Matrix.mulVec, dotProduct]
+  fun_prop
 
 end RigidBodyMotion

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -27,7 +27,7 @@ a rigid motion into a translation of the centre of mass plus a rotation about it
 
 @[expose] public section
 
-open Time Manifold Matrix
+open Time Manifold Matrix RigidBody
 
 attribute [local instance] Matrix.linftyOpNormedAddCommGroup Matrix.linftyOpNormedSpace
   Matrix.linftyOpNormedRing Matrix.linftyOpNormedAlgebra
@@ -93,6 +93,19 @@ lemma displacement_contDiff {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
   unfold displacement
   fun_prop
 
+/-- Rotating the body-frame position of `y` relative to the centre of mass gives its
+inertial-frame position relative to the moving centre of mass:
+`R(t) (y − c) = displacement t y − comTrajectory t`. -/
+lemma orientation_mulVec_sub_centerOfMass {d : ℕ} (M : RigidBodyMotion d) (t : Time)
+    (y : Space d) :
+    (M.orientation t).1 *ᵥ (fun j => y j - M.centerOfMass j)
+      = fun j => M.displacement t y j - M.comTrajectory t j := by
+  funext k
+  show ((M.orientation t).1 *ᵥ fun j => y j - M.centerOfMass j) k
+    = M.displacement t y k - M.comTrajectory t k
+  rw [eq_sub_iff_add_eq, displacement_apply]
+  rfl
+
 /-- The mass distribution of the rigid body in motion at time `t`: the pushforward of the
 body-fixed mass distribution along the rigid displacement, acting on a test function `f` by
 `f ↦ ρ (f ∘ displacement t)`. -/
@@ -110,16 +123,6 @@ lemma massDistribution_mass {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
   simp only [RigidBody.mass, massDistribution, LinearMap.coe_mk, AddHom.coe_mk]
   congr 1
 
-/-- Bundle a smooth real-valued function on `Space d` as an element of the space of test
-functions. Keeping this as a named constructor ensures the resulting type head stays
-`ContMDiffMap`, so the module/ring operations and `comp` resolve correctly. -/
-private def cmap {d : ℕ} (f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f) :
-    C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯ := ⟨f, hf.contMDiff⟩
-
-@[simp]
-private lemma cmap_apply {d : ℕ} (f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f) (y : Space d) :
-    cmap f hf y = f y := rfl
-
 /-- Evaluation commutes with finite sums of smooth functions. -/
 private lemma contMDiffMap_sum_apply {d : ℕ} {ι : Type*} (s : Finset ι)
     (f : ι → C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) (y : Space d) :
@@ -130,23 +133,6 @@ private lemma contMDiffMap_sum_apply {d : ℕ} {ι : Type*} (s : Finset ι)
   | insert a s ha ih =>
     simp only [Finset.sum_insert ha, ContMDiffMap.coe_add, Pi.add_apply, ih]
 
-/-- The first moment of the body-fixed distribution about its own centre of mass vanishes:
-for nonzero mass, `ρ` of the centred `j`-th coordinate function is zero. -/
-private lemma rho_coord_sub_centerOfMass {d : ℕ} (R : RigidBody d) (h : R.mass ≠ 0) (j : Fin d) :
-    R.ρ (cmap (fun y => y j - R.centerOfMass j) (by fun_prop)) = 0 := by
-  have hsplit : cmap (fun y => y j - R.centerOfMass j) (by fun_prop)
-        = cmap (fun y => y j) (by fun_prop)
-          - R.centerOfMass j • (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) := by
-    ext y
-    simp only [cmap_apply, ContMDiffMap.coe_sub, ContMDiffMap.coe_smul,
-      ContMDiffMap.coe_one, Pi.sub_apply, Pi.smul_apply, Pi.one_apply, smul_eq_mul, mul_one]
-  have hmass : R.ρ (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) = R.mass := rfl
-  have hcoord : R.ρ (cmap (fun y => y j) (by fun_prop)) = R.mass * R.centerOfMass j := by
-    have hc : R.centerOfMass j = (1 / R.mass) • R.ρ (cmap (fun y => y j) (by fun_prop)) := rfl
-    rw [hc, smul_eq_mul, one_div, ← mul_assoc, mul_inv_cancel₀ h, one_mul]
-  rw [hsplit, map_sub, map_smul, hmass, hcoord, smul_eq_mul]
-  ring
-
 /-- The centre of mass of the moving mass distribution tracks the prescribed trajectory: for a
 body of nonzero mass, the centre of mass of `massDistribution M t` is exactly `comTrajectory t`.
 This is the decisive check that `comTrajectory` and `orientation` are wired correctly in
@@ -154,7 +140,6 @@ This is the decisive check that `comTrajectory` and `orientation` are wired corr
 lemma massDistribution_centerOfMass {d : ℕ} (M : RigidBodyMotion d) (t : Time) (h : M.mass ≠ 0) :
     (M.massDistribution t).centerOfMass = M.comTrajectory t := by
   ext i
-  have hone : M.ρ (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) = M.mass := rfl
   have hdecomp :
       ContMDiffMap.comp (cmap (fun x => x i) (by fun_prop))
           ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩
@@ -168,8 +153,8 @@ lemma massDistribution_centerOfMass {d : ℕ} (M : RigidBodyMotion d) (t : Time)
   have key : (M.massDistribution t).ρ (cmap (fun x => x i) (by fun_prop))
       = M.comTrajectory t i * M.mass := by
     simp only [massDistribution, LinearMap.coe_mk, AddHom.coe_mk]
-    rw [hdecomp, map_add, map_sum, map_smul, hone]
-    simp only [map_smul, rho_coord_sub_centerOfMass M.toRigidBody h, smul_eq_mul, mul_zero,
+    rw [hdecomp, map_add, map_sum, map_smul, M.rho_one]
+    simp only [map_smul, M.rho_coord_sub_centerOfMass h, smul_eq_mul, mul_zero,
       Finset.sum_const_zero, zero_add]
   rw [show (M.massDistribution t).centerOfMass i
       = (1 / (M.massDistribution t).mass) •

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -245,10 +245,9 @@ lemma velocity_eq_deriv_orientation {d : ℕ} (M : RigidBodyMotion d) (y : Space
   simp only [Time.deriv_matrix_apply (fun s => (M.orientation s).1) t (hR t)]
   rw [hmv, Time.deriv_space hX t i, ← centerOfMassVelocity_eq]
 
-/-- The closed form `Ṙ(t) (y − c) + V(t)` of the velocity of the body point `y` at time `t`:
-the rate of change of the orientation acting on the body-frame position, plus the centre-of-mass
-velocity. It is polynomial in `y` for any motion, and for differentiable motions it agrees with
-the honest point velocity `∂ₜ (displacement · y)`; see `velocityClosedForm_eq_velocity`. -/
+/-- The closed form `Ṙ(t) (y − c) + V(t)` of the velocity of the body point `y` at time `t`.
+It is polynomial in `y` for any motion; for differentiable motions it agrees with the point
+velocity `∂ₜ (displacement · y)`, see `velocityClosedForm_eq_velocity`. -/
 noncomputable def velocityClosedForm {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d) :
     Space d :=
   ⟨∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j⟩


### PR DESCRIPTION
Adds the total kinetic energy of a rigid body in motion and proves the König decomposition `T = ½M V·V + ½∫|ω × r|² dm` (Landau–Lifshitz, Mechanics, §32). Follow-up to #1377 in the rigid-body API (#893).

## New declarations

`Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean` (new section for `RigidBodyMotion`):

- `RigidBodyMotion.velocityClosedForm` — the closed form `Ṙ(t)(y − c) + V(t)` of the velocity of the body point `y`. It is polynomial in `y`, hence smooth for *any* motion (`contDiff_velocityClosedForm_dotProduct`), whereas the honest point velocity `∂ₜ(displacement · y)` is not bundleable unconditionally (for non-differentiable motions its junk values need not be smooth in `y`). For differentiable motions the two agree: `velocityClosedForm_eq_velocity`.
- `RigidBodyMotion.kineticEnergy` — the total kinetic energy `T = ½ ∫ v ⬝ᵥ v dm` at time `t`, with `v = velocityClosedForm`.
- `kineticEnergy_eq_integral_velocity` — for differentiable motions the integrand is the honest point velocity: `T = ½ ∫ velocity ⬝ᵥ velocity dm`. This is the definitional-honesty lemma.
- `kineticEnergy_eq_translational_add_rotational` — **König's theorem in any dimension**: `T = ½ M (V ⬝ᵥ V) + ½ ∫ |Ṙ(y − c)|² dm` for `mass ≠ 0`, with no differentiability hypotheses. The cross term `∫ V ⬝ᵥ Ṙ(y − c) dm` vanishes because the first moment of the mass distribution about its centre of mass is zero (`rho_coord_sub_centerOfMass`).
- `kineticEnergy_eq_translational_add_angularVelocity` — **König's theorem in three dimensions**: `T = ½ M (V ⬝ᵥ V) + ½ ∫ |ω × r|² dm`, with `ω` the angular velocity vector and `r = displacement − comTrajectory` the position relative to the centre of mass, spelled exactly as in `velocity_eq_angularVelocity` (#1376). Needs only `DifferentiableAt` at `t`.

Supporting lemmas extracted so they are stated once (previously inline or private):

- `Basic.lean`: `RigidBody.rho_one` (`ρ 1 = mass`, `@[simp]`) replaces three identical inline `have ... := rfl`; `cmap`, `cmap_apply`, `rho_coord_sub_centerOfMass` move here from `Motion.lean` — their subject is `RigidBody`, so dot notation now works and `KineticEnergy.lean` can use them.
- `Motion.lean`: `orientation_mulVec_sub_centerOfMass` — `R(t)(y − c) = displacement t y − comTrajectory t`.
- `AngularVelocity.lean`: `deriv_orientation_mulVec_eq_angularVelocity_cross` — `Ṙ(t)(y − c) = ω(t) × r` under `DifferentiableAt`; `velocity_eq_angularVelocity` now reuses it and its proof shrinks to two lines.

## Other changes

- `Basic.lean`: removed the `informal_definition kineticEnergy` stub (tag MEYBM), now formalized. The `informal_lemma kinetic_energy_decomposition` (LL32-TK) is kept: its `½ ω · I_CM ω` form needs the body-frame angular velocity / rotated inertia tensor, planned as a follow-up.
- `API-map.yaml`: kinetic-energy requirement marked done; Overview extended.

## Reading order

`Basic.lean` (rho_one + relocations) → `Motion.lean` (orientation_mulVec_sub_centerOfMass) → `AngularVelocity.lean` (deriv_orientation_mulVec_eq_angularVelocity_cross) → `KineticEnergy.lean` from `namespace RigidBodyMotion`.

## Verification

- `lake build Physlib` clean; fresh compile of the touched files with zero warnings.
- `#print axioms` on all new declarations: only `[propext, Classical.choice, Quot.sound]`.
- `lake exe runLinter` — no issues in the touched files; `./scripts/lint-style.sh` clean.
