### PR TITLE
feat(QuantumMechanics): add `QuantumSystem`

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -315,6 +315,7 @@ public import Physlib.QuantumMechanics.Operators.StateObservables.Variance
 public import Physlib.QuantumMechanics.Operators.Unbounded
 public import Physlib.QuantumMechanics.Operators.Uncertainty
 public import Physlib.QuantumMechanics.PlanckConstant
+public import Physlib.QuantumMechanics.QuantumSystem.Basic
 public import Physlib.QuantumMechanics.ReflectionlessPotential.Basic
 public import Physlib.QuantumMechanics.SpaceDQuantumSystem
 public import Physlib.Relativity.Bispinors.Basic

--- a/Physlib/QuantumMechanics/QuantumSystem/API-map.yaml
+++ b/Physlib/QuantumMechanics/QuantumSystem/API-map.yaml
@@ -16,37 +16,51 @@ References:
 Requirements:
 
   - description:
-      The key data structure `QuantumSystem` (containing fields for a Hilbert space
-      and self-adjoint Hamiltonian operator) is defined.
+      Defines the key data structure `QuantumSystem` containing fields for a Hilbert space
+      and self-adjoint Hamiltonian operator.
     done: true
     location: Physlib/QuantumMechanics/QuantumSystem/Basic.lean (QuantumSystem)
 
   - description:
-      The API contains a zero instance representing the unique quantum system
+      Contains a zero instance representing the unique quantum system
       on the trivial (zero-dimensional) Hilbert space.
     done: true
     location: Physlib/QuantumMechanics/QuantumSystem/Basic.lean (Zero QuantumSystem)
 
   - description:
-      The API defines the notion of unitary equivalence as an equivalence relation on quantum
-      systems. Two quantum systems are unitary equivalent if there exists a unitary map between
+      Defines the notion of unitary equivalence as an equivalence relation on quantum systems.
+      Two quantum systems are unitary equivalent if there exists a unitary map between
       their Hilbert spaces which sends one Hamiltonian to the other under conjugation.
     done: true
     location:
       Physlib/QuantumMechanics/QuantumSystem/Basic.lean (UnitaryRelation, unitaryRelation_equiv)
 
   - description:
-      The API contains an instance of addition, where the 'sum' of two quantum systems
-      `Q₁` and `Q₂` is the quantum system on the product of their Hilbert spaces
-      and with Hamiltonian `Q₁.ℋ + Q₂.ℋ` (schematically).
+      Contains an instance of addition, where the 'sum' of two quantum systems `Q₁` and `Q₂`
+      is the quantum system on the product of their Hilbert spaces and with Hamiltonian
+      `Q₁.ℋ + Q₂.ℋ` (schematically).
     done: false
     location: N/A
 
   - description:
-      The API defines the Schrödinger equation for wavefunctions of type `Time → Q.ℋ.domain`.
+      Defines the Schrödinger equation for wavefunctions of type `Time → Q.ℋ.domain`.
     done: false
     location: N/A
 
-  - description: The API defines the time evolution operator of type `Time → Q.HS →L[ℂ] Q.HS`.
+  - description: Defines the time evolution operator of type `Time → Q.HS →L[ℂ] Q.HS`.
+    done: false
+    location: N/A
+
+  - description: Defines the energy eigenspaces, eigenvectors and eigenvalues.
+    done: false
+    location: N/A
+
+  - description: Defines energy eigenbases.
+    done: false
+    location: N/A
+
+  - description:
+      Allows one to transform an operator in/out of the Heisenberg picture
+      by conjugating by the time evolution operator.
     done: false
     location: N/A

