### PR TITLE
feat: add unitary conjugation of partially-defined operators

### DIFF
--- a/Physlib/Mathematics/LinearPMap.lean
+++ b/Physlib/Mathematics/LinearPMap.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Gregory J. Loges. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Adam Bornemann, Gregory J. Loges
+Authors: Gregory J. Loges
 -/
 module
 
@@ -29,12 +29,6 @@ composition of partial linear maps while having the domain implicitly accounted 
     with natural domain `{x : f.domain | f x ∈ g.domain}`.
 - `LinearPMap.instMonoid` : Partial linear maps `E →ₗ.[R] E` with `compRestricted`
     for multiplication and the identity map for `1` comprise a monoid.
-- `LinearPMap.unitaryConj` : The conjugation `U A U⁻¹ : H' →ₗ.[ℂ] H'` of `A` by `U`, with domain
-    `U (A.domain)`.
-- `LinearPMap.IsFormalAdjoint.unitaryConj` : Unitary conjugation preserves formal-adjoint pairs.
-- `LinearPMap.unitaryConj_dense_domain` : If `A` has dense domain, then so does `U A U⁻¹`.
-- `LinearPMap.unitaryConj_sub_smul_surjective` : If `A - z` is surjective for a scalar `z : ℂ`,
-    then so is `U A U⁻¹ - z`.
 
 ## iii. Table of contents
 
@@ -44,7 +38,6 @@ composition of partial linear maps while having the domain implicitly accounted 
 - D. Restricted composition
 - E. Monoid
 - F. Inverses
-- G. Unitary conjugation
 
 ## iv. References
 
@@ -389,72 +382,4 @@ lemma compRestricted_inverse_eq : f ∘ᵣ f.inverse = domRestrict 1 f.inverse.d
 
 end Inverses
 
