### PR TITLE
feat(ClassicalMechanics): König's theorem in the body frame

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -106,6 +106,7 @@ public import Physlib.Mathematics.LinearPMap
 public import Physlib.Mathematics.List
 public import Physlib.Mathematics.List.InsertIdx
 public import Physlib.Mathematics.List.InsertionSort
+public import Physlib.Mathematics.OrthogonalMatrix
 public import Physlib.Mathematics.PiTensorProduct
 public import Physlib.Mathematics.RatComplexNum
 public import Physlib.Mathematics.SO3.Basic

--- a/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
@@ -232,4 +232,15 @@ lemma bodyAngularVelocity_of_orientation_const (M : RigidBodyMotion 3)
   rw [bodyAngularVelocity_eq, congrFun (M.bodyAngularVelocityTensor_of_orientation_const R h) t]
   fin_cases i <;> simp [crossProductVee]
 
+/-- The rotational velocity written through the body-frame angular velocity,
+`Ṙ(t) v = R(t) (ω_body(t) × v)`: the derivative of the orientation acts as the body-frame angular
+velocity `ω_body` crossed with `v`, rotated back into the inertial frame by `R`. -/
+lemma deriv_orientation_mulVec_eq_orientation_bodyAngularVelocity_cross (M : RigidBodyMotion 3)
+    (v : Fin 3 → ℝ) (t : Time)
+    (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t) :
+    ∂ₜ (fun s => (M.orientation s).1) t *ᵥ v
+      = (M.orientation t).1 *ᵥ (M.bodyAngularVelocity t ⨯₃ v) := by
+  rw [← M.orientation_mul_bodyAngularVelocityTensor t, ← Matrix.mulVec_mulVec,
+    ← M.crossProductMatrix_bodyAngularVelocity t hR, Matrix.crossProductMatrix_mulVec]
+
 end RigidBodyMotion