--- a/Physlib/QuantumMechanics/QuantumSystem/API-map.yaml
+++ b/Physlib/QuantumMechanics/QuantumSystem/API-map.yaml
@@ -1,0 +1,52 @@
+version: v0.1
+
+Title: QuantumSystem
+
+Overview: |
+    A quantum system in non-relativistic quantum mechanics is characterized by a choice of complex
+    Hilbert space and self-adjoint Hamiltonian operator on that space. The key data structure
+    `QuantumSystem` contains the field `HS` (satisfying `NormedAddCommGroup HS`,
+    `InnerProductSpace ℂ HS` and `CompleteSpace HS`) for the Hilbert space, as well as the fields
+    `ℋ : HS →ₗ.[ℂ] HS` and `ℋ_self_adjoint : IsSelfAdjoint ℋ` for the self-adjoint Hamiltonian.
+
+ParentAPIs:
+
+References:
+
+Requirements:
+
+  - description:
+      The key data structure `QuantumSystem` (containing fields for a Hilbert space
+      and self-adjoint Hamiltonian operator) is defined.
+    done: true
+    location: Physlib/QuantumMechanics/QuantumSystem/Basic.lean (QuantumSystem)
+
+  - description:
+      The API contains a zero instance representing the unique quantum system
+      on the trivial (zero-dimensional) Hilbert space.
+    done: true
+    location: Physlib/QuantumMechanics/QuantumSystem/Basic.lean (Zero QuantumSystem)
+
+  - description:
+      The API defines the notion of unitary equivalence as an equivalence relation on quantum
+      systems. Two quantum systems are unitary equivalent if there exists a unitary map between
+      their Hilbert spaces which sends one Hamiltonian to the other under conjugation.
+    done: true
+    location:
+      Physlib/QuantumMechanics/QuantumSystem/Basic.lean (UnitaryRelation, unitaryRelation_equiv)
+
+  - description:
+      The API contains an instance of addition, where the 'sum' of two quantum systems
+      `Q₁` and `Q₂` is the quantum system on the product of their Hilbert spaces
+      and with Hamiltonian `Q₁.ℋ + Q₂.ℋ` (schematically).
+    done: false
+    location: N/A
+
+  - description:
+      The API defines the Schrödinger equation for wavefunctions of type `Time → Q.ℋ.domain`.
+    done: false
+    location: N/A
+
+  - description: The API defines the time evolution operator of type `Time → Q.HS →L[ℂ] Q.HS`.
+    done: false
+    location: N/A

--- a/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
+++ b/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2026 Gregory J. Loges. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gregory J. Loges
+-/
+module
+
+public import Physlib.QuantumMechanics.Operators.Unbounded
+/-!
+
+# Quantum systems
+
+## i. Overview
+
+## ii. Key results
+
+## iii. Table of contents
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+noncomputable section
+
+namespace QuantumMechanics
+
+open LinearPMap
+
+/-- A quantum system is identified by its Hilbert space and self-adjoint Hamiltonian operator. -/
+structure QuantumSystem where
+  /-- The complex Hilbert space. -/
+  HS : Type*
+  [instNormed : NormedAddCommGroup HS]
+  [instInner : InnerProductSpace ℂ HS]
+  [instComplete : CompleteSpace HS]
+  /-- The self-adjoint Hamiltonian operator. -/
+  ℋ : HS →ₗ.[ℂ] HS
+  ℋ_self_adjoint : IsSelfAdjoint ℋ
+
+end QuantumMechanics
+end

--- a/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
+++ b/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
@@ -39,5 +39,20 @@ structure QuantumSystem where
   ℋ : HS →ₗ.[ℂ] HS
   ℋ_self_adjoint : IsSelfAdjoint ℋ
 
+namespace QuantumSystem
+
+instance (Q : QuantumSystem) : NormedAddCommGroup Q.HS := Q.instNormed
+
+instance (Q : QuantumSystem) : InnerProductSpace ℂ Q.HS := Q.instInner
+
+instance (Q : QuantumSystem) : CompleteSpace Q.HS := Q.instComplete
+
+/-!
+## Zero
+-/
+
+instance instZero : Zero QuantumSystem := ⟨EuclideanSpace ℂ (Fin 0), 0, adjoint_zero⟩
+
+end QuantumSystem
 end QuantumMechanics
 end

--- a/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
+++ b/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
@@ -53,6 +53,45 @@ instance (Q : QuantumSystem) : CompleteSpace Q.HS := Q.instComplete
 
 instance instZero : Zero QuantumSystem := ⟨EuclideanSpace ℂ (Fin 0), 0, adjoint_zero⟩
 
