### PR TITLE
feat(QuantumMechanics): the Fourier transform on SpaceDHilbertSpace

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -289,6 +289,7 @@ public import Physlib.QuantumMechanics.HilbertSpaces.OneDimension.PlaneWaves
 public import Physlib.QuantumMechanics.HilbertSpaces.OneDimension.PositionStates
 public import Physlib.QuantumMechanics.HilbertSpaces.OneDimension.SchwartzSubmodule
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Basic
+public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Fourier
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.PolyBddSchwartzSubmodule
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
 public import Physlib.QuantumMechanics.Hydrogen.Basic

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Fourier.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Fourier.lean
@@ -24,7 +24,7 @@ equivalence of `Lp ℂ 2 volume`, hence of `SpaceDHilbertSpace d`, onto itself; 
   `SpaceDHilbertSpace d ≃ₗᵢ[ℂ] SpaceDHilbertSpace d`, acting as `𝓕`/`𝓕⁻`
   (`fourierUnitary_apply`, `fourierUnitary_symm_apply`).
 - `schwartzIncl_fourier_eq` : `𝓕 (schwartzIncl f) = schwartzIncl (𝓕 f)`.
-- `fourierUnitary_symm_schwartzIncl` : the inverse acts by the inverse Schwartz Fourier transform.
+- `schwartzIncl_fourierInv_eq` : the inverse acts by the inverse Schwartz Fourier transform.
 - `fourierUnitary_map_schwartzSubmodule` : `fourierUnitary d` maps the Schwartz submodule onto
   itself.
 
@@ -54,17 +54,6 @@ variable {d : ℕ}
 noncomputable def fourierUnitary (d : ℕ) :
     SpaceDHilbertSpace d ≃ₗᵢ[ℂ] SpaceDHilbertSpace d := Lp.fourierTransformₗᵢ (Space d) ℂ
 
-noncomputable instance : FourierTransform (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) where
-  fourier := fourierUnitary d
-
-noncomputable instance : FourierTransformInv (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) where
-  fourierInv := (fourierUnitary d).symm
-
-instance : FourierPair (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) where
-  fourierInv_fourier_eq := (fourierUnitary d).symm_apply_apply
-
-instance : FourierInvPair (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) where
-  fourier_fourierInv_eq := (fourierUnitary d).apply_symm_apply
 
 /-- `fourierUnitary d` acts as the L² Fourier transform `𝓕`. -/
 @[simp]
@@ -81,10 +70,10 @@ Schwartz Fourier transform `𝓕 f`. -/
 lemma schwartzIncl_fourier_eq (f : 𝓢(Space d, ℂ)) :
     𝓕 (schwartzIncl volume f) = schwartzIncl volume (𝓕 f) := SchwartzMap.toLp_fourier_eq f
 
-/-- Applying `(fourierUnitary d).symm` to the L² class of a Schwartz map `f` gives the L² class
-of the inverse Schwartz Fourier transform `𝓕⁻ f`. -/
-lemma fourierUnitary_symm_schwartzIncl (f : 𝓢(Space d, ℂ)) :
-    (fourierUnitary d).symm (schwartzIncl volume f) = schwartzIncl volume (𝓕⁻ f) :=
+/-- Applying `𝓕⁻` to the L² class of a Schwartz map `f` gives the L² class of the inverse
+Schwartz Fourier transform `𝓕⁻ f`. -/
+lemma schwartzIncl_fourierInv_eq (f : 𝓢(Space d, ℂ)) :
+    𝓕⁻ (schwartzIncl volume f) = schwartzIncl volume (𝓕⁻ f) :=
   SchwartzMap.toLp_fourierInv_eq f
 
 /-- Pulling the L² class of `𝓕 f` back through the Fourier unitary recovers the L² class of `f`. -/
@@ -100,7 +89,7 @@ lemma fourierUnitary_map_schwartzSubmodule :
   · rintro x ⟨y, ⟨f, rfl⟩, rfl⟩
     exact ⟨𝓕 f, (schwartzIncl_fourier_eq f).symm⟩
   · rintro x ⟨g, rfl⟩
-    exact ⟨𝓕⁻ (schwartzIncl volume g), ⟨𝓕⁻ g, (fourierUnitary_symm_schwartzIncl g).symm⟩, by simp⟩
+    exact ⟨𝓕⁻ (schwartzIncl volume g), ⟨𝓕⁻ g, (schwartzIncl_fourierInv_eq g).symm⟩, by simp⟩
 
 end SpaceDHilbertSpace
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Fourier.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Fourier.lean
@@ -23,7 +23,7 @@ equivalence of `Lp ℂ 2 volume`, hence of `SpaceDHilbertSpace d`, onto itself; 
 - `fourierUnitary d` : the L² Fourier transform as a unitary
   `SpaceDHilbertSpace d ≃ₗᵢ[ℂ] SpaceDHilbertSpace d`, acting as `𝓕`/`𝓕⁻`
   (`fourierUnitary_apply`, `fourierUnitary_symm_apply`).
