### PR TITLE
Remove erw in ComplexTensor metric basis lemmas

### DIFF
--- a/Physlib/Relativity/Tensors/ComplexTensor/Metrics/Basic.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/Metrics/Basic.lean
@@ -229,16 +229,24 @@ lemma coMetric_eq_basis : η' =
   rw [coMetric_eq_complexCoBasisFin4]
   conv_lhs =>
     enter [2]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .down _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .down _))
+    rw [fromPairT_apply_basis_repr]
   conv_lhs =>
     enter [1, 2]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .down _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .down _))
+    rw [fromPairT_apply_basis_repr]
   conv_lhs =>
     enter [1, 1, 2]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .down _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .down _))
+    rw [fromPairT_apply_basis_repr]
   conv_lhs =>
     enter [1, 1, 1]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .down _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .down _))
+    rw [fromPairT_apply_basis_repr]
   rfl
 
 open Lorentz in
@@ -254,16 +262,24 @@ lemma contrMetric_eq_basis : η =
   rw [contrMetric_eq_complexContrBasisFin4]
   conv_lhs =>
     enter [2]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .up _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .up _))
+    rw [fromPairT_apply_basis_repr]
   conv_lhs =>
     enter [1, 2]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .up _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .up _))
+    rw [fromPairT_apply_basis_repr]
   conv_lhs =>
     enter [1, 1, 2]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .up _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .up _))
+    rw [fromPairT_apply_basis_repr]
   conv_lhs =>
     enter [1, 1, 1]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .up _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .up _))
+    rw [fromPairT_apply_basis_repr]
   rfl
 
 open Fermion in
@@ -275,10 +291,14 @@ lemma leftMetric_eq_basis : εL =
   rw [leftMetric_eq_leftHandedWeyl_basis]
   conv_lhs =>
     enter [2]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .upL _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .upL _))
+    rw [fromPairT_apply_basis_repr]
   conv_lhs =>
     enter [1, 1]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .upL _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .upL _))
+    rw [fromPairT_apply_basis_repr]
   rfl
 
 open Fermion in
@@ -290,10 +310,14 @@ lemma dualLeftMetric_eq_basis : εL' =
   rw [dualLeftMetric_eq_dualLeftHandedWeyl_basis]
   conv_lhs =>
     enter [2]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .downL _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .downL _))
+    rw [fromPairT_apply_basis_repr]
   conv_lhs =>
     enter [1]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .downL _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .downL _))
+    rw [fromPairT_apply_basis_repr]
   rfl
 
 open Fermion in
@@ -305,10 +329,14 @@ lemma rightMetric_eq_basis : εR =
   rw [rightMetric_eq_rightHandedWeyl_basis]
   conv_lhs =>
     enter [2]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .upR _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .upR _))
+    rw [fromPairT_apply_basis_repr]
   conv_lhs =>
     enter [1, 1]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .upR _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .upR _))
+    rw [fromPairT_apply_basis_repr]
   rfl
 
 open Fermion in
@@ -320,10 +348,14 @@ lemma dualRightMetric_eq_basis : εR' =
   rw [dualRightMetric_eq_dualRightHandedWeyl_basis]
   conv_lhs =>
     enter [2]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .downR _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .downR _))
+    rw [fromPairT_apply_basis_repr]
   conv_lhs =>
     enter [1]
-    erw [fromPairT_apply_basis_repr]
+    change fromPairT ((complexLorentzTensor.basis .downR _) ⊗ₜ[ℂ]
+      (complexLorentzTensor.basis .downR _))
+    rw [fromPairT_apply_basis_repr]
   rfl
 
 /-!


### PR DESCRIPTION
Removes all 16 `erw` uses in `Physlib/Relativity/Tensors/ComplexTensor/Metrics/Basic.lean`, as part of #385.

## What changed
Each `erw [fromPairT_apply_basis_repr]` in the six metric `_eq_basis` lemmas — `coMetric_eq_basis`, `contrMetric_eq_basis`, `leftMetric_eq_basis`, `dualLeftMetric_eq_basis`, `rightMetric_eq_basis`, `dualRightMetric_eq_basis` — is replaced with an explicit `change` to the `complexLorentzTensor.basis <color>` form followed by a strict `rw [fromPairT_apply_basis_repr]`.

The `erw` was only bridging the semireducible defeq between the concrete basis vectors (`complexCoBasisFin4`, `complexContrBasisFin4`, `LeftHandedWeyl.basis`, …) and `complexLorentzTensor.basis <color>`; making that step explicit with `change` lets strict `rw` apply. No lemma statements or signatures change.

This mirrors the existing idiom already in the sibling file `Physlib/Relativity/Tensors/ComplexTensor/Units/Basic.lean`.

## Reviewer map
All changes are in one file and follow a single pattern — `coMetric_eq_basis` is representative of all six. The `change` color in each lemma matches that lemma's declared `Color.*` in its statement.

## Checks
- `lake build` succeeds
- `lake exe lint_all` passes
- `./scripts/lint-style.sh` passes
- no `sorry`, no `axiom`, no cheats

## AI assistance
Drafted with the assistance of Claude Opus 4.8; every line has been reviewed and certified by me. The commit carries the `Co-authored-by: Claude Opus 4.8` trailer.

Contributes to #385.