-/-!
-## G. Unitary conjugation
--/
-
-section UnitaryConj
-
-variable {H H' : Type*}
-  [NormedAddCommGroup H] [InnerProductSpace ℂ H]
-  [NormedAddCommGroup H'] [InnerProductSpace ℂ H']
-
-variable (U : H ≃ₗᵢ[ℂ] H') (A : H →ₗ.[ℂ] H)
-
-/-- The conjugation `U A U⁻¹` of a partially-defined operator `A : H →ₗ.[ℂ] H` by a unitary
-`U : H ≃ₗᵢ[ℂ] H'`, with domain `U (A.domain) = U⁻¹ ⁻¹' (A.domain)` and action
-`y ↦ U (A (U⁻¹ y))`. Since `U` and `U⁻¹` are `ℂ`-linear, the result is again `ℂ`-linear. -/
-def unitaryConj : H' →ₗ.[ℂ] H' where
-  domain := A.domain.comap (U.symm.toLinearEquiv : H' →ₗ[ℂ] H)
-  toFun := U.toLinearEquiv.toLinearMap.comp <| A.toFun.comp
-    (((U.symm.toLinearEquiv : H' →ₗ[ℂ] H).comp
-      (A.domain.comap (U.symm.toLinearEquiv : H' →ₗ[ℂ] H)).subtype).codRestrict A.domain
-        fun x => x.2)
-
-/-- Membership in the conjugated domain: `x ∈ D(U A U⁻¹) ↔ U⁻¹ x ∈ D(A)`. -/
-lemma mem_unitaryConj_domain_iff {x : H'} :
-    x ∈ (unitaryConj U A).domain ↔ U.symm x ∈ A.domain := Iff.rfl
-
-/-- The defining formula `(U A U⁻¹) x = U (A (U⁻¹ x))`. -/
-lemma unitaryConj_apply (x : (unitaryConj U A).domain) :
-    unitaryConj U A x = U (A ⟨U.symm (x : H'), (mem_unitaryConj_domain_iff U A).mp x.2⟩) := rfl
-
-/-- `U` maps `D(A)` into `D(U A U⁻¹)`. -/
-lemma map_mem_unitaryConj_domain (y : A.domain) : U (y : H) ∈ (unitaryConj U A).domain := by
-  simpa only [mem_unitaryConj_domain_iff, U.symm_apply_apply] using y.2
-
-/-- The action on the image domain: `(U A U⁻¹)(U y) = U (A y)` for `y ∈ D(A)`. -/
-lemma unitaryConj_apply_map (y : A.domain) :
-    unitaryConj U A ⟨U (y : H), map_mem_unitaryConj_domain U A y⟩ = U (A y) := by
-  simp only [unitaryConj_apply, U.symm_apply_apply]
-
-variable {U A}
-
-open scoped InnerProductSpace in
-/-- Unitary conjugation preserves formal adjointness. If `A` is a formal adjoint of `B`, then
-`U A U⁻¹` is a formal adjoint of `U B U⁻¹`. Unitary conjugation preserves symmetry when `A = B`. -/
-lemma IsFormalAdjoint.unitaryConj {B : H →ₗ.[ℂ] H} (h : A.IsFormalAdjoint B) :
-    (unitaryConj U A).IsFormalAdjoint (unitaryConj U B) := by
-  intro x y
-  let x' : A.domain := ⟨U.symm (x : H'), (mem_unitaryConj_domain_iff U A).mp x.2⟩
-  let y' : B.domain := ⟨U.symm (y : H'), (mem_unitaryConj_domain_iff U B).mp y.2⟩
-  calc ⟪LinearPMap.unitaryConj U A x, (y : H')⟫_ℂ
-      = ⟪A x', (y' : H)⟫_ℂ := U.inner_map_eq_flip _ _
-    _ = ⟪(x' : H), B y'⟫_ℂ := h x' y'
-    _ = ⟪(x : H'), LinearPMap.unitaryConj U B y⟫_ℂ := U.symm.inner_map_eq_flip _ _
-
-/-- If `A` has dense domain, then so does `U A U⁻¹`: the domain `U⁻¹ ⁻¹' (A.domain)` is the
-preimage of a dense set under a homeomorphism. -/
-lemma unitaryConj_dense_domain (hdense : Dense (A.domain : Set H)) :
-    Dense ((unitaryConj U A).domain : Set H') := hdense.preimage U.symm.toHomeomorph.isOpenMap
-
-/-- If `A - z` is surjective for a scalar `z : ℂ`, then so is `U A U⁻¹ - z`. -/
-lemma unitaryConj_sub_smul_surjective {z : ℂ}
-    (h : ∀ φ : H, ∃ ψ : A.domain, A ψ - z • (ψ : H) = φ) (φ : H') :
-    ∃ ψ : (unitaryConj U A).domain, unitaryConj U A ψ - z • (ψ : H') = φ := by
-  obtain ⟨w, hw⟩ := h (U.symm φ)
-  refine ⟨⟨U (w : H), map_mem_unitaryConj_domain U A w⟩, ?_⟩
-  rw [unitaryConj_apply_map, ← _root_.map_smul U, ← _root_.map_sub, hw, U.apply_symm_apply]
-
-end UnitaryConj
 end LinearPMap

--- a/Physlib/Mathematics/LinearPMap.lean
+++ b/Physlib/Mathematics/LinearPMap.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Gregory J. Loges. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Gregory J. Loges
+Authors: Adam Bornemann, Gregory J. Loges
 -/
 module
 
@@ -29,6 +29,12 @@ composition of partial linear maps while having the domain implicitly accounted 
     with natural domain `{x : f.domain | f x ∈ g.domain}`.
 - `LinearPMap.instMonoid` : Partial linear maps `E →ₗ.[R] E` with `compRestricted`
     for multiplication and the identity map for `1` comprise a monoid.
+- `LinearPMap.unitaryConj` : The conjugation `U A U⁻¹ : H' →ₗ.[ℂ] H'` of `A` by `U`, with domain
+    `U (A.domain)`.
+- `LinearPMap.IsFormalAdjoint.unitaryConj` : Unitary conjugation preserves formal-adjoint pairs.
+- `LinearPMap.unitaryConj_dense_domain` : If `A` has dense domain, then so does `U A U⁻¹`.
+- `LinearPMap.unitaryConj_sub_smul_surjective` : If `A - z` is surjective for a scalar `z : ℂ`,
+    then so is `U A U⁻¹ - z`.
 
 ## iii. Table of contents
 
@@ -38,6 +44,7 @@ composition of partial linear maps while having the domain implicitly accounted 
 - D. Restricted composition
 - E. Monoid
 - F. Inverses
+- G. Unitary conjugation
 
 ## iv. References
 
@@ -382,4 +389,72 @@ lemma compRestricted_inverse_eq : f ∘ᵣ f.inverse = domRestrict 1 f.inverse.d
 
 end Inverses
 
+/-!
+## G. Unitary conjugation
+-/
+
+section UnitaryConj
+
+variable {H H' : Type*}
+  [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+  [NormedAddCommGroup H'] [InnerProductSpace ℂ H']
+
+variable (U : H ≃ₗᵢ[ℂ] H') (A : H →ₗ.[ℂ] H)
+
+/-- The conjugation `U A U⁻¹` of a partially-defined operator `A : H →ₗ.[ℂ] H` by a unitary
+`U : H ≃ₗᵢ[ℂ] H'`, with domain `U (A.domain) = U⁻¹ ⁻¹' (A.domain)` and action
+`y ↦ U (A (U⁻¹ y))`. Since `U` and `U⁻¹` are `ℂ`-linear, the result is again `ℂ`-linear. -/
+def unitaryConj : H' →ₗ.[ℂ] H' where
+  domain := A.domain.comap (U.symm.toLinearEquiv : H' →ₗ[ℂ] H)
+  toFun := U.toLinearEquiv.toLinearMap.comp <| A.toFun.comp
+    (((U.symm.toLinearEquiv : H' →ₗ[ℂ] H).comp
+      (A.domain.comap (U.symm.toLinearEquiv : H' →ₗ[ℂ] H)).subtype).codRestrict A.domain
+        fun x => x.2)
+
+/-- Membership in the conjugated domain: `x ∈ D(U A U⁻¹) ↔ U⁻¹ x ∈ D(A)`. -/
+lemma mem_unitaryConj_domain_iff {x : H'} :
+    x ∈ (unitaryConj U A).domain ↔ U.symm x ∈ A.domain := Iff.rfl
+
+/-- The defining formula `(U A U⁻¹) x = U (A (U⁻¹ x))`. -/
+lemma unitaryConj_apply (x : (unitaryConj U A).domain) :
+    unitaryConj U A x = U (A ⟨U.symm (x : H'), (mem_unitaryConj_domain_iff U A).mp x.2⟩) := rfl
+
+/-- `U` maps `D(A)` into `D(U A U⁻¹)`. -/
+lemma map_mem_unitaryConj_domain (y : A.domain) : U (y : H) ∈ (unitaryConj U A).domain := by
+  simpa only [mem_unitaryConj_domain_iff, U.symm_apply_apply] using y.2
+
+/-- The action on the image domain: `(U A U⁻¹)(U y) = U (A y)` for `y ∈ D(A)`. -/
+lemma unitaryConj_apply_map (y : A.domain) :
+    unitaryConj U A ⟨U (y : H), map_mem_unitaryConj_domain U A y⟩ = U (A y) := by
+  simp only [unitaryConj_apply, U.symm_apply_apply]
+
+variable {U A}
+
+open scoped InnerProductSpace in
+/-- Unitary conjugation preserves formal adjointness. If `A` is a formal adjoint of `B`, then
+`U A U⁻¹` is a formal adjoint of `U B U⁻¹`. Unitary conjugation preserves symmetry when `A = B`. -/
+lemma IsFormalAdjoint.unitaryConj {B : H →ₗ.[ℂ] H} (h : A.IsFormalAdjoint B) :
+    (unitaryConj U A).IsFormalAdjoint (unitaryConj U B) := by
+  intro x y
+  let x' : A.domain := ⟨U.symm (x : H'), (mem_unitaryConj_domain_iff U A).mp x.2⟩
+  let y' : B.domain := ⟨U.symm (y : H'), (mem_unitaryConj_domain_iff U B).mp y.2⟩
+  calc ⟪LinearPMap.unitaryConj U A x, (y : H')⟫_ℂ
+      = ⟪A x', (y' : H)⟫_ℂ := U.inner_map_eq_flip _ _
+    _ = ⟪(x' : H), B y'⟫_ℂ := h x' y'
+    _ = ⟪(x : H'), LinearPMap.unitaryConj U B y⟫_ℂ := U.symm.inner_map_eq_flip _ _
+
+/-- If `A` has dense domain, then so does `U A U⁻¹`: the domain `U⁻¹ ⁻¹' (A.domain)` is the
+preimage of a dense set under a homeomorphism. -/
+lemma unitaryConj_dense_domain (hdense : Dense (A.domain : Set H)) :
+    Dense ((unitaryConj U A).domain : Set H') := hdense.preimage U.symm.toHomeomorph.isOpenMap
+
+/-- If `A - z` is surjective for a scalar `z : ℂ`, then so is `U A U⁻¹ - z`. -/
+lemma unitaryConj_sub_smul_surjective {z : ℂ}
+    (h : ∀ φ : H, ∃ ψ : A.domain, A ψ - z • (ψ : H) = φ) (φ : H') :
+    ∃ ψ : (unitaryConj U A).domain, unitaryConj U A ψ - z • (ψ : H') = φ := by
+  obtain ⟨w, hw⟩ := h (U.symm φ)
+  refine ⟨⟨U (w : H), map_mem_unitaryConj_domain U A w⟩, ?_⟩
+  rw [unitaryConj_apply_map, ← _root_.map_smul U, ← _root_.map_sub, hw, U.apply_symm_apply]
+
+end UnitaryConj
 end LinearPMap

--- a/Physlib/QuantumMechanics/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/Operators/Unbounded.lean
@@ -50,6 +50,12 @@ Definitions
 Results
 - `adjoint_add_le_add_adjoint` : The inequality `U₁† + U₂† ≤ (U₁ + U₂)†` when `U₁ + U₂` has
     dense domain.
+- `unitaryConj` : The conjugation `u A u⁻¹ : H' →ₗ.[ℂ] H'` of `A` by a unitary `u`, with domain
+    `u (A.domain)`.
+- `IsFormalAdjoint.unitaryConj` : Unitary conjugation preserves formal-adjoint pairs.
+- `HasDenseDomain.unitaryConj_dense_domain` : If `A` has dense domain, then so does `u A u⁻¹`.
+- `unitaryConj_sub_smul_surjective` : If `A - z` is surjective for a scalar `z : ℂ`,
+    then so is `u A u⁻¹ - z`.
 - `adjoint_compRestricted_le_compRestricted_adjoint` : The inequality `U† ∘ᵣ V† ≤ (V ∘ᵣ U)†`
     when `V` and `V ∘ᵣ U` have dense domain.
 - `IsEssentiallySelfAdjoint.unique_self_adjoint_extension` : The closure of an essentially
@@ -58,12 +64,7 @@ Results
 - `IsUnbounded.adjoint_closure_eq_adjoint` : An unbounded operator and its closure have
     the same adjoint.
 - `IsUnbounded.adjoint_adjoint_eq_closure` : An unbounded operator `U` satisfies `U†† = U.closure`.
-- `unitaryConj` : The conjugation `u A u⁻¹ : H' →ₗ.[ℂ] H'` of `A` by a unitary `u`, with domain
-    `u (A.domain)`.
-- `IsFormalAdjoint.unitaryConj` : Unitary conjugation preserves formal-adjoint pairs.
-- `HasDenseDomain.unitaryConj_dense_domain` : If `A` has dense domain, then so does `u A u⁻¹`.
-- `unitaryConj_sub_smul_surjective` : If `A - z` is surjective for a scalar `z : ℂ`,
-    then so is `u A u⁻¹ - z`.
+
 
 ## iii. Table of contents
 
@@ -73,12 +74,12 @@ Results
   - B.2. Closability
   - B.3. Adjoints
   - B.4. Continuity / boundedness
+  - B.5. Unitary conjugation
 - C. Classes of operators
   - C.1. Symmetric operators
   - C.2. Self-adjoint operators
   - C.3. Essentially self-adjoint operators
   - C.4. Unbounded operators
-- D. Unitary conjugation
 
 ## iv. References
 
@@ -554,6 +555,71 @@ lemma IsClosed.sub_continuous [CompleteSpace H']
   sub_eq_add_neg U₁ U₂ ▸ h₁.add_continuous h₂.neg h
 
 /-!
+### B.5. Unitary conjugation
+-/
+
+variable (u : H ≃ₗᵢ[ℂ] H') (A : H →ₗ.[ℂ] H)
+
+/-- The conjugation `u A u⁻¹` of a partially-defined operator `A : H →ₗ.[ℂ] H` by a unitary
+`u : H ≃ₗᵢ[ℂ] H'`, with domain `u (A.domain) = u⁻¹ ⁻¹' (A.domain)` and action
+`y ↦ u (A (u⁻¹ y))`. Since `u` and `u⁻¹` are `ℂ`-linear, the result is again `ℂ`-linear. -/
+def unitaryConj : H' →ₗ.[ℂ] H' where
+  domain := A.domain.comap (u.symm.toLinearEquiv : H' →ₗ[ℂ] H)
+  toFun := u.toLinearEquiv.toLinearMap.comp <| A.toFun.comp
+    (((u.symm.toLinearEquiv : H' →ₗ[ℂ] H).comp
+      (A.domain.comap (u.symm.toLinearEquiv : H' →ₗ[ℂ] H)).subtype).codRestrict A.domain
+        fun x => x.2)
+
+/-- Membership in the conjugated domain: `x ∈ D(u A u⁻¹) ↔ u⁻¹ x ∈ D(A)`. -/
+lemma mem_unitaryConj_domain_iff {x : H'} :
+    x ∈ (unitaryConj u A).domain ↔ u.symm x ∈ A.domain := Iff.rfl
+
+/-- The defining formula `(u A u⁻¹) x = u (A (u⁻¹ x))`. -/
+lemma unitaryConj_apply (x : (unitaryConj u A).domain) :
+    unitaryConj u A x = u (A ⟨u.symm (x : H'), (mem_unitaryConj_domain_iff u A).mp x.2⟩) := rfl
+
+/-- `u` maps `D(A)` into `D(u A u⁻¹)`. -/
+lemma map_mem_unitaryConj_domain (y : A.domain) : u (y : H) ∈ (unitaryConj u A).domain := by
+  simpa only [mem_unitaryConj_domain_iff, u.symm_apply_apply] using y.2
+
+/-- The action on the image domain: `(u A u⁻¹)(u y) = u (A y)` for `y ∈ D(A)`. -/
+lemma unitaryConj_apply_map (y : A.domain) :
+    unitaryConj u A ⟨u (y : H), map_mem_unitaryConj_domain u A y⟩ = u (A y) := by
+  simp only [unitaryConj_apply, u.symm_apply_apply]
+
+variable {u A}
+
+open scoped InnerProductSpace in
+/-- Unitary conjugation preserves formal adjointness. If `A` is a formal adjoint of `B`, then
+`u A u⁻¹` is a formal adjoint of `u B u⁻¹`. Unitary conjugation preserves symmetry when `A = B`. -/
+lemma IsFormalAdjoint.unitaryConj {B : H →ₗ.[ℂ] H} (h : A.IsFormalAdjoint B) :
+    (unitaryConj u A).IsFormalAdjoint (unitaryConj u B) := by
+  intro x y
+  let x' : A.domain := ⟨u.symm (x : H'), (mem_unitaryConj_domain_iff u A).mp x.2⟩
+  let y' : B.domain := ⟨u.symm (y : H'), (mem_unitaryConj_domain_iff u B).mp y.2⟩
+  calc ⟪LinearPMap.unitaryConj u A x, (y : H')⟫_ℂ
+      = ⟪A x', (y' : H)⟫_ℂ := u.inner_map_eq_flip _ _
+    _ = ⟪(x' : H), B y'⟫_ℂ := h x' y'
+    _ = ⟪(x : H'), LinearPMap.unitaryConj u B y⟫_ℂ := u.symm.inner_map_eq_flip _ _
+
+/-- If `A` has dense domain, then so does `u A u⁻¹`: the domain `u⁻¹ ⁻¹' (A.domain)` is the
+preimage of a dense set under a homeomorphism. -/
+lemma HasDenseDomain.unitaryConj_dense_domain (hdense : A.HasDenseDomain) :
+    (unitaryConj u A).HasDenseDomain := hdense.preimage u.symm.toHomeomorph.isOpenMap
+
+/-- If `A - z` is surjective for a scalar `z : ℂ`, then so is `u A u⁻¹ - z`. -/
+lemma unitaryConj_sub_smul_surjective {z : ℂ} (h : Function.Surjective (A - z • 1).toFun) :
+    Function.Surjective (unitaryConj u A - z • 1).toFun := by
+  intro φ
+  obtain ⟨ξ, hξ⟩ := h (u.symm φ)
+  obtain ⟨w, hw⟩ : ∃ w : A.domain, A w - z • (w : H) = u.symm φ :=
+    ⟨⟨(ξ : H), (Submodule.mem_inf.mp ξ.2).1⟩, hξ⟩
+  refine ⟨⟨u (w : H), Submodule.mem_inf.mpr
+    ⟨map_mem_unitaryConj_domain u A w, Submodule.mem_top⟩⟩, ?_⟩
+  show unitaryConj u A ⟨u (w : H), map_mem_unitaryConj_domain u A w⟩ - z • (u (w : H)) = φ
+  rw [unitaryConj_apply_map, ← _root_.map_smul u, ← _root_.map_sub, hw, u.apply_symm_apply]
+
+/-!
 ## C. Classes of operators
 -/
 
@@ -862,74 +928,5 @@ lemma isUnbounded_of_dense_of_isSymmetric' [CompleteSpace H]
     {E : Submodule ℂ H} (hE : Dense (E : Set H)) {f : E →ₗ[ℂ] E} (h : f.IsSymmetric) :
     (mk E (E.subtype ∘ₗ f)).IsUnbounded :=
   ⟨hE, IsSymmetric.isClosable h hE⟩
-
-/-!
-## D. Unitary conjugation
--/
-
-section UnitaryConj
-
-variable (u : H ≃ₗᵢ[ℂ] H') (A : H →ₗ.[ℂ] H)
-
-/-- The conjugation `u A u⁻¹` of a partially-defined operator `A : H →ₗ.[ℂ] H` by a unitary
-`u : H ≃ₗᵢ[ℂ] H'`, with domain `u (A.domain) = u⁻¹ ⁻¹' (A.domain)` and action
-`y ↦ u (A (u⁻¹ y))`. Since `u` and `u⁻¹` are `ℂ`-linear, the result is again `ℂ`-linear. -/
-def unitaryConj : H' →ₗ.[ℂ] H' where
-  domain := A.domain.comap (u.symm.toLinearEquiv : H' →ₗ[ℂ] H)
-  toFun := u.toLinearEquiv.toLinearMap.comp <| A.toFun.comp
-    (((u.symm.toLinearEquiv : H' →ₗ[ℂ] H).comp
-      (A.domain.comap (u.symm.toLinearEquiv : H' →ₗ[ℂ] H)).subtype).codRestrict A.domain
-        fun x => x.2)
-
-/-- Membership in the conjugated domain: `x ∈ D(u A u⁻¹) ↔ u⁻¹ x ∈ D(A)`. -/
-lemma mem_unitaryConj_domain_iff {x : H'} :
-    x ∈ (unitaryConj u A).domain ↔ u.symm x ∈ A.domain := Iff.rfl
-
-/-- The defining formula `(u A u⁻¹) x = u (A (u⁻¹ x))`. -/
-lemma unitaryConj_apply (x : (unitaryConj u A).domain) :
-    unitaryConj u A x = u (A ⟨u.symm (x : H'), (mem_unitaryConj_domain_iff u A).mp x.2⟩) := rfl
-
-/-- `u` maps `D(A)` into `D(u A u⁻¹)`. -/
-lemma map_mem_unitaryConj_domain (y : A.domain) : u (y : H) ∈ (unitaryConj u A).domain := by
-  simpa only [mem_unitaryConj_domain_iff, u.symm_apply_apply] using y.2
-
-/-- The action on the image domain: `(u A u⁻¹)(u y) = u (A y)` for `y ∈ D(A)`. -/
-lemma unitaryConj_apply_map (y : A.domain) :
-    unitaryConj u A ⟨u (y : H), map_mem_unitaryConj_domain u A y⟩ = u (A y) := by
-  simp only [unitaryConj_apply, u.symm_apply_apply]
-
-variable {u A}
-
-open scoped InnerProductSpace in
-/-- Unitary conjugation preserves formal adjointness. If `A` is a formal adjoint of `B`, then
-`u A u⁻¹` is a formal adjoint of `u B u⁻¹`. Unitary conjugation preserves symmetry when `A = B`. -/
-lemma IsFormalAdjoint.unitaryConj {B : H →ₗ.[ℂ] H} (h : A.IsFormalAdjoint B) :
-    (unitaryConj u A).IsFormalAdjoint (unitaryConj u B) := by
-  intro x y
-  let x' : A.domain := ⟨u.symm (x : H'), (mem_unitaryConj_domain_iff u A).mp x.2⟩
-  let y' : B.domain := ⟨u.symm (y : H'), (mem_unitaryConj_domain_iff u B).mp y.2⟩
-  calc ⟪LinearPMap.unitaryConj u A x, (y : H')⟫_ℂ
-      = ⟪A x', (y' : H)⟫_ℂ := u.inner_map_eq_flip _ _
-    _ = ⟪(x' : H), B y'⟫_ℂ := h x' y'
-    _ = ⟪(x : H'), LinearPMap.unitaryConj u B y⟫_ℂ := u.symm.inner_map_eq_flip _ _
-
-/-- If `A` has dense domain, then so does `u A u⁻¹`: the domain `u⁻¹ ⁻¹' (A.domain)` is the
-preimage of a dense set under a homeomorphism. -/
-lemma HasDenseDomain.unitaryConj_dense_domain (hdense : A.HasDenseDomain) :
-    (unitaryConj u A).HasDenseDomain := hdense.preimage u.symm.toHomeomorph.isOpenMap
-
-/-- If `A - z` is surjective for a scalar `z : ℂ`, then so is `u A u⁻¹ - z`. -/
-lemma unitaryConj_sub_smul_surjective {z : ℂ} (h : Function.Surjective (A - z • 1).toFun) :
-    Function.Surjective (unitaryConj u A - z • 1).toFun := by
-  intro φ
-  obtain ⟨ξ, hξ⟩ := h (u.symm φ)
-  obtain ⟨w, hw⟩ : ∃ w : A.domain, A w - z • (w : H) = u.symm φ :=
-    ⟨⟨(ξ : H), (Submodule.mem_inf.mp ξ.2).1⟩, hξ⟩
-  refine ⟨⟨u (w : H), Submodule.mem_inf.mpr
-    ⟨map_mem_unitaryConj_domain u A w, Submodule.mem_top⟩⟩, ?_⟩
-  show unitaryConj u A ⟨u (w : H), map_mem_unitaryConj_domain u A w⟩ - z • (u (w : H)) = φ
-  rw [unitaryConj_apply_map, ← _root_.map_smul u, ← _root_.map_sub, hw, u.apply_symm_apply]
-
-end UnitaryConj
 
 end LinearPMap

--- a/Physlib/QuantumMechanics/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/Operators/Unbounded.lean
@@ -22,7 +22,7 @@ essentially self-adjoint (closure is self-adjoint).
 
 In this module we collect results on how the properties `HasDenseDomain`, `IsUnbounded`,
 `IsSymmetric`, `IsSelfAdjoint` and `IsEssentiallySelfAdjoint` interact with the basic algebraic
-operations, closure, adjoints and each other.
+operations, closure, adjoints, unitary conjugation and each other.
 
 ### Notes
 
@@ -58,6 +58,12 @@ Results
 - `IsUnbounded.adjoint_closure_eq_adjoint` : An unbounded operator and its closure have
     the same adjoint.
 - `IsUnbounded.adjoint_adjoint_eq_closure` : An unbounded operator `U` satisfies `U†† = U.closure`.
+- `unitaryConj` : The conjugation `u A u⁻¹ : H' →ₗ.[ℂ] H'` of `A` by a unitary `u`, with domain
+    `u (A.domain)`.
+- `IsFormalAdjoint.unitaryConj` : Unitary conjugation preserves formal-adjoint pairs.
+- `HasDenseDomain.unitaryConj_dense_domain` : If `A` has dense domain, then so does `u A u⁻¹`.
+- `unitaryConj_sub_smul_surjective` : If `A - z` is surjective for a scalar `z : ℂ`,
+    then so is `u A u⁻¹ - z`.
 
 ## iii. Table of contents
 
@@ -72,6 +78,7 @@ Results
   - C.2. Self-adjoint operators
   - C.3. Essentially self-adjoint operators
   - C.4. Unbounded operators
+- D. Unitary conjugation
 
 ## iv. References
 
@@ -855,5 +862,74 @@ lemma isUnbounded_of_dense_of_isSymmetric' [CompleteSpace H]
     {E : Submodule ℂ H} (hE : Dense (E : Set H)) {f : E →ₗ[ℂ] E} (h : f.IsSymmetric) :
     (mk E (E.subtype ∘ₗ f)).IsUnbounded :=
   ⟨hE, IsSymmetric.isClosable h hE⟩
+
+/-!
+## D. Unitary conjugation
+-/
+
+section UnitaryConj
+
+variable (u : H ≃ₗᵢ[ℂ] H') (A : H →ₗ.[ℂ] H)
+
+/-- The conjugation `u A u⁻¹` of a partially-defined operator `A : H →ₗ.[ℂ] H` by a unitary
+`u : H ≃ₗᵢ[ℂ] H'`, with domain `u (A.domain) = u⁻¹ ⁻¹' (A.domain)` and action
+`y ↦ u (A (u⁻¹ y))`. Since `u` and `u⁻¹` are `ℂ`-linear, the result is again `ℂ`-linear. -/
+def unitaryConj : H' →ₗ.[ℂ] H' where
+  domain := A.domain.comap (u.symm.toLinearEquiv : H' →ₗ[ℂ] H)
+  toFun := u.toLinearEquiv.toLinearMap.comp <| A.toFun.comp
+    (((u.symm.toLinearEquiv : H' →ₗ[ℂ] H).comp
+      (A.domain.comap (u.symm.toLinearEquiv : H' →ₗ[ℂ] H)).subtype).codRestrict A.domain
+        fun x => x.2)
+
+/-- Membership in the conjugated domain: `x ∈ D(u A u⁻¹) ↔ u⁻¹ x ∈ D(A)`. -/
+lemma mem_unitaryConj_domain_iff {x : H'} :
+    x ∈ (unitaryConj u A).domain ↔ u.symm x ∈ A.domain := Iff.rfl
+
+/-- The defining formula `(u A u⁻¹) x = u (A (u⁻¹ x))`. -/
+lemma unitaryConj_apply (x : (unitaryConj u A).domain) :
+    unitaryConj u A x = u (A ⟨u.symm (x : H'), (mem_unitaryConj_domain_iff u A).mp x.2⟩) := rfl
+
+/-- `u` maps `D(A)` into `D(u A u⁻¹)`. -/
+lemma map_mem_unitaryConj_domain (y : A.domain) : u (y : H) ∈ (unitaryConj u A).domain := by
+  simpa only [mem_unitaryConj_domain_iff, u.symm_apply_apply] using y.2
+
+/-- The action on the image domain: `(u A u⁻¹)(u y) = u (A y)` for `y ∈ D(A)`. -/
+lemma unitaryConj_apply_map (y : A.domain) :
+    unitaryConj u A ⟨u (y : H), map_mem_unitaryConj_domain u A y⟩ = u (A y) := by
+  simp only [unitaryConj_apply, u.symm_apply_apply]
+
+variable {u A}
+
+open scoped InnerProductSpace in
+/-- Unitary conjugation preserves formal adjointness. If `A` is a formal adjoint of `B`, then
+`u A u⁻¹` is a formal adjoint of `u B u⁻¹`. Unitary conjugation preserves symmetry when `A = B`. -/
+lemma IsFormalAdjoint.unitaryConj {B : H →ₗ.[ℂ] H} (h : A.IsFormalAdjoint B) :
+    (unitaryConj u A).IsFormalAdjoint (unitaryConj u B) := by
+  intro x y
+  let x' : A.domain := ⟨u.symm (x : H'), (mem_unitaryConj_domain_iff u A).mp x.2⟩
+  let y' : B.domain := ⟨u.symm (y : H'), (mem_unitaryConj_domain_iff u B).mp y.2⟩
+  calc ⟪LinearPMap.unitaryConj u A x, (y : H')⟫_ℂ
+      = ⟪A x', (y' : H)⟫_ℂ := u.inner_map_eq_flip _ _
+    _ = ⟪(x' : H), B y'⟫_ℂ := h x' y'
+    _ = ⟪(x : H'), LinearPMap.unitaryConj u B y⟫_ℂ := u.symm.inner_map_eq_flip _ _
+
+/-- If `A` has dense domain, then so does `u A u⁻¹`: the domain `u⁻¹ ⁻¹' (A.domain)` is the
+preimage of a dense set under a homeomorphism. -/
+lemma HasDenseDomain.unitaryConj_dense_domain (hdense : A.HasDenseDomain) :
+    (unitaryConj u A).HasDenseDomain := hdense.preimage u.symm.toHomeomorph.isOpenMap
+
+/-- If `A - z` is surjective for a scalar `z : ℂ`, then so is `u A u⁻¹ - z`. -/
+lemma unitaryConj_sub_smul_surjective {z : ℂ} (h : Function.Surjective (A - z • 1).toFun) :
+    Function.Surjective (unitaryConj u A - z • 1).toFun := by
+  intro φ
+  obtain ⟨ξ, hξ⟩ := h (u.symm φ)
+  obtain ⟨w, hw⟩ : ∃ w : A.domain, A w - z • (w : H) = u.symm φ :=
+    ⟨⟨(ξ : H), (Submodule.mem_inf.mp ξ.2).1⟩, hξ⟩
+  refine ⟨⟨u (w : H), Submodule.mem_inf.mpr
+    ⟨map_mem_unitaryConj_domain u A w, Submodule.mem_top⟩⟩, ?_⟩
+  show unitaryConj u A ⟨u (w : H), map_mem_unitaryConj_domain u A w⟩ - z • (u (w : H)) = φ
+  rw [unitaryConj_apply_map, ← _root_.map_smul u, ← _root_.map_sub, hw, u.apply_symm_apply]
+
+end UnitaryConj
 
 end LinearPMap


### PR DESCRIPTION
Added section G to `Physlib/Mathematics/LinearPMap.lean`: the conjugation `U A U⁻¹` of a partial linear map `A : H →ₗ.[ℂ] H` by a unitary `U : H ≃ₗᵢ[ℂ] H'` (a `LinearIsometryEquiv`), with domain `U (A.domain)`, and the lemmas that transfer operator properties across it.

- `LinearPMap.unitaryConj` : the conjugated operator `U A U⁻¹`
- `LinearPMap.mem_unitaryConj_domain_iff` : `x ∈ D(U A U⁻¹) ↔ U⁻¹ x ∈ D(A)`
- `LinearPMap.unitaryConj_apply` : defining formula `(U A U⁻¹) x = U (A (U⁻¹ x))`
- `LinearPMap.map_mem_unitaryConj_domain` : `U` maps `D(A)` into `D(U A U⁻¹)`
- `LinearPMap.unitaryConj_apply_map` : `(U A U⁻¹)(U y) = U (A y)` for `y ∈ D(A)`
- `LinearPMap.IsFormalAdjoint.unitaryConj` : conjugation preserves formal-adjoint pairs; symmetry transfer is the case `A = B`
- `LinearPMap.unitaryConj_dense_domain` : dense domain transfers
- `LinearPMap.unitaryConj_sub_smul_surjective` : surjectivity of `A - z • 1` transfers