### PR TITLE
feat(ClassicalMechanics): add the body-frame angular velocity of a rigid body

### DIFF
--- a/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
@@ -26,11 +26,21 @@ In three dimensions the skew-symmetric tensor `Ω` is dual to the *angular veloc
 `ω(t) = Ωᵛ` via the hat map (`Physlib.Mathematics.CrossProductMatrix`), with `[ω]ₓ = Ω`; `ω` is the
 angular velocity proper, appearing in the decomposition `v = V + ω × r` as an honest cross product.
 
-The angular velocity can equally be expressed in the frame co-rotating with the body. The
-*body-frame angular velocity tensor* `Ω_body(t) = R(t)ᵀ Ṙ(t)` is the conjugate `Ω_body = Rᵀ Ω R` of
-the spatial tensor, and is again skew-symmetric; in three dimensions its dual is the *body-frame
-angular velocity vector* `ω_body = Ω_bodyᵛ`. The body frame is the natural setting for the inertia
-tensor and Euler's equations, since the inertia tensor is time-independent in body-fixed axes.
+The angular velocity can equally be expressed in the *body frame*: the moving coordinate system
+rigidly attached to the body, with origin at the centre of mass and axes rotating with the body,
+in which every material point has time-independent coordinates. The orientation `R(t)` is
+precisely the rotational part of the change of frame: a point fixed at position `a` in the body
+frame sits at `r = R(t) a` relative to the centre of mass in the lab frame (the inertial frame in
+which the trajectories of `RigidBodyMotion` are written), and a vector with lab-frame components
+`u` has body-frame components `R(t)ᵀ u`. The body frame is in general *not* inertial — it rotates
+with the body, and its origin follows the (generally accelerating) centre of mass — but it is the
+natural setting for the inertia tensor and Euler's equations, since the mass distribution, and
+with it the inertia tensor, is time-independent in body-fixed axes.
+
+The *body-frame angular velocity tensor* `Ω_body(t) = R(t)ᵀ Ṙ(t)` is the spatial tensor
+conjugated into the body frame, `Ω_body = Rᵀ Ω R`, and is again skew-symmetric; in three
+dimensions its dual is the *body-frame angular velocity vector* `ω_body = Ω_bodyᵛ`, the angular
+velocity `ω` resolved along the body-fixed axes, `ω_body = Rᵀ ω`.
 
 ## References
 - Landau and Lifshitz, Mechanics, Sections 31 and 32.
