### PR TITLE
chore(QuantumInfo): clear 4 stale linter exemptions; add real ToC to LinearEquiv

### DIFF
--- a/QuantumInfo/ForMathlib/LinearEquiv.lean
+++ b/QuantumInfo/ForMathlib/LinearEquiv.lean
@@ -26,7 +26,8 @@ together with lemmas relating them to `Matrix.reindex`.
 
 ## iii. Table of contents
 
-This can be filled in later.
+- A. Relabelling linear equivalences
+- B. Reindexing matrices and their linear maps
 
 ## iv. References
 
@@ -35,6 +36,12 @@ This can be filled in later.
 @[expose] public section
 
 variable {d d₁ d₂ d₃ R 𝕜 : Type*} [RCLike 𝕜]
+
+/-!
+
+## A. Relabelling linear equivalences
+
+-/
 
 namespace LinearEquiv
 
@@ -70,6 +77,12 @@ theorem euclidean_of_relabel_refl : euclidean_of_relabel 𝕜 (.refl d) =
   rfl
 
 end LinearEquiv
+
+/-!
+
+## B. Reindexing matrices and their linear maps
+
+-/
 
 namespace Matrix
 

--- a/scripts/LinterExemption.txt
+++ b/scripts/LinterExemption.txt
@@ -30,7 +30,6 @@ QuantumInfo/ForMathlib/HayataGroup/TraceInequality/LiebAndoTrace.lean
 QuantumInfo/ForMathlib/HayataGroup/TraceInequality/LownerHeinzCore.lean
 QuantumInfo/ForMathlib/HayataGroup/TraceInequality/LownerHeinzTheorem.lean
 QuantumInfo/ForMathlib/HayataGroup/TraceInequality/OperatorGeometricMean.lean
-QuantumInfo/ForMathlib/HermitianMat.lean
 QuantumInfo/ForMathlib/HermitianMat/Basic.lean
 QuantumInfo/ForMathlib/HermitianMat/CFC.lean
 QuantumInfo/ForMathlib/HermitianMat/Inner.lean
@@ -56,8 +55,6 @@ QuantumInfo/ForMathlib/Minimax.lean
 QuantumInfo/ForMathlib/Misc.lean
 QuantumInfo/ForMathlib/SionMinimax.lean
 QuantumInfo/ForMathlib/Superadditive.lean
-QuantumInfo/ForMathlib/Tactic/Commutes.lean
-QuantumInfo/ForMathlib/Tactic/Commutes/Attribute.lean
 QuantumInfo/ForMathlib/Unitary.lean
 QuantumInfo/Measurements/POVM.lean
 QuantumInfo/Regularized.lean
@@ -70,7 +67,6 @@ QuantumInfo/States/Entanglement.lean
 QuantumInfo/States/Mixed/Fidelity.lean
 QuantumInfo/States/Mixed/MState.lean
 QuantumInfo/States/Mixed/TraceDistance.lean
-QuantumInfo/States/Pure/BargmannInvariant.lean
 QuantumInfo/States/Pure/BlochSphere.lean
 QuantumInfo/States/Pure/Braket.lean
 QuantumInfo/States/Pure/Qubit.lean


### PR DESCRIPTION
Following up on your review note in #1244 — starting small, as you suggested.

## What

**Four stale exemptions.** These four files already pass both `lake exe runPhyslibLinters` and
`scripts/lint-style.py` **with no changes at all** — the exemption entries are simply obsolete.
No source file is touched for them; that part of the diff is four deleted lines.

- `QuantumInfo/ForMathlib/HermitianMat.lean`
- `QuantumInfo/ForMathlib/Tactic/Commutes.lean`
- `QuantumInfo/ForMathlib/Tactic/Commutes/Attribute.lean`
- `QuantumInfo/States/Pure/BargmannInvariant.lean`

**The ToC placeholder.** You asked us to stop emitting `This can be filled in later` for the
table of contents. `ForMathlib/LinearEquiv.lean` is the only file in `QuantumInfo/` still
carrying it, and it got there via my #1224 — so this PR replaces it with a real ToC and the
matching section markers, following the house style in `Capacity/Capacity.lean`. The generator
is fixed going forward.

## Verification

- `scripts/lint-style.py`: clean on all five touched files.
- `lake build QuantumInfo.ForMathlib.LinearEquiv` on v4.31.0: builds.
- Total diff: 2 files, +14/-5.

## On #1244

Point taken that a ~56-file PR is not reviewable in a reasonable window, and that ~50 individual
PRs isn't the answer either. I'll close it. The branch does contain finished, CI-green linter
fixes for ~50 files that are still exempted, so if it's useful to your `auto-task` tooling as a
source to pull from at your own pace, it's there — otherwise ignore it.

One honest caveat if anyone ever cherry-picks from that branch: it drops `@[simp]` from four
lemmas. Two of those are correct (`Prob.zero_le` and `CPTPMap.IsTracePreserving` are
simp-provable, so the tag is redundant), but **two are wrong** — `HermitianMat.ker_one` and
`HermitianMat.support_one` are proved by `simp [ker]` / `simp [support]`, i.e. plain `simp`
cannot re-derive them, so they should keep their `@[simp]`. Not carried into this PR.

Happy to send more in batches like this one if it's useful.