### PR TITLE
chore: ignore Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /lake-packages/*
 .lake/*
 .DS_Store
+
+# Python bytecode (e.g. from scripts/check_golf.py)
+__pycache__/
+*.pyc


### PR DESCRIPTION
Running `scripts/check_golf.py` locally leaves `__pycache__/` behind, and one `.pyc` already slipped into a commit once (via #1400, since removed on master). Add `__pycache__/` and `*.pyc` to `.gitignore` so it cannot happen again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)