--- a/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
@@ -171,9 +171,12 @@ theorem kineticEnergy_eq_translational_add_angularVelocity (M : RigidBodyMotion 
   ext y
   simp only [cmap_apply, M.deriv_orientation_mulVec_eq_angularVelocity_cross y t hR]
 
-/-- **König's theorem** in the body frame: at the centre of mass (`centerOfMass = 0`) the kinetic
-energy splits as `T = ½ M ⟪V, V⟫ + rotationalKineticEnergy ω_body`, the rotational term now carried
-by the body-frame angular velocity. -/
+/-- **König's theorem** in the body frame. The total kinetic energy `M.kineticEnergy t`, formed from
+the lab-frame point velocities, splits at the centre of mass (`centerOfMass = 0`) as
+`T = ½ M ⟪V, V⟫ + rotationalKineticEnergy ω_body`. The rotational energy is a frame-independent
+scalar, so it is evaluated here from the *body-frame* angular velocity `ω_body`: the spatial form
+`|Ṙ (y − c)|²` and the body form `|ω_body × (y − c)|²` agree because
+`Ṙ (y − c) = R (ω_body × (y − c))` and `R`, being orthogonal, preserves the norm. -/
 theorem kineticEnergy_eq_translational_add_bodyAngularVelocity (M : RigidBodyMotion 3) (t : Time)
     (h : M.mass ≠ 0) (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t)
     (hc : M.centerOfMass = 0) :

--- a/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
@@ -171,12 +171,9 @@ theorem kineticEnergy_eq_translational_add_angularVelocity (M : RigidBodyMotion 
   ext y
   simp only [cmap_apply, M.deriv_orientation_mulVec_eq_angularVelocity_cross y t hR]
 
-/-- **König's theorem** in the body frame: when the reference point is the centre of mass
-(`centerOfMass = 0`), the total kinetic energy of a rigid body in motion splits into the
-centre-of-mass kinetic energy plus the rotational energy expressed through the *body-frame* angular
-velocity, `T = ½ M ⟪V, V⟫ + rotationalKineticEnergy ω_body`. The rotational term is
-frame-independent, `|Ṙ (y − c)|² = |ω_body × (y − c)|²`, because the orientation `R` is
-orthogonal. -/
+/-- **König's theorem** in the body frame: at the centre of mass (`centerOfMass = 0`) the kinetic
+energy splits as `T = ½ M ⟪V, V⟫ + rotationalKineticEnergy ω_body`, the rotational term now carried
+by the body-frame angular velocity. -/
 theorem kineticEnergy_eq_translational_add_bodyAngularVelocity (M : RigidBodyMotion 3) (t : Time)
     (h : M.mass ≠ 0) (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t)
     (hc : M.centerOfMass = 0) :
@@ -189,9 +186,7 @@ theorem kineticEnergy_eq_translational_add_bodyAngularVelocity (M : RigidBodyMot
   congr 2
   ext y
   have hy : (fun j => (y : Fin 3 → ℝ) j - M.centerOfMass j) = (y : Fin 3 → ℝ) := by
-    funext j
-    rw [hc]
-    simp
+    simp [hc]
   simp only [cmap_apply, ContMDiffMap.coeFn_mk]
   rw [hy, M.deriv_orientation_mulVec_eq_orientation_bodyAngularVelocity_cross (y : Fin 3 → ℝ) t hR,
     Matrix.dotProduct_mulVec_orthogonal (mul_eq_one_comm.mp (M.orientation_mul_transpose t))]

--- a/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.ClassicalMechanics.RigidBody.AngularMomentum
 public import Physlib.ClassicalMechanics.RigidBody.AngularVelocity
+public import Physlib.Mathematics.OrthogonalMatrix
 /-!
 
 # Kinetic energy of a rigid body
@@ -169,5 +170,30 @@ theorem kineticEnergy_eq_translational_add_angularVelocity (M : RigidBodyMotion 
   congr 2
   ext y
   simp only [cmap_apply, M.deriv_orientation_mulVec_eq_angularVelocity_cross y t hR]
+
+/-- **König's theorem** in the body frame: when the reference point is the centre of mass
+(`centerOfMass = 0`), the total kinetic energy of a rigid body in motion splits into the
+centre-of-mass kinetic energy plus the rotational energy expressed through the *body-frame* angular
+velocity, `T = ½ M ⟪V, V⟫ + rotationalKineticEnergy ω_body`. The rotational term is
+frame-independent, `|Ṙ (y − c)|² = |ω_body × (y − c)|²`, because the orientation `R` is
+orthogonal. -/
+theorem kineticEnergy_eq_translational_add_bodyAngularVelocity (M : RigidBodyMotion 3) (t : Time)
+    (h : M.mass ≠ 0) (hR : DifferentiableAt ℝ (fun s => (M.orientation s).1) t)
+    (hc : M.centerOfMass = 0) :
+    M.kineticEnergy t
+      = (1 / (2 : ℝ)) * M.mass * (⟪M.centerOfMassVelocity t, M.centerOfMassVelocity t⟫_ℝ)
+        + M.toRigidBody.rotationalKineticEnergy (M.bodyAngularVelocity t) := by
+  rw [M.kineticEnergy_eq_translational_add_rotational t h,
+    RigidBody.rotationalKineticEnergy_eq_integral]
+  congr 1
+  congr 2
+  ext y
+  have hy : (fun j => (y : Fin 3 → ℝ) j - M.centerOfMass j) = (y : Fin 3 → ℝ) := by
+    funext j
+    rw [hc]
+    simp
+  simp only [cmap_apply, ContMDiffMap.coeFn_mk]
+  rw [hy, M.deriv_orientation_mulVec_eq_orientation_bodyAngularVelocity_cross (y : Fin 3 → ℝ) t hR,
+    Matrix.dotProduct_mulVec_orthogonal (mul_eq_one_comm.mp (M.orientation_mul_transpose t))]
 
 end RigidBodyMotion

--- a/Physlib/Mathematics/OrthogonalMatrix.lean
+++ b/Physlib/Mathematics/OrthogonalMatrix.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 Giuseppe Sorge. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Giuseppe Sorge
+-/
+module
+
+public import Mathlib.Data.Matrix.Mul
+/-!
+
+# Orthogonal matrices and the dot product
+
+An orthogonal matrix — a square matrix `A` with `Aᵀ A = 1` — preserves the dot product of vectors,
+and in particular their squared lengths. This is the algebraic content behind the
+frame-independence of the *rotational* kinetic energy in rigid-body dynamics: rotating a velocity
+does not change its speed.
+
+-/
+
+@[expose] public section
+
+namespace Matrix
+
+/-- An orthogonal matrix preserves the dot product: if `Aᵀ A = 1` then `(A v) ⬝ᵥ (A w) = v ⬝ᵥ w`.
+Taking `w = v` shows orthogonal matrices preserve squared lengths, `(A v) ⬝ᵥ (A v) = v ⬝ᵥ v`. -/
+lemma dotProduct_mulVec_orthogonal {R : Type*} [CommRing R] {n : ℕ}
+    {A : Matrix (Fin n) (Fin n) R} (hA : Aᵀ * A = 1) (v w : Fin n → R) :
+    (A *ᵥ v) ⬝ᵥ (A *ᵥ w) = v ⬝ᵥ w := by
+  rw [dotProduct_mulVec, ← mulVec_transpose, mulVec_mulVec, hA, one_mulVec]
+
+end Matrix

--- a/Physlib/Mathematics/OrthogonalMatrix.lean
+++ b/Physlib/Mathematics/OrthogonalMatrix.lean
@@ -23,8 +23,8 @@ namespace Matrix
 
 /-- An orthogonal matrix preserves the dot product: if `Aᵀ A = 1` then `(A v) ⬝ᵥ (A w) = v ⬝ᵥ w`.
 Taking `w = v` shows orthogonal matrices preserve squared lengths, `(A v) ⬝ᵥ (A v) = v ⬝ᵥ v`. -/
-lemma dotProduct_mulVec_orthogonal {R : Type*} [CommRing R] {n : ℕ}
-    {A : Matrix (Fin n) (Fin n) R} (hA : Aᵀ * A = 1) (v w : Fin n → R) :
+lemma dotProduct_mulVec_orthogonal {R : Type*} [CommRing R] {n : Type*} [Fintype n]
+    [DecidableEq n] {A : Matrix n n R} (hA : Aᵀ * A = 1) (v w : n → R) :
     (A *ᵥ v) ⬝ᵥ (A *ᵥ w) = v ⬝ᵥ w := by
   rw [dotProduct_mulVec, ← mulVec_transpose, mulVec_mulVec, hA, one_mulVec]
 


### PR DESCRIPTION
## König's theorem in the body frame

Builds on #1417 (body-frame angular velocity), now merged.

This expresses the rotational kinetic energy of a rigid body in motion through the *body-frame*
angular velocity `ω_body` (from #1417), giving König's theorem in the compact form
`T = ½ M ⟪V, V⟫ + rotationalKineticEnergy ω_body` when the reference point is the centre of mass
(Landau–Lifshitz §32). The rotational term is representation-independent — `|Ṙ (y − c)|²` in
spatial form equals `|ω_body × (y − c)|²` in body form — because the orientation `R` is orthogonal.

### New declarations

| Declaration | File | Statement |
|---|---|---|
| `Matrix.dotProduct_mulVec_orthogonal` | `Mathematics/OrthogonalMatrix.lean` (new) | `Aᵀ A = 1 → (A v) ⬝ᵥ (A w) = v ⬝ᵥ w` (orthogonal matrices preserve the dot product) |
| `deriv_orientation_mulVec_eq_orientation_bodyAngularVelocity_cross` | `RigidBody/AngularVelocity.lean` | `Ṙ v = R (ω_body × v)` |
| `kineticEnergy_eq_translational_add_bodyAngularVelocity` | `RigidBody/KineticEnergy.lean` | body-frame König, under `centerOfMass = 0` |

### On the new file `Mathematics/OrthogonalMatrix.lean`
`dotProduct_mulVec_orthogonal` is a general matrix fact (any `CommRing`, any finite index type), so per
AGENTS.md it must live outside the ClassicalMechanics file. It is not in Mathlib (no
orthogonal-group dot-product/isometry lemma over `Matrix`), and it does not fit the existing
`Mathematics/CrossProduct.lean` (cross-product-themed) or `Mathematics/SO3/Basic.lean` (a different
custom `SO3` type). A dedicated file also seeds the orthogonal-matrix facts the follow-up
rigid-body PRs will need (parallel-axis `R I Rᵀ`, principal axes). Happy to relocate if you prefer.

### Reviewer reading order
`OrthogonalMatrix.dotProduct_mulVec_orthogonal` →
`deriv_orientation_mulVec_eq_orientation_bodyAngularVelocity_cross` (the `Ṙ v = R(ω_body × v)`
bridge) → `kineticEnergy_eq_translational_add_bodyAngularVelocity`. The proof reduces to the merged
`kineticEnergy_eq_translational_add_rotational`, rewrites `Ṙ(y−c)` via the bridge, kills the `R`
with the orthogonality lemma, and uses `centerOfMass = 0` to match
`rotationalKineticEnergy_eq_integral` (which integrates `|ω × x|²` about the origin).

### Verification
- `lake build Physlib.ClassicalMechanics.RigidBody.KineticEnergy` — succeeds (builds the new file
  and both RigidBody files).
- `#print axioms` on all three new declarations: only `propext`, `Classical.choice`, `Quot.sound`.
- `runLinter` — 0 issues in the touched files. `./scripts/lint-style.sh` — exit 0.

🤖 Drafted with AI assistance (Claude); the human author has reviewed and certifies every
statement.