-- `fourierUnitary_schwartzIncl` : `fourierUnitary d (schwartzIncl f) = schwartzIncl (𝓕 f)`.
+- `schwartzIncl_fourier_eq` : `𝓕 (schwartzIncl f) = schwartzIncl (𝓕 f)`.
 - `fourierUnitary_symm_schwartzIncl` : the inverse acts by the inverse Schwartz Fourier transform.
 - `fourierUnitary_map_schwartzSubmodule` : `fourierUnitary d` maps the Schwartz submodule onto
   itself.
@@ -54,40 +54,53 @@ variable {d : ℕ}
 noncomputable def fourierUnitary (d : ℕ) :
     SpaceDHilbertSpace d ≃ₗᵢ[ℂ] SpaceDHilbertSpace d := Lp.fourierTransformₗᵢ (Space d) ℂ
 
+noncomputable instance : FourierTransform (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) where
+  fourier := fourierUnitary d
+
+noncomputable instance : FourierTransformInv (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) where
+  fourierInv := (fourierUnitary d).symm
+
+instance : FourierPair (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) where
+  fourierInv_fourier_eq := (fourierUnitary d).symm_apply_apply
+
+instance : FourierInvPair (SpaceDHilbertSpace d) (SpaceDHilbertSpace d) where
+  fourier_fourierInv_eq := (fourierUnitary d).apply_symm_apply
+
 /-- `fourierUnitary d` acts as the L² Fourier transform `𝓕`. -/
+@[simp]
 lemma fourierUnitary_apply (ψ : SpaceDHilbertSpace d) : fourierUnitary d ψ = 𝓕 ψ := rfl
 
 /-- `(fourierUnitary d).symm` acts as the inverse L² Fourier transform `𝓕⁻`. -/
+@[simp]
 lemma fourierUnitary_symm_apply (ψ : SpaceDHilbertSpace d) : (fourierUnitary d).symm ψ = 𝓕⁻ ψ := rfl
 
 /-! ## B. Action on the Schwartz submodule -/
 
 /-- Applying `fourierUnitary d` to the L² class of a Schwartz map `f` gives the L² class of the
 Schwartz Fourier transform `𝓕 f`. -/
-lemma fourierUnitary_schwartzIncl (f : 𝓢(Space d, ℂ)) :
-    fourierUnitary d (schwartzIncl f) = schwartzIncl (𝓕 f) := SchwartzMap.toLp_fourier_eq f
+lemma schwartzIncl_fourier_eq (f : 𝓢(Space d, ℂ)) :
+    𝓕 (schwartzIncl f) = schwartzIncl (𝓕 f) := SchwartzMap.toLp_fourier_eq f
 
 /-- Applying `(fourierUnitary d).symm` to the L² class of a Schwartz map `f` gives the L² class
 of the inverse Schwartz Fourier transform `𝓕⁻ f`. -/
 lemma fourierUnitary_symm_schwartzIncl (f : 𝓢(Space d, ℂ)) :
     (fourierUnitary d).symm (schwartzIncl f) = schwartzIncl (𝓕⁻ f) :=
-SchwartzMap.toLp_fourierInv_eq f
+  SchwartzMap.toLp_fourierInv_eq f
 
 /-- Pulling the L² class of `𝓕 f` back through the Fourier unitary recovers the L² class of `f`. -/
-lemma fourierUnitary_symm_schwartzIncl_fourier (f : 𝓢(Space d, ℂ)) :
-    (fourierUnitary d).symm (schwartzIncl (𝓕 f)) = schwartzIncl f := by
-  rw [← fourierUnitary_schwartzIncl, LinearIsometryEquiv.symm_apply_apply]
+@[simp]
+lemma fourierInv_schwartzIncl_fourier (f : 𝓢(Space d, ℂ)) :
+    𝓕⁻ (schwartzIncl (𝓕 f)) = schwartzIncl f := by
+  rw [← schwartzIncl_fourier_eq, FourierPair.fourierInv_fourier_eq]
 
 /-- The Fourier unitary maps the Schwartz submodule onto itself. -/
 lemma fourierUnitary_map_schwartzSubmodule :
-    (SchwartzSubmodule d).map (fourierUnitary d).toLinearEquiv.toLinearMap
- = SchwartzSubmodule d := by
+    (SchwartzSubmodule d).map (fourierUnitary d).toLinearMap = SchwartzSubmodule d := by
   apply le_antisymm
   · rintro x ⟨y, ⟨f, rfl⟩, rfl⟩
