### PR TITLE
Remove erw in inner_self_eq_zero'

### DIFF
--- a/Physlib/Mathematics/InnerProductSpace/Basic.lean
+++ b/Physlib/Mathematics/InnerProductSpace/Basic.lean
@@ -313,8 +313,8 @@ lemma inner_neg_right' (x y : E) : ⟪x, -y⟫ = -⟪x, y⟫ :=
 
 @[simp]
 lemma inner_self_eq_zero' {x : E} : ⟪x, x⟫ = 0 ↔ x = 0 := by
-  erw [inner_self_eq_zero (E:=WithLp 2 E)]
-  simp
+  rw [show (⟪x, x⟫ : 𝕜) = inner 𝕜 (toL2 𝕜 x) (toL2 𝕜 x) from rfl, inner_self_eq_zero,
+      map_eq_zero_iff _ (Function.LeftInverse.injective fromL2_toL2)]
 
 @[simp]
 lemma inner_sum'{ι : Type*} [Fintype ι] (x : E) (g : ι → E) :


### PR DESCRIPTION
Removes the `erw` in `inner_self_eq_zero'`, replacing it with an explicit definitional bridge across the `WithLp 2 E` type synonym followed by a strict `rw`. Contributes to #385.

## Change

- `Physlib/Mathematics/InnerProductSpace/Basic.lean` — lemma `inner_self_eq_zero'`: the previous `erw [inner_self_eq_zero (E := WithLp 2 E)]; simp` is replaced by

  ```lean
  rw [show (⟪x, x⟫ : 𝕜) = inner 𝕜 (toL2 𝕜 x) (toL2 𝕜 x) from rfl, inner_self_eq_zero,
      map_eq_zero_iff _ (Function.LeftInverse.injective fromL2_toL2)]
  ```

  The `show … from rfl` step makes explicit the definitional equality that `erw` was resolving implicitly (viewing `x : E` through `toL2` as an element of `WithLp 2 E`). The strict `rw [inner_self_eq_zero]` then applies, and the remaining goal `toL2 𝕜 x = 0 ↔ x = 0` closes via injectivity of `toL2`, obtained from the existing `fromL2_toL2`.

No lemmas or definitions are added or removed.

## Reviewer map

A single hunk in `Physlib/Mathematics/InnerProductSpace/Basic.lean` (lemma `inner_self_eq_zero'`); nothing else changes.

## Checks

`lake build`, `lake exe lint_all`, and `./scripts/lint-style.sh` all pass locally.

---

This PR was prepared with the assistance of Claude Opus 4.8. The human author has reviewed and verified every line.