@@ -189,7 +199,7 @@ lemma angularVelocityTensor_eq_orientation_conj (M : RigidBodyMotion d) (t : Tim
 
 /-- The body-frame angular velocity *vector* `ω_body(t)` of a rigid body moving in three-dimensional
 space: the vector dual to the body-frame angular velocity tensor `Ω_body(t)` under the hat map,
-`ω_body = Ω_bodyᵛ`. It is the angular velocity as measured in the co-rotating body frame. -/
+`ω_body = Ω_bodyᵛ`. It is the angular velocity `ω` resolved along the body-fixed axes. -/
 noncomputable def bodyAngularVelocity (M : RigidBodyMotion 3) (t : Time) : Fin 3 → ℝ :=
   crossProductVee (M.bodyAngularVelocityTensor t)
 

--- a/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
@@ -26,8 +26,14 @@ In three dimensions the skew-symmetric tensor `Ω` is dual to the *angular veloc
 `ω(t) = Ωᵛ` via the hat map (`Physlib.Mathematics.CrossProductMatrix`), with `[ω]ₓ = Ω`; `ω` is the
 angular velocity proper, appearing in the decomposition `v = V + ω × r` as an honest cross product.
 
+The angular velocity can equally be expressed in the frame co-rotating with the body. The
+*body-frame angular velocity tensor* `Ω_body(t) = R(t)ᵀ Ṙ(t)` is the conjugate `Ω_body = Rᵀ Ω R` of
+the spatial tensor, and is again skew-symmetric; in three dimensions its dual is the *body-frame
+angular velocity vector* `ω_body = Ω_bodyᵛ`. The body frame is the natural setting for the inertia
+tensor and Euler's equations, since the inertia tensor is time-independent in body-fixed axes.
+
 ## References
-- Landau and Lifshitz, Mechanics, Section 31.
+- Landau and Lifshitz, Mechanics, Sections 31 and 32.
 -/
 
 @[expose] public section
@@ -136,5 +142,87 @@ theorem velocity_eq_angularVelocity (M : RigidBodyMotion 3) (y : Space 3) (t : T
         + (M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j) i := by
   rw [M.velocity_eq_deriv_orientation y t i hR hX, add_comm,
     M.deriv_orientation_mulVec_eq_angularVelocity_cross y t (hR t)]
+
+/-- The body-frame (co-rotating) angular velocity tensor `Ω_body(t) = R(t)ᵀ Ṙ(t)` of a rigid body
+in motion, where `R(t) = orientation t`. It is the angular velocity tensor expressed in the frame
+rotating with the body, the conjugate `Ω_body = Rᵀ Ω R` of the spatial tensor `Ω = Ṙ Rᵀ`. -/
+noncomputable def bodyAngularVelocityTensor (M : RigidBodyMotion d) (t : Time) :
+    Matrix (Fin d) (Fin d) ℝ :=
+  ((M.orientation t).1)ᵀ * ∂ₜ (fun s => (M.orientation s).1) t
+
+lemma bodyAngularVelocityTensor_eq (M : RigidBodyMotion d) (t : Time) :
+    M.bodyAngularVelocityTensor t = ((M.orientation t).1)ᵀ * ∂ₜ (fun s => (M.orientation s).1) t :=
+  rfl
+
+/-- The body-frame angular velocity tensor is skew-symmetric, `Ω_bodyᵀ = -Ω_body`: it lies in the
+Lie algebra `𝔰𝔬(d)`. Like its spatial counterpart this follows by differentiating the orthogonality
+identity `Rᵀ R = 1`. -/
+lemma bodyAngularVelocityTensor_transpose (M : RigidBodyMotion d) (t : Time)
+    (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t) :
+    (M.bodyAngularVelocityTensor t)ᵀ = - M.bodyAngularVelocityTensor t := by
+  have hconst : (fun s => ((M.orientation s).1)ᵀ * (M.orientation s).1)
+      = fun _ => (1 : Matrix (Fin d) (Fin d) ℝ) := by
+    funext s
+    exact mul_eq_one_comm.mp (M.orientation_mul_transpose s)
+  have hderiv0 : ∂ₜ (fun s => ((M.orientation s).1)ᵀ * (M.orientation s).1) t = 0 := by
+    rw [hconst]
+    exact Time.deriv_const 1
+  have hprod := Time.deriv_matrix_mul (fun s => ((M.orientation s).1)ᵀ)
+    (fun s => (M.orientation s).1) t hR.matrix_transpose hR
+  rw [Time.deriv_matrix_transpose (fun s => (M.orientation s).1) t hR, hderiv0] at hprod
+  rw [bodyAngularVelocityTensor, transpose_mul, transpose_transpose]
+  exact eq_neg_of_add_eq_zero_right hprod.symm
+
+/-- The time derivative of the orientation is `Ṙ = R Ω_body`, recovering the orientation path from
+its body-frame angular velocity tensor `Ω_body = Rᵀ Ṙ` via the orthogonality `R Rᵀ = 1`. -/
+lemma orientation_mul_bodyAngularVelocityTensor (M : RigidBodyMotion d) (t : Time) :
+    (M.orientation t).1 * M.bodyAngularVelocityTensor t = ∂ₜ (fun s => (M.orientation s).1) t := by
+  rw [bodyAngularVelocityTensor, ← mul_assoc, M.orientation_mul_transpose t, one_mul]
+
+/-- The spatial and body-frame angular velocity tensors are conjugate under the orientation,
+`Ω = R Ω_body Rᵀ`: the spatial tensor `Ω = Ṙ Rᵀ` is the body-frame tensor `Ω_body = Rᵀ Ṙ` rotated
+into the inertial frame. -/
+lemma angularVelocityTensor_eq_orientation_conj (M : RigidBodyMotion d) (t : Time) :
+    M.angularVelocityTensor t
+      = (M.orientation t).1 * M.bodyAngularVelocityTensor t * ((M.orientation t).1)ᵀ := by
+  rw [angularVelocityTensor_eq, ← M.orientation_mul_bodyAngularVelocityTensor t]
+
+/-- The body-frame angular velocity *vector* `ω_body(t)` of a rigid body moving in three-dimensional
+space: the vector dual to the body-frame angular velocity tensor `Ω_body(t)` under the hat map,
+`ω_body = Ω_bodyᵛ`. It is the angular velocity as measured in the co-rotating body frame. -/
+noncomputable def bodyAngularVelocity (M : RigidBodyMotion 3) (t : Time) : Fin 3 → ℝ :=
+  crossProductVee (M.bodyAngularVelocityTensor t)
+
+lemma bodyAngularVelocity_eq (M : RigidBodyMotion 3) (t : Time) :
+    M.bodyAngularVelocity t = crossProductVee (M.bodyAngularVelocityTensor t) := rfl
+
+/-- The hat map recovers the body-frame angular velocity tensor from the body-frame angular
+velocity vector, `[ω_body]ₓ = Ω_body`; it holds because `Ω_body` is skew-symmetric. -/
+lemma crossProductMatrix_bodyAngularVelocity (M : RigidBodyMotion 3) (t : Time)
+    (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t) :
+    crossProductMatrix (M.bodyAngularVelocity t) = M.bodyAngularVelocityTensor t := by
+  rw [bodyAngularVelocity_eq,
+    crossProductMatrix_crossProductVee (M.bodyAngularVelocityTensor_transpose t hR)]
+
+/-- A rigid body whose orientation is constant in time has zero body-frame angular velocity
+tensor. -/
+lemma bodyAngularVelocityTensor_of_orientation_const (M : RigidBodyMotion d)
+    (R : Matrix.specialOrthogonalGroup (Fin d) ℝ) (h : M.orientation = fun _ => R) :
+    M.bodyAngularVelocityTensor = 0 := by
+  funext t
+  have hconst : (fun s => (M.orientation s).1) = fun _ => R.1 := by
+    funext s
+    rw [h]
+  rw [bodyAngularVelocityTensor_eq, hconst, Time.deriv_eq]
+  simp
+
+/-- A rigid body whose orientation is constant in time has zero body-frame angular velocity
+vector. -/
+lemma bodyAngularVelocity_of_orientation_const (M : RigidBodyMotion 3)
+    (R : Matrix.specialOrthogonalGroup (Fin 3) ℝ) (h : M.orientation = fun _ => R) :
+    M.bodyAngularVelocity = 0 := by
+  funext t i
+  rw [bodyAngularVelocity_eq, congrFun (M.bodyAngularVelocityTensor_of_orientation_const R h) t]
+  fin_cases i <;> simp [crossProductVee]
 
 end RigidBodyMotion

--- a/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
@@ -156,9 +156,7 @@ theorem velocity_eq_angularVelocity (M : RigidBodyMotion 3) (y : Space 3) (t : T
     M.deriv_orientation_mulVec_eq_angularVelocity_cross y t (hR t)]
 
 /-- The body-frame (co-rotating) angular velocity tensor `Ω_body(t) = R(t)ᵀ Ṙ(t)` of a rigid body
-in motion, where `R(t) = orientation t`. It is the angular velocity tensor expressed in the frame
-rotating with the body, related to the spatial tensor `Ω = Ṙ Rᵀ` by the conjugation
-`Ω = R Ω_body Rᵀ` (`angularVelocityTensor_eq_orientation_conj`). -/
+in motion, where `R(t) = orientation t`. -/
 noncomputable def bodyAngularVelocityTensor (M : RigidBodyMotion d) (t : Time) :
     Matrix (Fin d) (Fin d) ℝ :=
   ((M.orientation t).1)ᵀ * ∂ₜ (fun s => (M.orientation s).1) t
@@ -167,50 +165,38 @@ lemma bodyAngularVelocityTensor_eq (M : RigidBodyMotion d) (t : Time) :
     M.bodyAngularVelocityTensor t = ((M.orientation t).1)ᵀ * ∂ₜ (fun s => (M.orientation s).1) t :=
   rfl
 
-/-- The body-frame angular velocity tensor is skew-symmetric, `Ω_bodyᵀ = -Ω_body`: it lies in the
-Lie algebra `𝔰𝔬(d)`. Like its spatial counterpart this follows by differentiating the orthogonality
-identity `Rᵀ R = 1`. -/
-lemma bodyAngularVelocityTensor_transpose (M : RigidBodyMotion d) (t : Time)
-    (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t) :
-    (M.bodyAngularVelocityTensor t)ᵀ = - M.bodyAngularVelocityTensor t := by
-  have hconst : (fun s => ((M.orientation s).1)ᵀ * (M.orientation s).1)
-      = fun _ => (1 : Matrix (Fin d) (Fin d) ℝ) := by
-    funext s
-    exact mul_eq_one_comm.mp (M.orientation_mul_transpose s)
-  have hderiv0 : ∂ₜ (fun s => ((M.orientation s).1)ᵀ * (M.orientation s).1) t = 0 := by
-    rw [hconst]
-    exact Time.deriv_const 1
-  have hprod := Time.deriv_matrix_mul (fun s => ((M.orientation s).1)ᵀ)
-    (fun s => (M.orientation s).1) t hR.matrix_transpose hR
-  rw [Time.deriv_matrix_transpose (fun s => (M.orientation s).1) t hR, hderiv0] at hprod
-  rw [bodyAngularVelocityTensor, transpose_mul, transpose_transpose]
-  exact eq_neg_of_add_eq_zero_right hprod.symm
-
 /-- The time derivative of the orientation is `Ṙ = R Ω_body`, recovering the orientation path from
-its body-frame angular velocity tensor `Ω_body = Rᵀ Ṙ` via the orthogonality `R Rᵀ = 1`. -/
+its body-frame angular velocity tensor via the orthogonality `R Rᵀ = 1`. -/
 lemma orientation_mul_bodyAngularVelocityTensor (M : RigidBodyMotion d) (t : Time) :
     (M.orientation t).1 * M.bodyAngularVelocityTensor t = ∂ₜ (fun s => (M.orientation s).1) t := by
   rw [bodyAngularVelocityTensor, ← mul_assoc, M.orientation_mul_transpose t, one_mul]
 
-/-- The spatial and body-frame angular velocity tensors are conjugate under the orientation,
-`Ω = R Ω_body Rᵀ`: the spatial tensor `Ω = Ṙ Rᵀ` is the body-frame tensor `Ω_body = Rᵀ Ṙ` rotated
-into the inertial frame. -/
+/-- The spatial tensor is the body-frame tensor rotated into the inertial frame,
+`Ω = R Ω_body Rᵀ`. -/
 lemma angularVelocityTensor_eq_orientation_conj (M : RigidBodyMotion d) (t : Time) :
     M.angularVelocityTensor t
       = (M.orientation t).1 * M.bodyAngularVelocityTensor t * ((M.orientation t).1)ᵀ := by
   rw [angularVelocityTensor_eq, ← M.orientation_mul_bodyAngularVelocityTensor t]
 
-/-- The body-frame angular velocity tensor is the spatial tensor conjugated into the body frame,
-`Ω_body = Rᵀ Ω R`: the converse of `angularVelocityTensor_eq_orientation_conj`. -/
+/-- The body-frame tensor is the spatial tensor conjugated into the body frame,
+`Ω_body = Rᵀ Ω R`. -/
 lemma bodyAngularVelocityTensor_eq_orientation_conj (M : RigidBodyMotion d) (t : Time) :
     M.bodyAngularVelocityTensor t
       = ((M.orientation t).1)ᵀ * M.angularVelocityTensor t * (M.orientation t).1 := by
   rw [bodyAngularVelocityTensor_eq, angularVelocityTensor_eq, ← mul_assoc, mul_assoc,
     mul_eq_one_comm.mp (M.orientation_mul_transpose t), mul_one]
 
+/-- The body-frame angular velocity tensor is skew-symmetric, `Ω_bodyᵀ = -Ω_body`: it lies in the
+Lie algebra `𝔰𝔬(d)`, inherited from the spatial tensor by conjugation. -/
+lemma bodyAngularVelocityTensor_transpose (M : RigidBodyMotion d) (t : Time)
+    (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t) :
+    (M.bodyAngularVelocityTensor t)ᵀ = - M.bodyAngularVelocityTensor t := by
+  rw [M.bodyAngularVelocityTensor_eq_orientation_conj t, transpose_mul, transpose_mul,
+    transpose_transpose, M.angularVelocityTensor_transpose t hR, neg_mul, mul_neg, ← mul_assoc]
+
 /-- The body-frame angular velocity *vector* `ω_body(t)` of a rigid body moving in three-dimensional
 space: the vector dual to the body-frame angular velocity tensor `Ω_body(t)` under the hat map,
-`ω_body = Ω_bodyᵛ`. It is the angular velocity `ω` resolved along the body-fixed axes. -/
+`ω_body = Ω_bodyᵛ`. -/
 noncomputable def bodyAngularVelocity (M : RigidBodyMotion 3) (t : Time) : Fin 3 → ℝ :=
   crossProductVee (M.bodyAngularVelocityTensor t)
 

--- a/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
@@ -37,8 +37,10 @@ with the body, and its origin follows the (generally accelerating) centre of mas
 natural setting for the inertia tensor and Euler's equations, since the mass distribution, and
 with it the inertia tensor, is time-independent in body-fixed axes.
 
-The *body-frame angular velocity tensor* `Ω_body(t) = R(t)ᵀ Ṙ(t)` is the spatial tensor
-conjugated into the body frame, `Ω_body = Rᵀ Ω R`, and is again skew-symmetric; in three
+The *body-frame angular velocity tensor* `Ω_body(t) = R(t)ᵀ Ṙ(t)` is defined directly from the
+orientation, mirroring the spatial `Ω = Ṙ Rᵀ` rather than being derived from it — the two tensors
+are the derivative `Ṙ` translated back to the identity from the two sides — and they are related
+by conjugation, `Ω_body = Rᵀ Ω R`. The body-frame tensor is again skew-symmetric; in three
 dimensions its dual is the *body-frame angular velocity vector* `ω_body = Ω_bodyᵛ`, the angular
 velocity `ω` resolved along the body-fixed axes, `ω_body = Rᵀ ω`.
 
@@ -155,7 +157,8 @@ theorem velocity_eq_angularVelocity (M : RigidBodyMotion 3) (y : Space 3) (t : T
 
 /-- The body-frame (co-rotating) angular velocity tensor `Ω_body(t) = R(t)ᵀ Ṙ(t)` of a rigid body
 in motion, where `R(t) = orientation t`. It is the angular velocity tensor expressed in the frame
-rotating with the body, the conjugate `Ω_body = Rᵀ Ω R` of the spatial tensor `Ω = Ṙ Rᵀ`. -/
+rotating with the body, related to the spatial tensor `Ω = Ṙ Rᵀ` by the conjugation
+`Ω = R Ω_body Rᵀ` (`angularVelocityTensor_eq_orientation_conj`). -/
 noncomputable def bodyAngularVelocityTensor (M : RigidBodyMotion d) (t : Time) :
     Matrix (Fin d) (Fin d) ℝ :=
   ((M.orientation t).1)ᵀ * ∂ₜ (fun s => (M.orientation s).1) t
@@ -196,6 +199,14 @@ lemma angularVelocityTensor_eq_orientation_conj (M : RigidBodyMotion d) (t : Tim
     M.angularVelocityTensor t
       = (M.orientation t).1 * M.bodyAngularVelocityTensor t * ((M.orientation t).1)ᵀ := by
   rw [angularVelocityTensor_eq, ← M.orientation_mul_bodyAngularVelocityTensor t]
+
+/-- The body-frame angular velocity tensor is the spatial tensor conjugated into the body frame,
+`Ω_body = Rᵀ Ω R`: the converse of `angularVelocityTensor_eq_orientation_conj`. -/
+lemma bodyAngularVelocityTensor_eq_orientation_conj (M : RigidBodyMotion d) (t : Time) :
+    M.bodyAngularVelocityTensor t
+      = ((M.orientation t).1)ᵀ * M.angularVelocityTensor t * (M.orientation t).1 := by
+  rw [bodyAngularVelocityTensor_eq, angularVelocityTensor_eq, ← mul_assoc, mul_assoc,
+    mul_eq_one_comm.mp (M.orientation_mul_transpose t), mul_one]
 
 /-- The body-frame angular velocity *vector* `ω_body(t)` of a rigid body moving in three-dimensional
 space: the vector dual to the body-frame angular velocity tensor `Ω_body(t)` under the hat map,


### PR DESCRIPTION
## Body-frame angular velocity of a rigid body

Adds the co-rotating (body-frame) angular velocity to
`Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean`, mirroring the existing spatial
angular-velocity section (`angularVelocityTensor` / `angularVelocity`). This is the natural
kinematic prerequisite for the inertia tensor in body-fixed axes and, downstream, Euler's
equations. One new concept, one file, no new files.

The spatial tensor is `Ω = Ṙ Rᵀ`; the body-frame tensor is its conjugate `Ω_body = Rᵀ Ṙ = Rᵀ Ω R`,
again skew-symmetric, with 3-dimensional dual `ω_body = Ω_bodyᵛ`.

### New declarations (all in `namespace RigidBodyMotion`)

| Declaration | Statement |
|---|---|
| `bodyAngularVelocityTensor` (def) | `Ω_body(t) = R(t)ᵀ Ṙ(t)` |
| `bodyAngularVelocityTensor_eq` | unfolding lemma (`rfl`) |
| `bodyAngularVelocityTensor_transpose` | skew-symmetry `Ω_bodyᵀ = -Ω_body`, from `Rᵀ R = 1` |
| `orientation_mul_bodyAngularVelocityTensor` | `Ṙ = R Ω_body` |
| `angularVelocityTensor_eq_orientation_conj` | `Ω = R Ω_body Rᵀ` (body ↔ spatial bridge) |
| `bodyAngularVelocity` (def, `d = 3`) | `ω_body(t) = Ω_body(t)ᵛ` via the hat map |
| `bodyAngularVelocity_eq` | unfolding lemma (`rfl`) |
| `crossProductMatrix_bodyAngularVelocity` | `[ω_body]ₓ = Ω_body` |
| `bodyAngularVelocityTensor_of_orientation_const` | constant orientation ⇒ `Ω_body = 0` |
| `bodyAngularVelocity_of_orientation_const` | constant orientation ⇒ `ω_body = 0` |

The module docstring gains a paragraph on the body frame; references updated to Landau–Lifshitz
Sections 31 and 32.

### Reviewer reading order
`bodyAngularVelocityTensor` → `bodyAngularVelocityTensor_transpose` (skew) →
`orientation_mul_bodyAngularVelocityTensor` (`Ṙ = R Ω_body`) →
`angularVelocityTensor_eq_orientation_conj` (`Ω = R Ω_body Rᵀ`) → `bodyAngularVelocity` →
`crossProductMatrix_bodyAngularVelocity` → the two const-orientation lemmas.

### Verification
- `lake build Physlib.ClassicalMechanics.RigidBody.AngularVelocity` — succeeds; downstream
  `KineticEnergy` still builds.
- `#print axioms` on all 10 new declarations: only `propext`, `Classical.choice`, `Quot.sound`.
- `lake exe runLinter Physlib.ClassicalMechanics.RigidBody.AngularVelocity` — **0 issues in this
  file**. (The reported errors are the pre-existing `RigidBody/Basic.lean` informal-stub
  underscore names and `Meta/TODO`, unchanged from master.)
- `./scripts/lint-style.sh` — exit 0.

Follow-up (separate PR): König's theorem in the body frame,
`T = ½ M ⟪V,V⟫ + rotationalKineticEnergy ω_body` under `centerOfMass = 0`.

🤖 Drafted with AI assistance (Claude); the human author has reviewed and certifies every
statement.