-    exact ⟨𝓕 f, (fourierUnitary_schwartzIncl f).symm⟩
+    exact ⟨𝓕 f, (schwartzIncl_fourier_eq f).symm⟩
   · rintro x ⟨g, rfl⟩
-    exact ⟨(fourierUnitary d).symm (schwartzIncl g),
-      ⟨𝓕⁻ g, (fourierUnitary_symm_schwartzIncl g).symm⟩, (fourierUnitary d).apply_symm_apply _⟩
+    exact ⟨𝓕⁻ (schwartzIncl g), ⟨𝓕⁻ g, (fourierUnitary_symm_schwartzIncl g).symm⟩, by simp⟩
 
 end SpaceDHilbertSpace
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Fourier.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Fourier.lean
@@ -79,18 +79,18 @@ lemma fourierUnitary_symm_apply (ψ : SpaceDHilbertSpace d) : (fourierUnitary d)
 /-- Applying `fourierUnitary d` to the L² class of a Schwartz map `f` gives the L² class of the
 Schwartz Fourier transform `𝓕 f`. -/
 lemma schwartzIncl_fourier_eq (f : 𝓢(Space d, ℂ)) :
-    𝓕 (schwartzIncl f) = schwartzIncl (𝓕 f) := SchwartzMap.toLp_fourier_eq f
+    𝓕 (schwartzIncl volume f) = schwartzIncl volume (𝓕 f) := SchwartzMap.toLp_fourier_eq f
 
 /-- Applying `(fourierUnitary d).symm` to the L² class of a Schwartz map `f` gives the L² class
 of the inverse Schwartz Fourier transform `𝓕⁻ f`. -/
 lemma fourierUnitary_symm_schwartzIncl (f : 𝓢(Space d, ℂ)) :
-    (fourierUnitary d).symm (schwartzIncl f) = schwartzIncl (𝓕⁻ f) :=
+    (fourierUnitary d).symm (schwartzIncl volume f) = schwartzIncl volume (𝓕⁻ f) :=
   SchwartzMap.toLp_fourierInv_eq f
 
 /-- Pulling the L² class of `𝓕 f` back through the Fourier unitary recovers the L² class of `f`. -/
 @[simp]
 lemma fourierInv_schwartzIncl_fourier (f : 𝓢(Space d, ℂ)) :
-    𝓕⁻ (schwartzIncl (𝓕 f)) = schwartzIncl f := by
+    𝓕⁻ (schwartzIncl volume (𝓕 f)) = schwartzIncl volume f := by
   rw [← schwartzIncl_fourier_eq, FourierPair.fourierInv_fourier_eq]
 
 /-- The Fourier unitary maps the Schwartz submodule onto itself. -/
@@ -100,7 +100,7 @@ lemma fourierUnitary_map_schwartzSubmodule :
   · rintro x ⟨y, ⟨f, rfl⟩, rfl⟩
     exact ⟨𝓕 f, (schwartzIncl_fourier_eq f).symm⟩
   · rintro x ⟨g, rfl⟩
