### PR TITLE
refactor(Mathematics/List): remove 3 erw in InsertionSort.lean

### DIFF
--- a/Physlib/Mathematics/List/InsertionSort.lean
+++ b/Physlib/Mathematics/List/InsertionSort.lean
@@ -67,17 +67,16 @@ lemma insertionSortMin_lt_mem_insertionSortDropMinPos_of_lt {α : Type} (r : α 
     (h : (insertionSortMinPosFin r a l).succAbove i < insertionSortMinPosFin r a l) :
     ¬ r ((insertionSortDropMinPos r a l)[i]) (insertionSortMin r a l) := by
   simp only [Fin.getElem_fin, insertionSortMin, List.get_eq_getElem, List.length_cons]
-  have h1 : (insertionSortDropMinPos r a l)[i] =
+  have h1 : (insertionSortDropMinPos r a l)[(i : ℕ)] =
     (a :: l).get (finCongr (eraseIdx_length_succ (a :: l) (insertionSortMinPos r a l))
     ((insertionSortMinPosFin r a l).succAbove i)) := by
     trans (insertionSortDropMinPos r a l).get i
-    simp only [Fin.getElem_fin, List.get_eq_getElem]
+    simp only [List.get_eq_getElem]
     simp only [insertionSortDropMinPos, List.length_cons, Nat.succ_eq_add_one, finCongr_apply]
     rw [eraseIdx_get]
     simp only [List.length_cons, Function.comp_apply, List.get_eq_getElem, Fin.val_cast]
     rfl
-  rw [show (insertionSortDropMinPos r a l)[(i : ℕ)] = (insertionSortDropMinPos r a l)[i] from rfl,
-    h1]
+  rw [h1]
   simp only [List.length_cons, Nat.succ_eq_add_one, List.get_eq_getElem]
   apply insertionSortEquiv_order
   exact h

--- a/Physlib/Mathematics/List/InsertionSort.lean
+++ b/Physlib/Mathematics/List/InsertionSort.lean
@@ -76,7 +76,8 @@ lemma insertionSortMin_lt_mem_insertionSortDropMinPos_of_lt {α : Type} (r : α 
     rw [eraseIdx_get]
     simp only [List.length_cons, Function.comp_apply, List.get_eq_getElem, Fin.val_cast]
     rfl
-  erw [h1]
+  rw [show (insertionSortDropMinPos r a l)[(i : ℕ)] = (insertionSortDropMinPos r a l)[i] from rfl,
+    h1]
   simp only [List.length_cons, Nat.succ_eq_add_one, List.get_eq_getElem]
   apply insertionSortEquiv_order
   exact h
@@ -509,12 +510,12 @@ lemma filter_rel_eq_insertionSort {α : Type} (r : α → α → Prop) [Decidabl
     List.filter (fun c => r a c ∧ r c a) l
   | [] => by simp
   | b :: l => by
-    simp only [List.insertionSort]
+    simp only [List.insertionSort_cons]
     by_cases h : r a b ∧ r b a
     · have hl := orderedInsert_filter_of_pos r b (fun c => r a c ∧ r c a) h
         (List.insertionSort r l) (by exact List.pairwise_insertionSort r l)
       simp only [Bool.decide_and] at hl ⊢
-      erw [hl]
+      rw [hl]
       rw [List.orderedInsert_eq_take_drop]
       have ht : List.takeWhile (fun b_1 => decide ¬r b b_1)
         (List.filter (fun b => decide (r a b) && decide (r b a))
@@ -551,7 +552,7 @@ lemma filter_rel_eq_insertionSort {α : Type} (r : α → α → Prop) [Decidabl
       simp_all
     · have hl := orderedInsert_filter_of_neg r b (fun c => r a c ∧ r c a) h (List.insertionSort r l)
       simp only [Bool.decide_and] at hl ⊢
-      erw [hl]
+      rw [hl]
       rw [List.filter_cons_of_neg]
       have ih := filter_rel_eq_insertionSort r a l
       simp_all only [not_and, Bool.decide_and]


### PR DESCRIPTION
Removes 3 of the 13 `erw` in `Physlib/Mathematics/List/InsertionSort.lean` (#385), continuing the warm-up from #1227.

- `insertionSortMin_lt_mem_insertionSortDropMinPos_of_lt`: the goal displays the `getElem` index via the `Nat` coercion (`[↑i]`) while the local hypothesis states it with the direct `Fin` index (`[i]`); bridged that with an explicit `rfl` step instead of `erw`.
- `filter_rel_eq_insertionSort` (both branches): unfolding `List.insertionSort` via the bare equation lemma left the goal in `List.foldr` form, which didn't match the hypothesis syntactically; switching to `List.insertionSort_cons` keeps it in the one-step-unfolded form the hypothesis already uses, so plain `rw` applies.

Left the remaining 10 alone rather than force something I wasn't confident in: they're concentrated in `insertionSortEquiv_commute`, `insertionSortEquiv_orderedInsert_append`, and `insertionSortEquiv_insertionSort_append`, all three already carrying `set_option backward.isDefEq.respectTransparency false`. The couple of substitutions I tried there hit a genuine motive/transparency issue (dependent rewriting under a `Fin`-indexed equality), not a simple lemma-name swap, so I stopped rather than push through with something unclear.

`lake build Physlib QuantumInfo PhyslibAlpha` and `lake exe lint_all` both clean (the lint errors that do show up are pre-existing transitive-import debt in unrelated `SpaceAndTime` files, not touched here).
