### PR TITLE
feat(QuantumMechanics): generalize `SpaceDHilbertSpace` cont.

### DIFF
--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PolyBddSchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PolyBddSchwartzSubmodule.lean
@@ -14,14 +14,14 @@ public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
 
 ## i. Overview
 
-In this module we define polynomially-bounded Schwartz submodules of `SpaceDHilbertSpace`.
+In this module we define polynomially-bounded Schwartz submodules of `SpaceDHilbertSpace d μ`.
 
-For each `a : ℕ∞`, `PolyBddSchwartzSubmodule d a` is the submodule corresponding to Schwartz
+For each `a : ℕ∞`, `PolyBddSchwartzSubmodule d a μ` is the submodule corresponding to Schwartz
 maps `f` satisfying the polynomial growth bounds `‖x‖ ^ (-k) * ‖f x‖ ≤ Cₖ` for all `(k : ℕ) ≤ a`.
 In particular, for `a = ⊤` such a bound holds for all natural numbers.
 
 These serve as a natural domain for singular unbounded operators. For example, the `1/r` Coulomb
-potential operator maps `PolyBddSchwartzSubmodule d ⊤` to itself. In the same way that multiplying
+potential operator maps `PolyBddSchwartzSubmodule d ⊤ μ` to itself. In the same way that multiplying
 a Schwartz map by any polynomial in the coordinates results in a square-integrable function,
 polynomially-bounded Schwartz maps may be multiplied by Laurent polynomials and remain
 square-integrable (the precise condition depends on `d`, `a` and the negative degree of
@@ -36,9 +36,9 @@ their being dense in `SpaceDHilbertSpace 0 ≅ ℂ`).
 
 ## ii. Key results
 
-- `PolyBddSchwartzSubmodule d (a : ℕ∞)`: Restriction of `SchwartzSubmodule d` to those Schwartz maps
-  which are bounded by powers of `‖x‖`.
-- `PolyBddSchwartzSubmodule.dense d a`: These submodules are dense in `SpaceDHilbertSpace`.
+- `PolyBddSchwartzSubmodule d (a : ℕ∞) μ`: Restriction of `SchwartzSubmodule d μ` to those
+  Schwartz maps which are bounded by powers of `‖x‖`.
+- `PolyBddSchwartzSubmodule.dense`: These submodules are dense in `SpaceDHilbertSpace d μ`.
 
 ## iii. Table of contents
 
@@ -88,52 +88,58 @@ def PolyBddSchwartzMap (d : ℕ) (a : ℕ∞) : Submodule ℂ 𝓢(Space d, ℂ)
     exact le_trans (mul_le_mul_of_nonneg_left (hC x) (norm_nonneg c)) (by linarith)
 
 /-- The continuous linear map `schwartzIncl` with domain restricted to `PolyBddSchwartzMap d a`. -/
-def polyBddSchwartzIncl {d : ℕ} {a : ℕ∞} : PolyBddSchwartzMap d a →L[ℂ] SpaceDHilbertSpace d :=
-  ⟨schwartzIncl.domRestrict (PolyBddSchwartzMap d a),
-    schwartzIncl.continuous_domRestrict schwartzIncl.continuous _⟩
+def polyBddSchwartzIncl {d : ℕ} {a : ℕ∞} (μ : Measure (Space d)) [μ.HasTemperateGrowth] :
+    PolyBddSchwartzMap d a →L[ℂ] SpaceDHilbertSpace d μ :=
+  ⟨(schwartzIncl μ).domRestrict (PolyBddSchwartzMap d a),
+    (schwartzIncl μ).continuous_domRestrict (schwartzIncl μ).continuous _⟩
 
 /-- The submodule of `SpaceDHilbertSpace d` corresponding to bounded Schwartz maps. -/
-abbrev PolyBddSchwartzSubmodule (d : ℕ) (a : ℕ∞) : Submodule ℂ (SpaceDHilbertSpace d) :=
-  (polyBddSchwartzIncl (a := a)).range
+abbrev PolyBddSchwartzSubmodule
+    (d : ℕ) (a : ℕ∞) (μ : Measure (Space d) := volume) [μ.HasTemperateGrowth] :
+    Submodule ℂ (SpaceDHilbertSpace d μ) :=
+  (polyBddSchwartzIncl (a := a) μ).range
 
-lemma polyBddSchwartzIncl_injective (d : ℕ) (a : ℕ∞) :
-    Function.Injective (polyBddSchwartzIncl (d := d) (a := a)) :=
-  LinearMap.injective_domRestrict_iff.mpr <| schwartzIncl_ker.symm ▸ inf_bot_eq _
+lemma polyBddSchwartzIncl_injective
+    {d : ℕ} (a : ℕ∞) (μ : Measure (Space d)) [μ.HasTemperateGrowth] [μ.IsOpenPosMeasure] :
+    Function.Injective (polyBddSchwartzIncl (a := a) μ) :=
+  LinearMap.injective_domRestrict_iff.mpr <| (schwartzIncl_ker μ).symm ▸ inf_bot_eq _
 
 /-- The linear equivalence between polynomially-bounded Schwartz maps and the corresponding
   submodule of the Hilbert space. -/
-def polyBddSchwartzEquiv {d : ℕ} {a : ℕ∞} :
-    PolyBddSchwartzMap d a ≃ₗ[ℂ] PolyBddSchwartzSubmodule d a :=
-  LinearEquiv.ofInjective polyBddSchwartzIncl.toLinearMap (polyBddSchwartzIncl_injective d a)
+def polyBddSchwartzEquiv
+    {d : ℕ} {a : ℕ∞} (μ : Measure (Space d)) [μ.HasTemperateGrowth] [μ.IsOpenPosMeasure] :
+    PolyBddSchwartzMap d a ≃ₗ[ℂ] PolyBddSchwartzSubmodule d a μ :=
+  LinearEquiv.ofInjective (polyBddSchwartzIncl μ).toLinearMap (polyBddSchwartzIncl_injective a μ)
 
 namespace PolyBddSchwartzSubmodule
+
+variable {d : ℕ} {a : ℕ∞}
+variable (μ : Measure (Space d)) [μ.HasTemperateGrowth]
 
 /-!
 ## B. Coercions
 -/
 
-instance {d : ℕ} {a : ℕ∞} : CoeOut (PolyBddSchwartzMap d a) 𝓢(Space d, ℂ) := ⟨fun f ↦ f.val⟩
+instance : CoeOut (PolyBddSchwartzMap d a) 𝓢(Space d, ℂ) := ⟨fun f ↦ f.val⟩
 
-instance {d : ℕ} {a : ℕ∞} : CoeFun (PolyBddSchwartzMap d a) (fun _ ↦ Space d → ℂ) :=
-  ⟨fun f ↦ ⇑f.val⟩
+instance : CoeFun (PolyBddSchwartzMap d a) (fun _ ↦ Space d → ℂ) := ⟨fun f ↦ ⇑f.val⟩
 
 @[simp]
-lemma toFun_eq_coe {d : ℕ} {a : ℕ∞} (f : PolyBddSchwartzMap d a) (x : Space d) :
-    f.val.toFun x = f.val x :=
-  rfl
+lemma toFun_eq_coe (f : PolyBddSchwartzMap d a) (x : Space d) : f.val.toFun x = f.val x := rfl
 
-lemma polyBddSchwartzEquiv_symm_apply_coe {d : ℕ} {a : ℕ∞}
-    {ψ : SchwartzSubmodule d} (hψ : ↑ψ ∈ PolyBddSchwartzSubmodule d a) :
-    (polyBddSchwartzEquiv.symm ⟨ψ, hψ⟩).val = schwartzEquiv.symm ψ := by
-  apply schwartzEquiv.injective
+lemma polyBddSchwartzEquiv_symm_apply_coe [μ.IsOpenPosMeasure]
+    {ψ : SchwartzSubmodule d μ} (hψ : ↑ψ ∈ PolyBddSchwartzSubmodule d a μ) :
+    ((polyBddSchwartzEquiv μ).symm ⟨ψ, hψ⟩).val = (schwartzEquiv μ).symm ψ := by
+  apply (schwartzEquiv μ).injective
   apply SetLike.coe_eq_coe.mp
