### PR TITLE
auto-task(HermitianMat.CFC): minimize imports of QuantumInfo/ForMathlib/HermitianMat/CFC.lean

### DIFF
--- a/QuantumInfo/ForMathlib/HermitianMat/CFC.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/CFC.lean
@@ -8,14 +8,10 @@ module
 public import QuantumInfo.ForMathlib.HermitianMat.Inner
 public import QuantumInfo.ForMathlib.HermitianMat.NonSingular
 public import QuantumInfo.ForMathlib.Isometry
-public import QuantumInfo.ForMathlib.Unitary
 
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Continuity
-public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
-public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Commute
 public import Mathlib.Analysis.CStarAlgebra.CStarMatrix
-public import Mathlib.Algebra.Order.Group.Pointwise.CompleteLattice
 public import Mathlib.Topology.TietzeExtension
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 

--- a/QuantumInfo/ForMathlib/HermitianMat/Rpow.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Rpow.lean
@@ -8,6 +8,7 @@ module
 public import QuantumInfo.ForMathlib.HermitianMat.CompoundMatrix
 public import QuantumInfo.ForMathlib.HermitianMat.LogExp
 public import QuantumInfo.ForMathlib.HermitianMat.Sqrt
+public import QuantumInfo.ForMathlib.HermitianMat.Unitary
 
 @[expose] public section
 


### PR DESCRIPTION
# Minimize imports of `QuantumInfo/ForMathlib/HermitianMat/CFC.lean`

## What changed

Removed 4 unneeded `public import` lines from `QuantumInfo/ForMathlib/HermitianMat/CFC.lean`:

- `QuantumInfo.ForMathlib.Unitary` — nothing from this module (unitary conjugation on
  linear maps, `conj_unitary_eigenvalue_equiv`, etc.) is used in the file.
- `Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic` — redundant: it is
  publicly re-exported by `Mathlib.Analysis.CStarAlgebra.CStarMatrix`, which the file keeps.
- `Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances` — redundant: it is
  publicly re-exported by both `...ContinuousFunctionalCalculus.Continuity` (via `Isometric`)
  and `...ContinuousFunctionalCalculus.Commute`, which the file keeps.
- `Mathlib.Algebra.Order.Group.Pointwise.CompleteLattice` — not used by anything in the file.

All 8 remaining imports are directly used (`norm_eq_trace_sq` from `Inner`, `NonSingular` /
`nonSingular_iff_eigenvalue_ne_zero`, `Matrix.cfc_reindex` / `Matrix.cfc_conj_unitary` from
`Isometry`, `ContinuousOn.cfc` from `Continuity`, `Commute.cfc_real` from `Commute`,
`CStarMatrix` explicitly, `ContinuousMap.exists_restrict_eq` from `TietzeExtension`, and
`intervalIntegral` from `IntervalIntegral.Basic`).

## Downstream fix

- `QuantumInfo/ForMathlib/HermitianMat/Rpow.lean`: added
  `public import QuantumInfo.ForMathlib.HermitianMat.Unitary`. Rpow uses the `𝐔[d]`
  notation (defined in `HermitianMat.Unitary`) and was previously receiving it only
  transitively through `CFC → ForMathlib.Unitary → HermitianMat.Unitary`. It now imports
  the module it actually uses directly.

No code, docstrings, or declarations were touched — only `import` lines.

## Verification

`lake build` (default targets `Physlib` + `QuantumInfo`, 9130 jobs) completes successfully
with no new errors or warnings (the only warning is the pre-existing, replayed
`unusedSimpArgs` warning in `Physlib/Electromagnetism/Kinematics/EMPotential.lean`,
untouched by this PR).