-    exact ⟨𝓕⁻ (schwartzIncl g), ⟨𝓕⁻ g, (fourierUnitary_symm_schwartzIncl g).symm⟩, by simp⟩
+    exact ⟨𝓕⁻ (schwartzIncl volume g), ⟨𝓕⁻ g, (fourierUnitary_symm_schwartzIncl g).symm⟩, by simp⟩
 
 end SpaceDHilbertSpace
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Fourier.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Fourier.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 Adam Bornemann. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Bornemann
+-/
+module
+
+public import Mathlib.Analysis.Fourier.LpSpace
+public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
+/-!
+
+# The Fourier transform on `SpaceDHilbertSpace`
+
+## i. Overview
+
+In this module we define the Fourier transform on `SpaceDHilbertSpace d` as a unitary operator.
+Mathlib's L² Fourier transform `MeasureTheory.Lp.fourierTransformₗᵢ` is a linear isometry
+equivalence of `Lp ℂ 2 volume`, hence of `SpaceDHilbertSpace d`, onto itself; packaged as
+`fourierUnitary d`.
+
+## ii. Key results
+
+- `fourierUnitary d` : the L² Fourier transform as a unitary
+  `SpaceDHilbertSpace d ≃ₗᵢ[ℂ] SpaceDHilbertSpace d`, acting as `𝓕`/`𝓕⁻`
+  (`fourierUnitary_apply`, `fourierUnitary_symm_apply`).
+- `fourierUnitary_schwartzIncl` : `fourierUnitary d (schwartzIncl f) = schwartzIncl (𝓕 f)`.
+- `fourierUnitary_symm_schwartzIncl` : the inverse acts by the inverse Schwartz Fourier transform.
+- `fourierUnitary_map_schwartzSubmodule` : `fourierUnitary d` maps the Schwartz submodule onto
+  itself.
+
+## iii. Table of contents
+
+- A. The Fourier unitary
+- B. Action on the Schwartz submodule
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+namespace QuantumMechanics
+namespace SpaceDHilbertSpace
+
+open MeasureTheory
+open SchwartzMap
+open scoped FourierTransform
+
+variable {d : ℕ}
+
+/-! ## A. The Fourier unitary -/
+
+/-- The L² Fourier transform as a unitary on `SpaceDHilbertSpace d`. -/
+noncomputable def fourierUnitary (d : ℕ) :
+    SpaceDHilbertSpace d ≃ₗᵢ[ℂ] SpaceDHilbertSpace d := Lp.fourierTransformₗᵢ (Space d) ℂ
+
+/-- `fourierUnitary d` acts as the L² Fourier transform `𝓕`. -/
+lemma fourierUnitary_apply (ψ : SpaceDHilbertSpace d) : fourierUnitary d ψ = 𝓕 ψ := rfl
+
+/-- `(fourierUnitary d).symm` acts as the inverse L² Fourier transform `𝓕⁻`. -/
+lemma fourierUnitary_symm_apply (ψ : SpaceDHilbertSpace d) : (fourierUnitary d).symm ψ = 𝓕⁻ ψ := rfl
+
+/-! ## B. Action on the Schwartz submodule -/
+
+/-- Applying `fourierUnitary d` to the L² class of a Schwartz map `f` gives the L² class of the
+Schwartz Fourier transform `𝓕 f`. -/
+lemma fourierUnitary_schwartzIncl (f : 𝓢(Space d, ℂ)) :
+    fourierUnitary d (schwartzIncl f) = schwartzIncl (𝓕 f) := SchwartzMap.toLp_fourier_eq f
+
+/-- Applying `(fourierUnitary d).symm` to the L² class of a Schwartz map `f` gives the L² class
+of the inverse Schwartz Fourier transform `𝓕⁻ f`. -/
+lemma fourierUnitary_symm_schwartzIncl (f : 𝓢(Space d, ℂ)) :
+    (fourierUnitary d).symm (schwartzIncl f) = schwartzIncl (𝓕⁻ f) :=
+SchwartzMap.toLp_fourierInv_eq f
+
+/-- Pulling the L² class of `𝓕 f` back through the Fourier unitary recovers the L² class of `f`. -/
+lemma fourierUnitary_symm_schwartzIncl_fourier (f : 𝓢(Space d, ℂ)) :
+    (fourierUnitary d).symm (schwartzIncl (𝓕 f)) = schwartzIncl f := by
+  rw [← fourierUnitary_schwartzIncl, LinearIsometryEquiv.symm_apply_apply]
+
+/-- The Fourier unitary maps the Schwartz submodule onto itself. -/
+lemma fourierUnitary_map_schwartzSubmodule :
+    (SchwartzSubmodule d).map (fourierUnitary d).toLinearEquiv.toLinearMap
+ = SchwartzSubmodule d := by
+  apply le_antisymm
+  · rintro x ⟨y, ⟨f, rfl⟩, rfl⟩
+    exact ⟨𝓕 f, (fourierUnitary_schwartzIncl f).symm⟩
+  · rintro x ⟨g, rfl⟩
+    exact ⟨(fourierUnitary d).symm (schwartzIncl g),
+      ⟨𝓕⁻ g, (fourierUnitary_symm_schwartzIncl g).symm⟩, (fourierUnitary d).apply_symm_apply _⟩
+
+end SpaceDHilbertSpace
+end QuantumMechanics


### PR DESCRIPTION
Add `Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Fourier`: mathlib's L² Fourier transform `Lp.fourierTransformₗᵢ`, packaged as a unitary `fourierUnitary d : SpaceDHilbertSpace d ≃ₗᵢ[ℂ] SpaceDHilbertSpace d`, with its interface:

- `fourierUnitary_apply` / `fourierUnitary_symm_apply` : the unitary and
  its inverse act as `𝓕` / `𝓕⁻` (both `rfl`);
- `fourierUnitary_schwartzIncl` / `fourierUnitary_symm_schwartzIncl` :
  on the L² class of a Schwartz map it agrees with the Schwartz-level
  Fourier transform, `fourierUnitary d (schwartzIncl f) = schwartzIncl (𝓕 f)`;
- `fourierUnitary_symm_schwartzIncl_fourier` : the round trip
  `(fourierUnitary d).symm (schwartzIncl (𝓕 f)) = schwartzIncl f`;
- `fourierUnitary_map_schwartzSubmodule` : the Schwartz submodule is
  mapped onto itself.

Infrastructure for defining momentum-type operators by unitary conjugation of multiplication operators through `(fourierUnitary d).symm` (maximal momentum operator, stacked in a follow-up).