-  obtain ⟨g, hg⟩ := polyBddSchwartzEquiv.surjective ⟨ψ.val, hψ⟩
-  have hg' : polyBddSchwartzIncl g = ψ := SetLike.coe_eq_coe.mpr hg
+  obtain ⟨g, hg⟩ := (polyBddSchwartzEquiv μ).surjective ⟨ψ.val, hψ⟩
+  have hg' : polyBddSchwartzIncl μ g = ψ := SetLike.coe_eq_coe.mpr hg
   rw [← hg, LinearEquiv.symm_apply_apply, LinearEquiv.apply_symm_apply, ← hg']
   rfl
 
-lemma polyBddSchwartzEquiv_coe_ae {d : ℕ} {a : ℕ∞} (f : PolyBddSchwartzMap d a) :
-    polyBddSchwartzEquiv f =ᵐ[volume] f.val := schwartzEquiv_coe_ae f.val
+lemma polyBddSchwartzEquiv_coe_ae [μ.IsOpenPosMeasure] (f : PolyBddSchwartzMap d a) :
+    polyBddSchwartzEquiv μ f =ᵐ[μ] f.val :=
+  schwartzEquiv_coe_ae f.val
 
 /-!
 ### C. (In)equalities
@@ -147,14 +153,14 @@ lemma PolyBddSchwartzMap_zero_eq_top (d : ℕ) : PolyBddSchwartzMap d 0 = ⊤ :=
 lemma PolyBddSchwartzMap_antitone (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
     PolyBddSchwartzMap d b ≤ PolyBddSchwartzMap d a := fun _ hx k hk ↦ hx k (hk.trans h)
 
-lemma of_zero_eq (d : ℕ) : PolyBddSchwartzSubmodule d 0 = SchwartzSubmodule d := by
+lemma of_zero_eq : PolyBddSchwartzSubmodule d 0 μ = SchwartzSubmodule d μ := by
   simp [PolyBddSchwartzSubmodule, polyBddSchwartzIncl, PolyBddSchwartzMap_zero_eq_top]
 
 lemma le_SchwartzSubmodule (d : ℕ) (a : ℕ∞) : PolyBddSchwartzSubmodule d a ≤ SchwartzSubmodule d :=
   LinearMap.range_domRestrict_le_range _ _
 
-lemma antitone (d : ℕ) {a b : ℕ∞} (h : a ≤ b) :
-    PolyBddSchwartzSubmodule d b ≤ PolyBddSchwartzSubmodule d a := by
+lemma antitone {a b : ℕ∞} (h : a ≤ b) :
+    PolyBddSchwartzSubmodule d b μ ≤ PolyBddSchwartzSubmodule d a μ := by
   simp only [PolyBddSchwartzSubmodule, polyBddSchwartzIncl,
     ContinuousLinearMap.toLinearMap_domRestrict, LinearMap.range_domRestrict]
   exact Submodule.map_mono (PolyBddSchwartzMap_antitone d h)
@@ -175,8 +181,8 @@ private lemma enorm_bump_mul_le_enorm {𝕜 E : Type*} [RCLike 𝕜] [NormedAddC
   rw [norm_algebraMap', Real.norm_eq_abs, norm_one, ← abs_one]
   exact abs_le_abs_of_nonneg f.nonneg f.le_one
 
-private lemma dense_zero_top :
-    Dense (PolyBddSchwartzSubmodule 0 ⊤ : Set (SpaceDHilbertSpace 0)) := by
+private lemma dense_zero_top (μ : Measure (Space 0)) [μ.HasTemperateGrowth] [μ.IsOpenPosMeasure] :
+    Dense (PolyBddSchwartzSubmodule 0 ⊤ μ : Set (SpaceDHilbertSpace 0 μ)) := by
   suffices PolyBddSchwartzMap 0 ⊤ = ⊤ by
     simp [PolyBddSchwartzSubmodule, polyBddSchwartzIncl, this]
   refine Submodule.eq_top_iff'.mpr (fun f k hk ↦ ?_)
@@ -184,22 +190,25 @@ private lemma dense_zero_top :
   simp only [Space.point_dim_zero_eq, norm_zero, zpow_neg, zpow_natCast]
   rcases k with _ | k <;> simp [add_nonneg]
 
-lemma dense_top (d : ℕ) : Dense (PolyBddSchwartzSubmodule d ⊤ : Set (SpaceDHilbertSpace d)) := by
+TODO "Generalize density of PolyBddSchwartzSubmodule to more general measures than just μ ≤ volume."
+
+lemma dense_top (hμ : μ ≤ volume) [μ.IsOpenPosMeasure] [IsFiniteMeasureOnCompacts μ] :
+    Dense (PolyBddSchwartzSubmodule d ⊤ μ : Set (SpaceDHilbertSpace d μ)) := by
   rcases eq_zero_or_pos d with (rfl | hd)
-  · -- `d = 0`: Every function `Space 0 ≅ {0} → ℂ` is in `PolyBddSchwartzSubmodule 0 ⊤`.
-    exact dense_zero_top
-  · -- `d > 0`: Construct a sequence in `PolyBddSchwartzSubmodule d ⊤` which tends to `ξ`
+  · -- `d = 0`: Every function `Space 0 ≅ {0} → ℂ` is in `PolyBddSchwartzSubmodule 0 ⊤ μ`.
+    exact dense_zero_top _
+  · -- `d > 0`: Construct a sequence in `PolyBddSchwartzSubmodule d ⊤ μ` which tends to `ξ`
     intro ξ
     apply mem_closure_iff_seq_limit.mpr
     -- `ψₙ = [fₙ]` is a sequence in `SchwartzSubmodule` which tends to `ξ`
-    obtain ⟨ψ, hψ, hψξ⟩ := mem_closure_iff_seq_limit.mp (SchwartzSubmodule.dense d ξ)
-    let f (n : ℕ) : 𝓢(Space d, ℂ) := schwartzEquiv.symm ⟨ψ n, hψ n⟩
+    obtain ⟨ψ, hψ, hψξ⟩ := mem_closure_iff_seq_limit.mp (SchwartzSubmodule.dense d μ ξ)
+    let f (n : ℕ) : 𝓢(Space d, ℂ) := (schwartzEquiv μ).symm ⟨ψ n, hψ n⟩
     -- `bₙ` is a sequence of bump functions with shrinking domain
     let b (n : ℕ) : ContDiffBump (0 : Space d) :=
       ⟨(n + 1)⁻¹, 2 * (n + 1 : ℝ)⁻¹, by positivity, lt_two_mul_self Nat.inv_pos_of_nat⟩
     -- `φₙ = [bₙfₙ]` is a sequence in `SchwartzSubmodule` which tends to `0`
     let g (n : ℕ) : 𝓢(Space d, ℂ) := smulLeftCLM ℂ (b n) (f n)
-    let φ (n : ℕ) : SpaceDHilbertSpace d := schwartzIncl (g n)
+    let φ (n : ℕ) : SpaceDHilbertSpace d μ := schwartzIncl μ (g n)
     have hg (n : ℕ) (x : Space d) : g n x = b n x * f n x := by
       have := (b n).hasCompactSupport.hasTemperateGrowth (b n).contDiff
       rw [smulLeftCLM_apply_apply this, ← Complex.coe_smul, smul_eq_mul]
@@ -229,46 +238,47 @@ lemma dense_top (d : ℕ) : Dense (PolyBddSchwartzSubmodule d ⊤ : Set (SpaceDH
       rw [sub_sub_cancel_left, Pi.neg_def, ← neg_zero, tendsto_neg_iff]
       -- Split `φₙ = σₙ + (φₙ - σₐ)` with `σₙ ≔ [bₙξ]` a sequence in `SpaceDHilbertSpace`
       let s (n : ℕ) : Space d → ℂ := fun x ↦ b n x * ξ x
-      let σ (n : ℕ) : SpaceDHilbertSpace d := by
+      let σ (n : ℕ) : SpaceDHilbertSpace d μ := by
         refine mk (f := s n) ⟨?_, ?_⟩
         · exact (continuous_ofReal.comp (b n).continuous).aestronglyMeasurable.mul
             ξ.val.aestronglyMeasurable
         · refine lt_of_le_of_lt ?_ (memHS_coe ξ).2
           exact eLpNorm_mono_enorm (enorm_bump_mul_le_enorm (b n) ξ)
-      have hψ_ae (n : ℕ) : ψ n =ᵐ[volume] f n := (schwartzEquiv_symm_coe_ae ⟨ψ n, hψ n⟩).symm
-      have hφ_ae (n : ℕ) : φ n =ᵐ[volume] g n := schwartzEquiv_coe_ae (g n)
-      have hσ_ae (n : ℕ) : σ n =ᵐ[volume] s n := coeFn_mk _
-      have hφσ_ae (n : ℕ) : (φ - σ) n =ᵐ[volume] g n - s n :=
+      have hψ_ae (n : ℕ) : ψ n =ᵐ[μ] f n := (schwartzEquiv_symm_coe_ae ⟨ψ n, hψ n⟩).symm
+      have hφ_ae (n : ℕ) : φ n =ᵐ[μ] g n := schwartzEquiv_coe_ae (g n)
+      have hσ_ae (n : ℕ) : σ n =ᵐ[μ] s n := coeFn_mk _
+      have hφσ_ae (n : ℕ) : (φ - σ) n =ᵐ[μ] g n - s n :=
         (coeFn_sub (φ n) (σ n)).trans <| (hφ_ae n).sub (hσ_ae n)
-      have hψξ_ae (n : ℕ) : ψ n - ξ =ᵐ[volume] f n - ξ :=
+      have hψξ_ae (n : ℕ) : ψ n - ξ =ᵐ[μ] f n - ξ :=
         (coeFn_sub (ψ n) ξ).trans <| (hψ_ae n).sub EventuallyEq.rfl
       refine tendsto_of_sub_tendsto_zero (f := σ) 0 ?_ ?_
       · -- `σ = bₙξ → 0` since the norms are bounded by the integral of `‖ξ‖²` (independent of `n`!)
         -- on a domain which tends to zero
         apply tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq.mpr
         let B (n : ℕ) : Set (Space d) := Metric.ball 0 (b n).rOut
-        have hξB : Tendsto (fun n ↦ ∫⁻ x in B n, ‖ξ x‖ₑ ^ 2) atTop (nhds 0) := by
+        have hξB : Tendsto (fun n ↦ ∫⁻ x in B n, ‖ξ x‖ₑ ^ 2 ∂μ) atTop (nhds 0) := by
           refine tendsto_setLIntegral_zero ?_ ?_
           · refine lt_top_iff_ne_top.mp ?_
             simpa [eLpNorm_one_eq_lintegral_enorm, Real.rpow_ofNat, enorm_pow, enorm_norm]
               using L2.eLpNorm_rpow_two_norm_lt_top ξ
           · have : NeZero d := ⟨hd.ne'⟩
+            refine tendsto_const_nhds.squeeze ?_ zero_le (fun n ↦ hμ (B n))
             let C : ℝ := (ENNReal.ofReal (√Real.pi ^ d / Real.Gamma (d / 2 + 1))).toReal
-            have hvolB : ⇑volume ∘ B = fun n ↦ ENNReal.ofReal (C * (b n).rOut ^ d) := by
-              ext n
+            have hvolB : ∀ n, volume (B n) = ENNReal.ofReal (C * (b n).rOut ^ d) := by
+              intro n
               simp [B, InnerProductSpace.volume_ball, C, mul_comm,
                 ENNReal.ofReal_pow (b n).rOut_pos.le]
             simp_rw [hvolB, ← ENNReal.ofReal_zero, b, ← one_div, mul_pow, ← mul_assoc]
             rw [← mul_zero (C * 2 ^ d), ← zero_pow (M₀ := ℝ) hd.ne']
             refine ENNReal.tendsto_ofReal <| Tendsto.const_mul (C * 2 ^ d) ?_
             exact tendsto_one_div_add_atTop_nhds_zero_nat.pow d
-        refine Tendsto.squeeze tendsto_const_nhds hξB (zero_le) (fun n ↦ ?_)
-        suffices ∫⁻ x, ‖σ n x‖ₑ ^ 2 = ∫⁻ x in B n, ‖σ n x‖ₑ ^ 2 by
+        refine tendsto_const_nhds.squeeze hξB (zero_le) (fun n ↦ ?_)
+        suffices ∫⁻ x, ‖σ n x‖ₑ ^ 2 ∂μ = ∫⁻ x in B n, ‖σ n x‖ₑ ^ 2 ∂μ by
           rw [this]
           refine setLIntegral_mono_ae' measurableSet_ball ?_
           filter_upwards [hσ_ae n] with x h _
           exact ENNReal.pow_le_pow_left <| h ▸ enorm_bump_mul_le_enorm (b n) ξ x
-        have h (A : Set (Space d)) : ∫⁻ x in A, ‖σ n x‖ₑ ^ 2 = ∫⁻ x in A, ‖s n x‖ₑ ^ 2 :=
+        have h (A : Set (Space d)) : ∫⁻ x in A, ‖σ n x‖ₑ ^ 2 ∂μ = ∫⁻ x in A, ‖s n x‖ₑ ^ 2 ∂μ :=
           lintegral_congr_ae ((hσ_ae n).fun_comp (fun z ↦ ‖z‖ₑ ^ 2)).restrict
         rw [← setLIntegral_univ, h, h, setLIntegral_univ]
         refine (setLIntegral_eq_of_support_subset ?_).symm
@@ -276,7 +286,7 @@ lemma dense_top (d : ℕ) : Dense (PolyBddSchwartzSubmodule d ⊤ : Set (SpaceDH
         simp [s, (b n).zero_of_le_dist (not_lt.mp hx)]
       · -- `φₙ - σₙ = bₙ(ψₙ - ξ) → 0` since `ψₙ → ξ` (by definition) and the `bₙ` are bounded
         apply tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq.mpr
-        have hψξ : Tendsto (fun n ↦ ∫⁻ x, ‖(ψ n - ξ) x‖ₑ ^ 2) atTop (nhds 0) :=
+        have hψξ : Tendsto (fun n ↦ ∫⁻ x, ‖(ψ n - ξ) x‖ₑ ^ 2 ∂μ) atTop (nhds 0) :=
           tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq.mp (sub_self ξ ▸ hψξ.sub_const ξ)
         refine Tendsto.squeeze tendsto_const_nhds hψξ (zero_le) (fun n ↦ ?_)
         refine lintegral_mono_ae ?_
@@ -284,8 +294,9 @@ lemma dense_top (d : ℕ) : Dense (PolyBddSchwartzSubmodule d ⊤ : Set (SpaceDH
         simp_rw [h, h', Pi.sub_apply, hg, s, ← mul_sub]
         exact ENNReal.pow_le_pow_left <| enorm_bump_mul_le_enorm (b n) (fun x ↦ f n x - ξ x) x
 
-lemma dense (d : ℕ) (a : ℕ∞) : Dense (PolyBddSchwartzSubmodule d a : Set (SpaceDHilbertSpace d)) :=
-  (dense_top d).mono (antitone d le_top)
+lemma dense (hμ : μ ≤ volume) [μ.IsOpenPosMeasure] [IsFiniteMeasureOnCompacts μ] :
+    Dense (PolyBddSchwartzSubmodule d a μ : Set (SpaceDHilbertSpace d μ)) :=
+  (dense_top μ hμ).mono (antitone μ le_top)
 
 end PolyBddSchwartzSubmodule
 end

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PolyBddSchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PolyBddSchwartzSubmodule.lean
@@ -137,6 +137,7 @@ lemma polyBddSchwartzEquiv_symm_apply_coe [μ.IsOpenPosMeasure]
   rw [← hg, LinearEquiv.symm_apply_apply, LinearEquiv.apply_symm_apply, ← hg']
   rfl
 
+variable {μ} in
 lemma polyBddSchwartzEquiv_coe_ae [μ.IsOpenPosMeasure] (f : PolyBddSchwartzMap d a) :
     polyBddSchwartzEquiv μ f =ᵐ[μ] f.val :=
   schwartzEquiv_coe_ae f.val

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/SchwartzSubmodule.lean
@@ -13,11 +13,11 @@ public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Basic
 
 ## i. Overview
 
-In this module we define the Schwartz submodule of `SpaceDHilbertSpace`.
+In this module we define the Schwartz submodule of `SpaceDHilbertSpace d μ`.
 
 ## ii. Key results
 
-- `SchwartzSubmodule d`: Submodule of `SpaceDHilbertSpace d` consisting of the L² equivalence
+- `SchwartzSubmodule d μ`: Submodule of `SpaceDHilbertSpace d μ` consisting of the L² equivalence
   classes of Schwartz maps `𝓢(Space d, ℂ)`.
 
 ## iii. Table of contents
@@ -41,42 +41,48 @@ open MeasureTheory
 open InnerProductSpace
 open SchwartzMap
 
-variable {d : ℕ}
-
 /-!
 ## A. Definitions
 -/
 
-/-- The continuous linear map including Schwartz maps into `SpaceDHilbertSpace d`. -/
-def schwartzIncl : 𝓢(Space d, ℂ) →L[ℂ] SpaceDHilbertSpace d := toLpCLM ℂ (E := Space d) ℂ 2
+/-- The continuous linear map including Schwartz maps into `SpaceDHilbertSpace d μ`. -/
+def schwartzIncl {d : ℕ} (μ : Measure (Space d)) [μ.HasTemperateGrowth] :
+    𝓢(Space d, ℂ) →L[ℂ] SpaceDHilbertSpace d μ :=
+  toLpCLM ℂ ℂ 2 μ
 
 /-- The submodule of `SpaceDHilbertSpace d` corresponding to Schwartz maps. -/
-abbrev SchwartzSubmodule (d : ℕ) := (schwartzIncl (d := d)).range
+abbrev SchwartzSubmodule (d : ℕ) (μ : Measure (Space d) := volume) [μ.HasTemperateGrowth] :
+    Submodule ℂ (SpaceDHilbertSpace d μ) :=
+  (schwartzIncl μ).range
 
 /-- The linear equivalence between the Schwartz maps `𝓢(Space d, ℂ)` and the Schwartz submodule
-  of `SpaceDHilbertSpace d`. -/
-def schwartzEquiv : 𝓢(Space d, ℂ) ≃ₗ[ℂ] SchwartzSubmodule d :=
-  LinearEquiv.ofInjective schwartzIncl.toLinearMap (injective_toLp (E := Space d) 2)
+  of `SpaceDHilbertSpace d μ`. -/
+def schwartzEquiv
+    {d : ℕ} (μ : Measure (Space d)) [μ.HasTemperateGrowth] [μ.IsOpenPosMeasure] :
+    𝓢(Space d, ℂ) ≃ₗ[ℂ] SchwartzSubmodule d μ :=
+  LinearEquiv.ofInjective (schwartzIncl μ).toLinearMap (injective_toLp 2 μ)
 
 namespace SchwartzSubmodule
 
-variable (f g : 𝓢(Space d, ℂ)) (ψ : SchwartzSubmodule d)
+variable {d : ℕ}
+variable {μ : Measure (Space d)} [μ.HasTemperateGrowth] [μ.IsOpenPosMeasure]
+variable (f g : 𝓢(Space d, ℂ)) (ψ : SchwartzSubmodule d μ)
 
 /-!
 ## B. Coercions
 -/
 
-instance : CoeFun (SchwartzSubmodule d) fun _ ↦ Space d → ℂ := ⟨fun ψ ↦ ψ.val⟩
+instance : CoeFun (SchwartzSubmodule d μ) fun _ ↦ Space d → ℂ := ⟨fun ψ ↦ ψ.val⟩
 
-lemma schwartzEquiv_apply_coe : ↑(schwartzEquiv f) = schwartzIncl f := by simp [schwartzEquiv]
+lemma schwartzEquiv_apply_coe : ↑(schwartzEquiv μ f) = schwartzIncl μ f := by simp [schwartzEquiv]
 
-lemma schwartzEquiv_coe_ae : schwartzEquiv f =ᵐ[volume] f := coeFn_toLp f 2 volume
+lemma schwartzEquiv_coe_ae : schwartzEquiv μ f =ᵐ[μ] f := coeFn_toLp f 2 μ
 
-lemma schwartzEquiv_symm_coe_ae : schwartzEquiv.symm ψ =ᵐ[volume] ψ := by
-  nth_rw 2 [← schwartzEquiv.apply_symm_apply ψ]
+lemma schwartzEquiv_symm_coe_ae : (schwartzEquiv μ).symm ψ =ᵐ[μ] ψ := by
+  nth_rw 2 [← (schwartzEquiv μ).apply_symm_apply ψ]
   exact (schwartzEquiv_coe_ae _).symm
 
-lemma schwartzEquiv_ae_eq (h : schwartzEquiv f =ᵐ[volume] schwartzEquiv g) : f = g :=
+lemma schwartzEquiv_ae_eq (h : schwartzEquiv μ f =ᵐ[μ] schwartzEquiv μ g) : f = g :=
   (EmbeddingLike.apply_eq_iff_eq _).mp (SetLike.coe_eq_coe.mp (ext_iff.mpr h))
 
 /-!
@@ -104,16 +110,18 @@ lemma zero_eq_top : SchwartzSubmodule 0 = ⊤ := by
   rw [← schwartzEquiv_apply_coe, hg, Space.point_dim_zero_eq x]
   rfl
 
-lemma dense (d : ℕ) : Dense (SchwartzSubmodule d : Set (SpaceDHilbertSpace d)) :=
+omit [μ.IsOpenPosMeasure] in
+lemma dense [IsFiniteMeasureOnCompacts μ] :
+    Dense (SchwartzSubmodule d μ : Set (SpaceDHilbertSpace d μ)) :=
   denseRange_toLpCLM ENNReal.top_ne_ofNat.symm
 
 lemma schwartzEquiv_inner :
-    ⟪schwartzEquiv f, schwartzEquiv g⟫_ℂ = ∫ x : Space d, starRingEnd ℂ (f x) * g x := by
+    ⟪schwartzEquiv μ f, schwartzEquiv μ g⟫_ℂ = ∫ x, starRingEnd ℂ (f x) * g x ∂μ := by
   apply integral_congr_ae
   filter_upwards [schwartzEquiv_coe_ae f, schwartzEquiv_coe_ae g] with _ hf hg
   simp [hf, hg, mul_comm]
 
-lemma schwartzIncl_ker : schwartzIncl.ker = (⊥ : Submodule ℂ 𝓢(Space d, ℂ)) := by
+lemma schwartzIncl_ker : (schwartzIncl μ).ker = (⊥ : Submodule ℂ 𝓢(Space d, ℂ)) := by
   ext; simp [← schwartzEquiv_apply_coe]
 
 end SchwartzSubmodule

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/SchwartzSubmodule.lean
@@ -90,7 +90,8 @@ lemma schwartzEquiv_ae_eq (h : schwartzEquiv μ f =ᵐ[μ] schwartzEquiv μ g) :
 -/
 
 @[simp]
-lemma zero_eq_top : SchwartzSubmodule 0 = ⊤ := by
+lemma zero_eq_top (μ : Measure (Space 0)) [μ.HasTemperateGrowth] [μ.IsOpenPosMeasure] :
+    SchwartzSubmodule 0 μ = ⊤ := by
   ext ψ
   simp only [LinearMap.mem_range, ContinuousLinearMap.coe_coe, Submodule.mem_top, iff_true]
   let g : 𝓢(Space 0, ℂ) := {
@@ -110,6 +111,7 @@ lemma zero_eq_top : SchwartzSubmodule 0 = ⊤ := by
   rw [← schwartzEquiv_apply_coe, hg, Space.point_dim_zero_eq x]
   rfl
 
+variable (d μ) in
 omit [μ.IsOpenPosMeasure] in
 lemma dense [IsFiniteMeasureOnCompacts μ] :
     Dense (SchwartzSubmodule d μ : Set (SpaceDHilbertSpace d μ)) :=
@@ -121,6 +123,7 @@ lemma schwartzEquiv_inner :
   filter_upwards [schwartzEquiv_coe_ae f, schwartzEquiv_coe_ae g] with _ hf hg
   simp [hf, hg, mul_comm]
 
+variable (μ) in
 lemma schwartzIncl_ker : (schwartzIncl μ).ker = (⊥ : Submodule ℂ 𝓢(Space d, ℂ)) := by
   ext; simp [← schwartzEquiv_apply_coe]
 

--- a/Physlib/QuantumMechanics/Operators/Momentum.lean
+++ b/Physlib/QuantumMechanics/Operators/Momentum.lean
@@ -90,29 +90,29 @@ open SchwartzSubmodule
 /-- The momentum operator as a LinearPMap with domain the Schwartz submodule. -/
 def momentumOperator : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d where
   domain := SchwartzSubmodule d
-  toFun := schwartzIncl.toLinearMap ∘ₗ (𝐩 i).toLinearMap ∘ₗ schwartzEquiv.symm.toLinearMap
+  toFun := (schwartzIncl volume).1 ∘ₗ (𝐩 i).1 ∘ₗ (schwartzEquiv volume).symm.1
 
 @[inherit_doc momentumOperator]
 notation "𝓟" => momentumOperator
 
 lemma momentumOperator_apply (ψ : SchwartzSubmodule d) :
-    𝓟 i ψ = schwartzEquiv (𝐩 i (schwartzEquiv.symm ψ)) := rfl
+    𝓟 i ψ = schwartzEquiv volume (𝐩 i ((schwartzEquiv volume).symm ψ)) := rfl
 
 lemma momentumOperator_apply_ae (ψ : SchwartzSubmodule d) :
-    𝓟 i ψ =ᵐ[volume] 𝐩 i (schwartzEquiv.symm ψ) :=
+    𝓟 i ψ =ᵐ[volume] 𝐩 i ((schwartzEquiv volume).symm ψ) :=
   schwartzEquiv_coe_ae _
 
 lemma momentumOperator_range (ψ : SchwartzSubmodule d) : 𝓟 i ψ ∈ SchwartzSubmodule d := by
   simp [momentumOperator_apply]
 
-lemma momentumOperator_hasDenseDomain : (𝓟 i).HasDenseDomain := SchwartzSubmodule.dense d
+lemma momentumOperator_hasDenseDomain : (𝓟 i).HasDenseDomain := SchwartzSubmodule.dense d _
 
 lemma momentumOperator_isSymmetric : (𝓟 i).IsSymmetric := by
   intro ψ φ
-  obtain ⟨f, rfl⟩ := schwartzEquiv.surjective ψ
-  obtain ⟨g, rfl⟩ := schwartzEquiv.surjective φ
+  obtain ⟨f, rfl⟩ := (schwartzEquiv volume).surjective ψ
+  obtain ⟨g, rfl⟩ := (schwartzEquiv volume).surjective φ
   simp only [momentumOperator_apply, ← Submodule.coe_inner, schwartzEquiv_inner,
-    schwartzEquiv.symm_apply_apply, momentumCLM_apply]
+    (schwartzEquiv volume).symm_apply_apply, momentumCLM_apply]
   have heq : ∀ x, fderiv ℝ (star ∘ f) x = (starL' ℝ).toContinuousLinearMap ∘L (fderiv ℝ f x) :=
     fun _ ↦ fderiv_star
   have hI₁ : Integrable fun x ↦ star (f x) := (starL' ℝ).integrable_comp_iff.mpr f.integrable

--- a/Physlib/QuantumMechanics/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/Operators/Multiplication.lean
@@ -15,7 +15,7 @@ public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
 
 In this module we introduce unbounded operators defined by multiplication by a function
 `f : Space d → ℂ`. The domain is defined to be as large as possible, namely a vector
-`ψ ∈ SpaceDHilbertSpace d` is in the domain iff `f • ψ ∈ SpaceDHilbertSpace d`.
+`ψ ∈ SpaceDHilbertSpace d μ` is in the domain iff `f • ψ ∈ SpaceDHilbertSpace d μ`.
 
 ## ii. Key results
 
@@ -39,8 +39,7 @@ In this module we introduce unbounded operators defined by multiplication by a f
 ## iv. References
 
 See examples 1.3 and 3.8 in
-- K. Schmüdgen, (2012). "Unbounded self-adjoint operators on Hilbert space" (Vol. 265). Springer.
-  https://doi.org/10.1007/978-94-007-4753-1
+- [Konrad Schmüdgen, *Unbounded Self-Adjoint Operators on Hilbert Space*][Schmudgen2012]
 
 -/
 
@@ -61,16 +60,17 @@ variable {d : ℕ}
 ## A. Definition
 -/
 
-/-- The LinearPMap which maps `ψ` to `f • ψ` with domain `{ψ | f • ψ ∈ SpaceDHilbertSpace d}`. -/
-def mulOperator (f : Space d → ℂ) : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d where
+/-- The LinearPMap which maps `ψ` to `f • ψ` with domain `{ψ | f • ψ ∈ SpaceDHilbertSpace d μ}`. -/
+def mulOperator (μ : Measure (Space d)) (f : Space d → ℂ) :
+    SpaceDHilbertSpace d μ →ₗ.[ℂ] SpaceDHilbertSpace d μ where
   domain := {
-    carrier := {ψ : SpaceDHilbertSpace d | MemHS (f • ψ.val.cast)}
+    carrier := {ψ : SpaceDHilbertSpace d μ | MemHS (f • ψ.val.cast) μ}
     add_mem' := by
       intro ψ φ hψ hφ
       refine (hψ.add hφ).ae_eq ?_
       filter_upwards [coeFn_add ψ φ] with x h
       simp [mul_add, h]
-    zero_mem' := MemHS.zero.ae_eq (by filter_upwards; simp)
+    zero_mem' := by sorry
     smul_mem' c ψ hψ := by
       refine (hψ.const_smul c).ae_eq ?_
       filter_upwards [coeFn_smul c ψ] with x h
@@ -92,25 +92,28 @@ def mulOperator (f : Space d → ℂ) : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceD
 notation "𝓜" => mulOperator
 
 lemma mem_mulOperator_domain_iff
-    {f : Space d → ℂ} {ψ : SpaceDHilbertSpace d} : ψ ∈ (𝓜 f).domain ↔ MemHS (f • ψ.val.cast) :=
+    {μ : Measure (Space d)} {f : Space d → ℂ} {ψ : SpaceDHilbertSpace d μ} :
+    ψ ∈ (𝓜 μ f).domain ↔ MemHS (f • ψ.val.cast) μ :=
   Iff.rfl
 
-lemma mulOperator_apply_ae {f : Space d → ℂ} (ψ : (𝓜 f).domain) : (𝓜 f) ψ =ᵐ[volume] f • ψ :=
+lemma mulOperator_apply_ae {μ : Measure (Space d)} {f : Space d → ℂ} (ψ : (𝓜 μ f).domain) :
+    (𝓜 μ f) ψ =ᵐ[μ] f • ψ :=
   coeFn_mk ψ.prop
 
 /-!
 ## B. Domain
 -/
 
-lemma mulOperator_hasDenseDomain {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (𝓜 f).HasDenseDomain := by
+lemma mulOperator_hasDenseDomain
+    {μ : Measure (Space d)} {f : Space d → ℂ} (hf : AEStronglyMeasurable f μ) :
+    (𝓜 μ f).HasDenseDomain := by
   intro ψ
   apply mem_closure_iff_seq_limit.mpr
-  obtain ⟨u, hu, hfu⟩ := AEStronglyMeasurable.aemeasurable hf
+  obtain ⟨u, hu, hfu⟩ := hf.aemeasurable
   let s : ℕ → Set (Space d) := fun n ↦ u ⁻¹' (Metric.closedBall 0 n)
-  let φ : ℕ → SpaceDHilbertSpace d := fun n ↦
+  let φ : ℕ → SpaceDHilbertSpace d μ := fun n ↦
     mk ((memHS_coe ψ).indicator (Ω := s n) (by measurability))
-  have hφ : ∀ n, φ n =ᵐ[volume] (s n).indicator ψ := fun n ↦ coeFn_mk _
+  have hφ : ∀ n, φ n =ᵐ[μ] (s n).indicator ψ := fun n ↦ coeFn_mk _
   use φ
   constructor
   · intro n
@@ -126,19 +129,19 @@ lemma mulOperator_hasDenseDomain {f : Space d → ℂ} (hf : AEStronglyMeasurabl
     · simp [h₃, hx]
   · apply tendsto_sub_nhds_zero_iff.mp
     apply tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq.mpr
-    have h : ∀ n, ∫⁻ x, ‖(φ n - ψ) x‖ₑ ^ 2 = ∫⁻ x, ‖(s n)ᶜ.indicator ψ x‖ₑ ^ 2 := by
+    have h : ∀ n, ∫⁻ x, ‖(φ n - ψ) x‖ₑ ^ 2 ∂μ = ∫⁻ x, ‖(s n)ᶜ.indicator ψ x‖ₑ ^ 2 ∂μ := by
       intro n
       refine lintegral_congr_ae ?_
       filter_upwards [coeFn_sub (φ n) ψ, hφ n] with x h₁ h₂
       by_cases hx : x ∈ s n <;> simp [hx, h₁, h₂]
     simp_rw [h]
-    rw [← MeasureTheory.lintegral_zero (α := Space d) (μ := volume)]
+    rw [← MeasureTheory.lintegral_zero (α := Space d) (μ := μ)]
     refine tendsto_lintegral_of_dominated_convergence' (fun x ↦ ‖ψ x‖ₑ ^ 2) ?_ ?_ ?_ ?_
     · measurability
     · intro n
       filter_upwards with x
       by_cases hx : x ∈ s n <;> simp [hx]
-    · have : ∫⁻ x, ‖‖ψ x‖ ^ 2‖ₑ ≠ ⊤ := (memHS_iff.mp <| memHS_coe ψ).2.2.ne
+    · have : ∫⁻ x, ‖‖ψ x‖ ^ 2‖ₑ ∂μ ≠ ⊤ := (memHS_iff.mp <| memHS_coe ψ).2.2.ne
       simp_all
     · filter_upwards with x
       rw [← zero_pow two_ne_zero, ← enorm_zero (E := ℂ)]
@@ -148,12 +151,13 @@ lemma mulOperator_hasDenseDomain {f : Space d → ℂ} (hf : AEStronglyMeasurabl
       exact (Nat.le_ceil _).trans (by exact_mod_cast hn)
 
 open SchwartzMap SchwartzSubmodule in
-lemma mulOperator_domain_ge_of_hasTemperateGrowth
-    {f : Space d → ℂ} (hf : f.HasTemperateGrowth) : SchwartzSubmodule d ≤ (𝓜 f).domain := by
+lemma mulOperator_domain_ge_of_hasTemperateGrowth {f : Space d → ℂ} (hf : f.HasTemperateGrowth)
+    (μ : Measure (Space d)) [μ.HasTemperateGrowth] [μ.IsOpenPosMeasure] :
+    SchwartzSubmodule d μ ≤ (𝓜 μ f).domain := by
   intro ψ hψ
-  obtain ⟨g, hg⟩ := schwartzEquiv.surjective ⟨ψ, hψ⟩
+  obtain ⟨g, hg⟩ := (schwartzEquiv μ).surjective ⟨ψ, hψ⟩
   let w : 𝓢(Space d, ℂ) := smulLeftCLM ℂ f g
-  let φ : SpaceDHilbertSpace d := schwartzEquiv w
+  let φ : SpaceDHilbertSpace d μ := schwartzEquiv μ w
   refine (memHS_coe φ).ae_eq ?_
   filter_upwards [schwartzEquiv_coe_ae w, schwartzEquiv_coe_ae g] with x h₁ h₂
   simp [w, φ, h₁, ← h₂, hg, smulLeftCLM_apply_apply hf]
@@ -163,19 +167,21 @@ lemma mulOperator_domain_ge_of_hasTemperateGrowth
 -/
 
 -- Can the AEStronglyMeasurable hypothesis be removed?
-lemma mulOperator_conj_domain {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (𝓜 (conj ∘ f)).domain = (𝓜 f).domain := by
+lemma mulOperator_conj_domain
+    {μ : Measure (Space d)} {f : Space d → ℂ} (hf : AEStronglyMeasurable f μ) :
+    (𝓜 μ (conj ∘ f)).domain = (𝓜 μ f).domain := by
   ext
   simp only [mulOperator, smul_eq_mul, memHS_iff]
   exact and_congr (iff_of_true (by fun_prop) (by fun_prop)) (by simp)
 
 private lemma exists_monotone_sets_hasFiniteIntegral
-    (f g : Space d → ℂ) (hf : AEStronglyMeasurable f) (hg : AEStronglyMeasurable g) :
+    {μ : Measure (Space d)} [IsFiniteMeasureOnCompacts μ]
+    (f g : Space d → ℂ) (hf : AEStronglyMeasurable f μ) (hg : AEStronglyMeasurable g μ) :
     ∃ s : ℕ → Set (Space d), Monotone s ∧ ⋃ n, s n = Set.univ ∧ (∀ n, MeasurableSet (s n))
       ∧ ∀ k, k = 1 ∨ k = 2 →
-        ∀ n, HasFiniteIntegral (fun x ↦ ‖f x ^ k * g x‖ ^ 2) (volume.restrict (s n)) := by
-  obtain ⟨w₁, hw₁, hw₁'⟩ : AEStronglyMeasurable (fun x ↦ f x * g x) := by measurability
-  obtain ⟨w₂, hw₂, hw₂'⟩ : AEStronglyMeasurable (fun x ↦ f x ^ 2 * g x) := by measurability
+        ∀ n, HasFiniteIntegral (fun x ↦ ‖f x ^ k * g x‖ ^ 2) (μ.restrict (s n)) := by
+  obtain ⟨w₁, hw₁, hw₁'⟩ : AEStronglyMeasurable (fun x ↦ f x * g x) μ := by measurability
+  obtain ⟨w₂, hw₂, hw₂'⟩ : AEStronglyMeasurable (fun x ↦ f x ^ 2 * g x) μ := by measurability
   let s : ℕ → Set (Space d) :=
     fun n ↦ Metric.closedBall 0 n ∩ (w₁ ⁻¹' Metric.closedBall 0 n ∩ w₂ ⁻¹' Metric.closedBall 0 n)
   refine ⟨s, ?_, ?_, by measurability, ?_⟩
@@ -189,7 +195,7 @@ private lemma exists_monotone_sets_hasFiniteIntegral
     suffices ∀ r : ℝ, r ≤ ⌈r⌉.toNat by simp [s, this]
     exact fun r ↦ (Int.le_ceil r).trans (by exact_mod_cast Int.self_le_toNat _)
   · intro k hk n
-    refine lt_of_le_of_lt (b := ‖(n : ℝ) ^ 2‖ₑ * volume (s n)) ?_ ?_
+    refine lt_of_le_of_lt (b := ‖(n : ℝ) ^ 2‖ₑ * μ (s n)) ?_ ?_
     · rw [← setLIntegral_const]
       refine setLIntegral_mono_ae' (by measurability) ?_
       filter_upwards [hw₁', hw₂'] with x h₁ h₂ ⟨h₃, h₃'⟩
@@ -201,56 +207,58 @@ private lemma exists_monotone_sets_hasFiniteIntegral
       exact measure_inter_lt_top_of_left_ne_top measure_closedBall_lt_top.ne
 
 open Complex InnerProductSpace in
-lemma mulOperator_adjoint_domain_le {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (𝓜 f)†.domain ≤ (𝓜 (conj ∘ f)).domain := by
+lemma mulOperator_adjoint_domain_le
+    {μ : Measure (Space d)} [IsFiniteMeasureOnCompacts μ]
+    {f : Space d → ℂ} (hf : AEStronglyMeasurable f μ) :
+    (𝓜 μ f)†.domain ≤ (𝓜 μ (conj ∘ f)).domain := by
   intro ψ hψ
-  let ξ : SpaceDHilbertSpace d := (𝓜 f)† ⟨ψ, hψ⟩
+  let ξ : SpaceDHilbertSpace d μ := (𝓜 μ f)† ⟨ψ, hψ⟩
   obtain ⟨s, hs_mono, hs_univ, hs_meas, hs_int⟩ :=
     exists_monotone_sets_hasFiniteIntegral (conj ∘ f) ψ (by fun_prop) ψ.val.aestronglyMeasurable
   let w : ℕ → Space d → ℂ := fun n ↦ (s n).indicator ((conj ∘ f) • ψ)
-  have hw : ∀ n, MemHS (w n) := by
+  have hw : ∀ n, MemHS (w n) μ := by
     intro n
     refine memHS_iff.mpr ⟨by measurability, by measurability, ?_⟩
     refine lt_of_eq_of_lt ?_ (hs_int 1 (Or.inl rfl) n)
-    trans ∫⁻ x in s n, ‖‖w n x‖ ^ 2‖ₑ
+    trans ∫⁻ x in s n, ‖‖w n x‖ ^ 2‖ₑ ∂μ
     · exact (setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]).symm
     exact setLIntegral_congr_fun (hs_meas n) fun x hx ↦ by simp [w, hx, mul_pow]
-  let φ : ℕ → SpaceDHilbertSpace d := fun n ↦ mk (hw n)
-  have hφ : ∀ n, φ n ∈ (𝓜 f).domain := by
+  let φ : ℕ → SpaceDHilbertSpace d μ := fun n ↦ mk (hw n)
+  have hφ : ∀ n, φ n ∈ (𝓜 μ f).domain := by
     intro n
     apply memHS_iff.mpr ⟨by measurability, by measurability, ?_⟩
     refine lt_of_eq_of_lt ?_ (hs_int 2 (Or.inr rfl) n)
     calc
-      _ = ∫⁻ x, ‖‖(f • w n) x‖ ^ 2‖ₑ := by
+      _ = ∫⁻ x, ‖‖(f • w n) x‖ ^ 2‖ₑ ∂μ := by
         refine lintegral_congr_ae ?_
         filter_upwards [coeFn_mk (hw n)] with _ h
         simp [φ, h]
-      _ = ∫⁻ x in s n, ‖‖(f • w n) x‖ ^ 2‖ₑ :=
+      _ = ∫⁻ x in s n, ‖‖(f • w n) x‖ ^ 2‖ₑ ∂μ :=
         (setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]).symm
     exact setLIntegral_congr_fun (hs_meas n) fun x hx ↦ by simp [w, hx, ← mul_assoc, ← pow_two]
-  suffices ∀ n, ∫⁻ x in s n, ‖‖f x‖ ^ 2 * ‖ψ x‖ ^ 2‖ₑ ≤ ∫⁻ x, ‖‖ξ x‖ ^ 2‖ₑ by
+  suffices ∀ n, ∫⁻ x in s n, ‖‖f x‖ ^ 2 * ‖ψ x‖ ^ 2‖ₑ ∂μ ≤ ∫⁻ x, ‖‖ξ x‖ ^ 2‖ₑ ∂μ by
     refine memHS_iff.mpr ⟨by measurability, by measurability, ?_⟩
     refine lt_of_le_of_lt ?_ (memHS_iff.mp <| memHS_coe ξ).2.2
-    trans ⨆ n, ∫⁻ x in s n, ‖‖f x‖ ^ 2 * ‖ψ x‖ ^ 2‖ₑ
+    trans ⨆ n, ∫⁻ x in s n, ‖‖f x‖ ^ 2 * ‖ψ x‖ ^ 2‖ₑ ∂μ
     · rw [← setLIntegral_univ, ← hs_univ,
         setLIntegral_iUnion_of_directed _ (directed_of_isDirected_le hs_mono)]
       simp [mul_pow]
     exact iSup_le this
   intro n
   suffices ‖φ n‖ ^ 2 ≤ ‖ξ‖ ^ 2 by
-    refine le_of_eq_of_le (b := ∫⁻ x, ‖‖φ n x‖ ^ 2‖ₑ) ?_ <| (ENNReal.toReal_le_toReal ?_ ?_).mp ?_
+    refine le_of_eq_of_le (b := ∫⁻ x, ‖‖φ n x‖ ^ 2‖ₑ ∂μ) ?_ ((ENNReal.toReal_le_toReal ?_ ?_).mp ?_)
     · calc
-        _ = ∫⁻ x in s n, ‖‖w n x‖ ^ 2‖ₑ :=
+        _ = ∫⁻ x in s n, ‖‖w n x‖ ^ 2‖ₑ ∂μ :=
           setLIntegral_congr_fun (hs_meas n) fun x hx ↦ by simp [w, hx, mul_pow]
-        _ = ∫⁻ x, ‖‖w n x‖ ^ 2‖ₑ :=
+        _ = ∫⁻ x, ‖‖w n x‖ ^ 2‖ₑ ∂μ :=
           setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]
-        _ = ∫⁻ x, ‖‖φ n x‖ ^ 2‖ₑ := by
+        _ = ∫⁻ x, ‖‖φ n x‖ ^ 2‖ₑ ∂μ := by
           refine lintegral_congr_ae ?_
           filter_upwards [coeFn_mk (hw n)] with x h₁
           simp [φ, h₁]
     · exact (memHS_iff.mp <| memHS_coe (φ n)).2.2.ne
     · exact (memHS_iff.mp <| memHS_coe ξ).2.2.ne
-    · suffices h : ∀ ψ : SpaceDHilbertSpace d, ‖ψ‖ ^ 2 = (∫⁻ x, ‖‖ψ x‖ ^ 2‖ₑ).toReal by
+    · suffices h : ∀ ψ : SpaceDHilbertSpace d μ, ‖ψ‖ ^ 2 = (∫⁻ x, ‖‖ψ x‖ ^ 2‖ₑ ∂μ).toReal by
         simp only [← h, this]
       intro ψ
       rw [Lp.norm_def, eLpNorm_eq_lintegral_rpow_enorm_toReal two_ne_zero ENNReal.ofNat_ne_top]
@@ -259,7 +267,7 @@ lemma mulOperator_adjoint_domain_le {f : Space d → ℂ} (hf : AEStronglyMeasur
     nlinarith [this, sq_nonneg (‖ξ‖ - ‖φ n‖)]
   calc
     _ = ‖⟪φ n, φ n⟫_ℂ‖ := by simp
-    _ = ‖⟪ψ, 𝓜 f ⟨φ n, hφ n⟩⟫_ℂ‖ := by
+    _ = ‖⟪ψ, 𝓜 μ f ⟨φ n, hφ n⟩⟫_ℂ‖ := by
       refine congrArg norm ?_
       refine integral_congr_ae ?_
       filter_upwards [coeFn_mk (hw n), mulOperator_apply_ae ⟨φ n, hφ n⟩] with x h₁ h₂
@@ -276,9 +284,10 @@ lemma mulOperator_adjoint_domain_le {f : Space d → ℂ} (hf : AEStronglyMeasur
       rw [(adjoint_isFormalAdjoint (mulOperator_hasDenseDomain hf) ⟨ψ, hψ⟩ ⟨φ n, hφ n⟩).symm]
     _ ≤ ‖ξ‖ * ‖φ n‖ := norm_inner_le_norm ξ (φ n)
 
-lemma mulOperator_adjoint_eq_conj {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (𝓜 f)† = 𝓜 (conj ∘ f) := by
-  have hFA : (𝓜 f).IsFormalAdjoint (𝓜 (conj ∘ f)) := by
+lemma mulOperator_adjoint_eq_conj {μ : Measure (Space d)} [IsFiniteMeasureOnCompacts μ]
+    {f : Space d → ℂ} (hf : AEStronglyMeasurable f μ) :
+    (𝓜 μ f)† = 𝓜 μ (conj ∘ f) := by
+  have hFA : (𝓜 μ f).IsFormalAdjoint (𝓜 μ (conj ∘ f)) := by
     intro ψ φ
     refine integral_congr_ae ?_
     filter_upwards [mulOperator_apply_ae ψ, mulOperator_apply_ae φ] with x h₁ h₂
@@ -292,30 +301,33 @@ lemma mulOperator_adjoint_eq_conj {f : Space d → ℂ} (hf : AEStronglyMeasurab
 ### C.1. Self-adjoint
 -/
 
-lemma mulOperator_isSelfAdjoint_ofReal
-    {f : Space d → ℂ} (hf : AEStronglyMeasurable f) (hf' : conj ∘ f = f) :
-    IsSelfAdjoint (𝓜 f) := by
+lemma mulOperator_isSelfAdjoint_ofReal {μ : Measure (Space d)} [IsFiniteMeasureOnCompacts μ]
+    {f : Space d → ℂ} (hf : AEStronglyMeasurable f μ) (hf' : conj ∘ f = f) :
+    IsSelfAdjoint (𝓜 μ f) := by
   rw [isSelfAdjoint_def, mulOperator_adjoint_eq_conj hf, hf']
 
 /-!
 ## D. Closable & unbounded
 -/
 
-lemma mulOperator_isClosable {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (𝓜 f).IsClosable := by
+lemma mulOperator_isClosable {μ : Measure (Space d)} [IsFiniteMeasureOnCompacts μ]
+    {f : Space d → ℂ} (hf : AEStronglyMeasurable f μ) :
+    (𝓜 μ f).IsClosable := by
   refine isClosable_of_exists_dense_formalAdjoint (mulOperator_hasDenseDomain hf) ?_
-  exact ⟨𝓜 (conj ∘ f), mulOperator_hasDenseDomain (by measurability),
+  exact ⟨𝓜 μ (conj ∘ f), mulOperator_hasDenseDomain (by measurability),
     mulOperator_adjoint_eq_conj hf ▸ adjoint_isFormalAdjoint (mulOperator_hasDenseDomain hf)⟩
 
-lemma mulOperator_isUnbounded {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (𝓜 f).IsUnbounded :=
+lemma mulOperator_isUnbounded {μ : Measure (Space d)} [IsFiniteMeasureOnCompacts μ]
+    {f : Space d → ℂ} (hf : AEStronglyMeasurable f μ) :
+    (𝓜 μ f).IsUnbounded :=
   ⟨mulOperator_hasDenseDomain hf, mulOperator_isClosable hf⟩
 
 /-!
 ## E. Composition
 -/
 
-lemma mulOperator_compRestricted_le (f g : Space d → ℂ) : 𝓜 f ∘ᵣ 𝓜 g ≤ 𝓜 (f • g) := by
+lemma mulOperator_compRestricted_le (μ : Measure (Space d)) (f g : Space d → ℂ) :
+    𝓜 μ f ∘ᵣ 𝓜 μ g ≤ 𝓜 μ (f • g) := by
   constructor
   · intro ψ hψ
     obtain ⟨hψ, hgψ⟩ := mem_compRestricted_domain_iff.mp hψ
@@ -326,12 +338,13 @@ lemma mulOperator_compRestricted_le (f g : Space d → ℂ) : 𝓜 f ∘ᵣ 𝓜
     apply ext_iff.mpr
     obtain ⟨hψ, hgψ⟩ := mem_compRestricted_domain_iff.mp ψ.2
     filter_upwards [mulOperator_apply_ae φ, mulOperator_apply_ae ⟨ψ, hψ⟩,
-      mulOperator_apply_ae ⟨𝓜 g ⟨ψ, hψ⟩, hgψ⟩]
+      mulOperator_apply_ae ⟨𝓜 μ g ⟨ψ, hψ⟩, hgψ⟩]
     simp_all [mul_assoc]
 
-lemma mulOperator_compRestricted_eq (f : Space d → ℂ) {g : Space d → ℂ} (h : (𝓜 g).domain = ⊤) :
-    𝓜 f ∘ᵣ 𝓜 g = 𝓜 (f • g) := by
-  have hle := mulOperator_compRestricted_le f g
+lemma mulOperator_compRestricted_eq
+    {μ : Measure (Space d)} (f : Space d → ℂ) {g : Space d → ℂ} (h : (𝓜 μ g).domain = ⊤) :
+    𝓜 μ f ∘ᵣ 𝓜 μ g = 𝓜 μ (f • g) := by
+  have hle := mulOperator_compRestricted_le μ f g
   refine eq_of_le_of_domain_eq hle ?_
   refine eq_of_le_of_ge hle.1 fun ψ hψ ↦ ?_
   refine mem_compRestricted_domain_iff.mpr ⟨h ▸ Submodule.mem_top, ?_⟩
@@ -343,10 +356,10 @@ lemma mulOperator_compRestricted_eq (f : Space d → ℂ) {g : Space d → ℂ} 
 ## F. Spectrum
 -/
 
-TODO "Prove that the spectrum of the multiplication operator `𝓜 f`
-  is the 'essential range' of `f`."
+TODO "Prove that the spectrum of the multiplication operator `𝓜 μ f`
+  is the 'μ-essential range' of `f`."
 
-TODO "Prove that the spectrum of the multiplication operator `𝓜 f`
+TODO "Prove that the spectrum of the multiplication operator `𝓜 μ f`
   is the closure of `f.range` for continuous `f`."
 
 end

--- a/Physlib/QuantumMechanics/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/Operators/Multiplication.lean
@@ -70,7 +70,10 @@ def mulOperator (μ : Measure (Space d)) (f : Space d → ℂ) :
       refine (hψ.add hφ).ae_eq ?_
       filter_upwards [coeFn_add ψ φ] with x h
       simp [mul_add, h]
-    zero_mem' := by sorry
+    zero_mem' := by
+      refine MemHS.zero.ae_eq ?_
+      filter_upwards [AEEqFun.coeFn_zero (μ := μ) (β := ℂ)]
+      simp_all
     smul_mem' c ψ hψ := by
       refine (hψ.const_smul c).ae_eq ?_
       filter_upwards [coeFn_smul c ψ] with x h

--- a/Physlib/QuantumMechanics/Operators/Position.lean
+++ b/Physlib/QuantumMechanics/Operators/Position.lean
@@ -58,7 +58,7 @@ open SchwartzMap
 open SpaceDHilbertSpace
 open SchwartzSubmodule PolyBddSchwartzSubmodule
 
-variable {d : ℕ} (i : Fin d)
+variable {d : ℕ} (μ : Measure (Space d)) (i : Fin d)
 
 /-!
 ## A. Schwartz operators
@@ -331,20 +331,20 @@ open Space
 -/
 
 /-- The operator on `SpaceDHilbertSpace d` acting by multiplication by `fun x ↦ xᵢ`. -/
-def positionOperator : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d :=
-  𝓜 (Complex.ofRealCLM ∘L Space.coordCLM i)
+def positionOperator : SpaceDHilbertSpace d μ →ₗ.[ℂ] SpaceDHilbertSpace d μ :=
+  𝓜 μ (Complex.ofRealCLM ∘L Space.coordCLM i)
 
 @[inherit_doc positionOperator]
 notation "𝓧" => positionOperator
 
-lemma positionOperator_hasDenseDomain : (𝓧 i).HasDenseDomain :=
+lemma positionOperator_hasDenseDomain : (𝓧 μ i).HasDenseDomain :=
   mulOperator_hasDenseDomain (by fun_prop)
 
-lemma positionOperator_isSelfAdjoint : IsSelfAdjoint (𝓧 i) :=
+lemma positionOperator_isSelfAdjoint [IsFiniteMeasureOnCompacts μ] : IsSelfAdjoint (𝓧 μ i) :=
   mulOperator_isSelfAdjoint_ofReal (by fun_prop) (by ext; simp)
 
-lemma positionOperator_isUnbounded : (𝓧 i).IsUnbounded :=
-  LinearPMap.IsSelfAdjoint.isUnbounded (positionOperator_isSelfAdjoint i)
+lemma positionOperator_isUnbounded [IsFiniteMeasureOnCompacts μ] : (𝓧 μ i).IsUnbounded :=
+  LinearPMap.IsSelfAdjoint.isUnbounded (positionOperator_isSelfAdjoint μ i)
 
 /-!
 ### B.2. Radius powers (regularized)
@@ -352,46 +352,44 @@ lemma positionOperator_isUnbounded : (𝓧 i).IsUnbounded :=
 
 /-- The operator on `SpaceDHilbertSpace d` acting by multiplication by
   `fun x ↦ (‖x‖² + ε²)^(s/2)`. -/
-def radiusRegPowOperator (ε : ℝˣ) (s : ℝ) : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d :=
-  𝓜 (Complex.ofReal ∘ normRegularizedPow d ε s)
+def radiusRegPowOperator (ε : ℝˣ) (s : ℝ) :
+    SpaceDHilbertSpace d μ →ₗ.[ℂ] SpaceDHilbertSpace d μ :=
+  𝓜 μ (Complex.ofReal ∘ normRegularizedPow d ε s)
 
 @[inherit_doc radiusRegPowOperator]
 notation "𝓡₀" => radiusRegPowOperator
 
-@[inherit_doc radiusRegPowOperator]
-notation "𝓡₀[" d' "]" => radiusRegPowOperator (d := d')
-
-lemma radiusRegPowOperator_hasDenseDomain (ε : ℝˣ) (s : ℝ) : (𝓡₀[d] ε s).HasDenseDomain :=
+lemma radiusRegPowOperator_hasDenseDomain (ε : ℝˣ) (s : ℝ) : (𝓡₀ μ ε s).HasDenseDomain :=
   mulOperator_hasDenseDomain (by fun_prop)
 
-lemma radiusRegPowOperator_isSelfAdjoint (ε : ℝˣ) (s : ℝ) : IsSelfAdjoint (𝓡₀[d] ε s) :=
+lemma radiusRegPowOperator_isSelfAdjoint [IsFiniteMeasureOnCompacts μ] (ε : ℝˣ) (s : ℝ) :
+    IsSelfAdjoint (𝓡₀ μ ε s) :=
   mulOperator_isSelfAdjoint_ofReal (by fun_prop) (by ext; simp)
 
-lemma radiusRegPowOperator_isUnbounded (ε : ℝˣ) (s : ℝ) : (𝓡₀[d] ε s).IsUnbounded :=
-  LinearPMap.IsSelfAdjoint.isUnbounded (radiusRegPowOperator_isSelfAdjoint ε s)
+lemma radiusRegPowOperator_isUnbounded [IsFiniteMeasureOnCompacts μ] (ε : ℝˣ) (s : ℝ) :
+    (𝓡₀ μ ε s).IsUnbounded :=
+  LinearPMap.IsSelfAdjoint.isUnbounded (radiusRegPowOperator_isSelfAdjoint μ ε s)
 
 /-!
 ### B.3. Radius powers
 -/
 
 /-- The operator on `SpaceDHilbertSpace d` acting by multiplication by `fun x ↦ ‖x‖ˢ`. -/
-def radiusPowOperator (s : ℝ) : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d :=
-  𝓜 (Complex.ofReal ∘ fun x ↦ ‖x‖ ^ s)
+def radiusPowOperator (s : ℝ) : SpaceDHilbertSpace d μ →ₗ.[ℂ] SpaceDHilbertSpace d μ :=
+  𝓜 μ (Complex.ofReal ∘ fun x ↦ ‖x‖ ^ s)
 
 @[inherit_doc radiusPowOperator]
 notation "𝓡" => radiusPowOperator
 
-@[inherit_doc radiusPowOperator]
-notation "𝓡[" d' "]" => radiusPowOperator (d := d')
-
-lemma radiusPowOperator_hasDenseDomain (s : ℝ) : (𝓡[d] s).HasDenseDomain :=
+lemma radiusPowOperator_hasDenseDomain (s : ℝ) : (𝓡 μ s).HasDenseDomain :=
   mulOperator_hasDenseDomain (Measurable.aestronglyMeasurable (by fun_prop))
 
-lemma radiusPowOperator_isSelfAdjoint (s : ℝ) : IsSelfAdjoint (𝓡[d] s) :=
+lemma radiusPowOperator_isSelfAdjoint [IsFiniteMeasureOnCompacts μ] (s : ℝ) :
+    IsSelfAdjoint (𝓡 μ s) :=
   mulOperator_isSelfAdjoint_ofReal (Measurable.aestronglyMeasurable (by fun_prop)) (by ext; simp)
 
-lemma radiusPowOperator_isUnbounded (s : ℝ) : (𝓡[d] s).IsUnbounded :=
-  LinearPMap.IsSelfAdjoint.isUnbounded (radiusPowOperator_isSelfAdjoint s)
+lemma radiusPowOperator_isUnbounded [IsFiniteMeasureOnCompacts μ] (s : ℝ) : (𝓡 μ s).IsUnbounded :=
+  LinearPMap.IsSelfAdjoint.isUnbounded (radiusPowOperator_isSelfAdjoint μ s)
 
 open Complex
 
@@ -402,16 +400,16 @@ private lemma add_floor_toNat_pos_aux (d : ℕ) (s : ℝ) :
   have hn₂ : (n : ℝ) ≤ n.toNat := Int.cast_le.mpr (Int.self_le_toNat _)
   linarith
 
-lemma radiusPowLM_apply_polyBddSchwartz_memHS {d : ℕ} {s : ℝ}
-    (ψ : PolyBddSchwartzSubmodule d ⌊1 - d / 2 - s⌋.toNat) :
-    MemHS (𝐫[d] s (polyBddSchwartzEquiv.symm ψ)) :=
-  let f := polyBddSchwartzEquiv.symm ψ
+lemma radiusPowLM_apply_polyBddSchwartz_memHS
+    {d : ℕ} {s : ℝ} (ψ : PolyBddSchwartzSubmodule d ⌊1 - d / 2 - s⌋.toNat) :
+    MemHS (𝐫[d] s ((polyBddSchwartzEquiv volume).symm ψ)) :=
+  let f := (polyBddSchwartzEquiv volume).symm ψ
   radiusPowLM_apply_memHS s f.1 ⌊1 - d / 2 - s⌋.toNat f.2 (add_floor_toNat_pos_aux d s)
 
 lemma radiusPowOperator_domain_ge {d : ℕ} (s : ℝ) :
-    PolyBddSchwartzSubmodule d ⌊1 - d / 2 - s⌋.toNat ≤ (radiusPowOperator s).domain := by
+    PolyBddSchwartzSubmodule d ⌊1 - d / 2 - s⌋.toNat ≤ (radiusPowOperator volume s).domain := by
   intro ψ hψ
-  let f := polyBddSchwartzEquiv.symm ⟨ψ, hψ⟩
+  let f := (polyBddSchwartzEquiv volume).symm ⟨ψ, hψ⟩
   apply mem_mulOperator_domain_iff.mpr
   refine MemHS.ae_eq (f := 𝐫 s f.1) ?_ ?_
   · filter_upwards [polyBddSchwartzEquiv_coe_ae f]

--- a/Physlib/QuantumMechanics/SpaceDQuantumSystem.lean
+++ b/Physlib/QuantumMechanics/SpaceDQuantumSystem.lean
@@ -119,9 +119,9 @@ lemma potentialCLM_apply_apply
 
 /-- The potential operator as a self-adjoint, unbounded multiplication operator
   with domain `{ψ ∈ Q.HS | Q.potential • ψ ∈ Q.HS}`. -/
-def potentialOperator : Q.HS →ₗ.[ℂ] Q.HS := 𝓜 (ofReal ∘ Q.potential)
+def potentialOperator : Q.HS →ₗ.[ℂ] Q.HS := 𝓜 volume (ofReal ∘ Q.potential)
 
-lemma potentialOperator_eq : Q.potentialOperator = 𝓜 (ofReal ∘ Q.potential) := rfl
+lemma potentialOperator_eq : Q.potentialOperator = 𝓜 volume (ofReal ∘ Q.potential) := rfl
 
 lemma potentialOperator_isSelfAdjoint (h_AESM : AEStronglyMeasurable Q.potential) :
     IsSelfAdjoint Q.potentialOperator :=
@@ -129,7 +129,7 @@ lemma potentialOperator_isSelfAdjoint (h_AESM : AEStronglyMeasurable Q.potential
 
 lemma potentialOperator_domain_ge (h_HTG : Q.potential.HasTemperateGrowth) :
     SchwartzSubmodule Q.d ≤ Q.potentialOperator.domain :=
-  mulOperator_domain_ge_of_hasTemperateGrowth (by fun_prop)
+  mulOperator_domain_ge_of_hasTemperateGrowth (by fun_prop) volume
 
 /-!
 ### B.3. Hamiltonian


### PR DESCRIPTION
A follow-up to #1380.
This PR generalizes `SchwartzSubmodule`, `PolyBddSchwartzSubmodule`, `mulOperator` and `positionOperator` to take any `Space d` measure. The assumptions `HasTemperateGrowth μ`, `IsOpenPosMeasure μ` and `IsFiniteMeasureOnCompacts μ` are needed in various lemmas.