+/-!
+## Unitary equivalence
+-/
+
+/-- The relation on quantum systems where `Q₁` is related to `Q₂` if there exists a linear isometry
+  equivalence `e : Q₁.HS ≃ₗᵢ[ℂ] Q₂.HS` between the respective Hilbert spaces satisfying
+  `e ∘ Q₁.ℋ ∘ e.symm = Q₂.ℋ`. -/
+def UnitaryRelation (Q₁ Q₂ : QuantumSystem) : Prop :=
+  ∃ (e : Q₁.HS ≃ₗᵢ[ℂ] Q₂.HS) (h : Q₁.ℋ.domain.map e.toLinearMap = Q₂.ℋ.domain),
+    ∀ ψ : Q₁.ℋ.domain, e (Q₁.ℋ ψ) = Q₂.ℋ ⟨e ψ, by simp [← h]⟩
+
+/-- The relation `UnitaryRelation` is reflexive. -/
+lemma unitaryRelation_refl (Q : QuantumSystem) : UnitaryRelation Q Q :=
+  ⟨LinearIsometryEquiv.refl _ _, by ext; simp [LinearIsometryEquiv.refl], by simp⟩
+
+/-- The relation `UnitaryRelation` is symmetric. -/
+lemma unitaryRelation_symm {Q₁ Q₂ : QuantumSystem} (h₁₂ : UnitaryRelation Q₁ Q₂) :
+    UnitaryRelation Q₂ Q₁ := by
+  obtain ⟨e, h_domain, h⟩ := h₁₂
+  refine ⟨e.symm, by ext; simp [← h_domain], fun ψ₂ ↦ ?_⟩
+  apply e.symm_apply_eq.mpr
+  simp [h ⟨e.symm ψ₂, by simpa [← h_domain] using ψ₂.2⟩]
+
+/-- The relation `UnitaryRelation` is transitive. -/
+lemma unitaryRelation_trans {Q₁ Q₂ Q₃ : QuantumSystem} (h₁₂ : UnitaryRelation Q₁ Q₂)
+    (h₂₃ : UnitaryRelation Q₂ Q₃) : UnitaryRelation Q₁ Q₃ := by
+  obtain ⟨e₁₂, h_domain₁₂, _⟩ := h₁₂
+  obtain ⟨e₂₃, h_domain₂₃, _⟩ := h₂₃
+  exact ⟨e₁₂.trans e₂₃, by ext; simp [← h_domain₁₂, ← h_domain₂₃], by simp_all⟩
+
+/-- The relation `UnitaryRelation` is an equivalence relation. -/
+lemma unitaryRelation_equiv : Equivalence UnitaryRelation where
+  refl := unitaryRelation_refl
+  symm := unitaryRelation_symm
+  trans := unitaryRelation_trans
+
+/-- The setoid of quantum systems with `UnitaryRelation` for equivalence relation. -/
+instance QuantumSystemSetoid : Setoid QuantumSystem := ⟨UnitaryRelation, unitaryRelation_equiv⟩
+
 end QuantumSystem
 end QuantumMechanics
 end

--- a/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
+++ b/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
@@ -8,13 +8,31 @@ module
 public import Physlib.QuantumMechanics.Operators.Unbounded
 /-!
 
-# Quantum systems
+# Quantum system
 
 ## i. Overview
 
+In non-relativistic quantum mechanics a quantum system is characterized by a Hilbert space
+(complete inner product space) and self-adjoint Hamiltonian operator; these data are collected in
+the `QuantumSystem` structure.
+
+Two quantum systems are said to be "unitary equivalent" if there is a unitary bijection between
+their respective Hilbert spaces which sends one Hamiltonian to the other under conjugation.
+Unitary equivalent quantum systems are physically indestinguishable, as all operators, states,
+matrix elements, probabilities, eigenvalues, etc. are in 1-1 correspondence.
+
 ## ii. Key results
 
+Definitions
+- `QuantumSystem` : Structure bundling together a choice of Hilbert space
+    and self-adjoint Hamiltonian operator.
+- `UnitaryRelation` : The unitary equivalence relation.
+
 ## iii. Table of contents
+
+- A. Definition
+- B. Zero
+- C. Unitary equivalence
 
 ## iv. References
 
@@ -27,6 +45,10 @@ noncomputable section
 namespace QuantumMechanics
 
 open LinearPMap
+
+/-!
+## A. Definition
+-/
 
 /-- A quantum system is identified by its Hilbert space and self-adjoint Hamiltonian operator. -/
 structure QuantumSystem where
@@ -48,13 +70,13 @@ instance (Q : QuantumSystem) : InnerProductSpace ℂ Q.HS := Q.instInner
 instance (Q : QuantumSystem) : CompleteSpace Q.HS := Q.instComplete
 
 /-!
-## Zero
+## B. Zero
 -/
 
 instance instZero : Zero QuantumSystem := ⟨EuclideanSpace ℂ (Fin 0), 0, adjoint_zero⟩
 
 /-!
-## Unitary equivalence
+## C. Unitary equivalence
 -/
 
 /-- The relation on quantum systems where `Q₁` is related to `Q₂` if there exists a linear isometry

--- a/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
+++ b/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
@@ -54,8 +54,11 @@ open LinearPMap
 structure QuantumSystem where
   /-- The complex Hilbert space. -/
   HS : Type*
+  /-- The Hilbert space is a normed, commutative group. -/
   [instNormed : NormedAddCommGroup HS]
+  /-- The Hilbert space is a complex inner product space. -/
   [instInner : InnerProductSpace ℂ HS]
+  /-- The Hilbert space is complete. -/
   [instComplete : CompleteSpace HS]
   /-- The self-adjoint Hamiltonian operator. -/
   ℋ : HS →ₗ.[ℂ] HS


### PR DESCRIPTION
Lays the groundwork for general quantum systems.
- Defines a structure `QuantumSystem` which represents a generic non-relativistic quantum mechanical system, comprised of a Hilbert space and self-adjoint Hamiltonian operator.
- Defines the unitary equivalence relation for `QuantumSystem`.
- Begins an API map.