### PR TITLE
feat(QuantumMechanics): add `FreeParticle` and `InfiniteSquareWell`

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -276,6 +276,7 @@ public import Physlib.QFT.QED.AnomalyCancellation.Permutations
 public import Physlib.QFT.QED.AnomalyCancellation.Sorts
 public import Physlib.QFT.QED.AnomalyCancellation.VectorLike
 public import Physlib.QuantumMechanics.FiniteTarget
+public import Physlib.QuantumMechanics.FreeParticle.Basic
 public import Physlib.QuantumMechanics.HarmonicOscillator.Basic
 public import Physlib.QuantumMechanics.HarmonicOscillator.OneDimension.Basic
 public import Physlib.QuantumMechanics.HarmonicOscillator.OneDimension.Completeness
@@ -293,6 +294,7 @@ public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.PolyBddSchwartzSubmo
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
 public import Physlib.QuantumMechanics.Hydrogen.Basic
 public import Physlib.QuantumMechanics.Hydrogen.LaplaceRungeLenzVector
+public import Physlib.QuantumMechanics.InfiniteSquareWell.Basic
 public import Physlib.QuantumMechanics.Operators.AngularMomentum
 public import Physlib.QuantumMechanics.Operators.Commutation
 public import Physlib.QuantumMechanics.Operators.Covariance

--- a/Physlib/QuantumMechanics/FreeParticle/Basic.lean
+++ b/Physlib/QuantumMechanics/FreeParticle/Basic.lean
@@ -37,14 +37,12 @@ noncomputable section
 namespace QuantumMechanics
 
 /-- A free, spinless quantum particle with mass `m > 0` in `Space d`. -/
-structure FreeParticle where
-  /-- The number of spatial dimensions. -/
-  d : ℕ
+structure FreeParticle (d : ℕ) where
   /-- The mass (positive). -/
   m : ℝ
   hm : 0 < m
 
-variable {Q : FreeParticle}
+variable {d : ℕ} (Q : FreeParticle d)
 
 namespace FreeParticle
 
@@ -66,7 +64,7 @@ lemma m_ne_zero : Q.m ≠ 0 := Q.hm.ne'
 -/
 
 /-- The Hilbert space for the free particle. -/
-abbrev HS := SpaceDHilbertSpace Q.d
+abbrev HS (_ : FreeParticle d) : Type _ := SpaceDHilbertSpace d
 
 /-!
 ## C. Hamiltonian

--- a/Physlib/QuantumMechanics/FreeParticle/Basic.lean
+++ b/Physlib/QuantumMechanics/FreeParticle/Basic.lean
@@ -5,6 +5,7 @@ Authors: Gregory J. Loges
 -/
 module
 
+public import Physlib.Meta.Informal.Basic
 public import Physlib.QuantumMechanics.Operators.Momentum
 public import Physlib.QuantumMechanics.QuantumSystem.Basic
 /-!
@@ -19,6 +20,8 @@ public import Physlib.QuantumMechanics.QuantumSystem.Basic
 
 - A. Basic properties
 - B. Hilbert space
+- C. Hamiltonian
+- D. As a quantum system
 
 ## iv. References
 
@@ -59,6 +62,28 @@ lemma m_ne_zero : Q.m ≠ 0 := Q.hm.ne'
 -/
 
 abbrev HS := SpaceDHilbertSpace Q.d
+
+/-!
+## C. Hamiltonian
+-/
+
+/-- The Hamiltonian, `p²/(2m)`. -/
+def hamiltonian : Q.HS →ₗ.[ℂ] Q.HS := (2 * Q.m)⁻¹ • momentumSqOperator
+
+/-- The Hamiltonian for the free particle is essentially self-adjoint.
+  This follows immediately from the ess. self-adjointness of the momentum-square operator. -/
+informal_lemma hamiltonian_essentially_self_adjoint where
+  deps := [``FreeParticle]
+  tag := "QM-FP-hamESA"
+
+/-!
+## D. As a quantum system
+-/
+
+/-- The free particle as a quantum system (self-adjoint Hamiltonian acting on a Hilbert space). -/
+informal_definition toQuantumSystem where
+  deps := [``FreeParticle]
+  tag := "QM-FP-sys"
 
 end FreeParticle
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/FreeParticle/Basic.lean
+++ b/Physlib/QuantumMechanics/FreeParticle/Basic.lean
@@ -64,6 +64,7 @@ lemma m_ne_zero : Q.m ≠ 0 := Q.hm.ne'
 -/
 
 /-- The Hilbert space for the free particle. -/
+@[nolint unusedArguments]
 abbrev HS (_ : FreeParticle d) : Type _ := SpaceDHilbertSpace d
 
 /-!

--- a/Physlib/QuantumMechanics/FreeParticle/Basic.lean
+++ b/Physlib/QuantumMechanics/FreeParticle/Basic.lean
@@ -65,6 +65,7 @@ lemma m_ne_zero : Q.m ≠ 0 := Q.hm.ne'
 ## B. Hilbert space
 -/
 
+/-- The Hilbert space for the free particle. -/
 abbrev HS := SpaceDHilbertSpace Q.d
 
 /-!

--- a/Physlib/QuantumMechanics/FreeParticle/Basic.lean
+++ b/Physlib/QuantumMechanics/FreeParticle/Basic.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 Gregory J. Loges. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gregory J. Loges
+-/
+module
+
+public import Physlib.QuantumMechanics.Operators.Momentum
+public import Physlib.QuantumMechanics.QuantumSystem.Basic
+/-!
+
+# The free particle on `Space d`
+
+## i. Overview
+
+## ii. Key results
+
+## iii. Table of contents
+
+- A. Basic properties
+- B. Hilbert space
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+noncomputable section
+namespace QuantumMechanics
+
+/-- A free, spinless quantum particle with mass `m > 0` in `Space d`. -/
+structure FreeParticle where
+  /-- The number of spatial dimensions. -/
+  d : ℕ
+  /-- The mass (positive). -/
+  m : ℝ
+  hm : 0 < m
+
+variable {Q : FreeParticle}
+
+namespace FreeParticle
+
+/-!
+## A. Basic properties
+-/
+
+@[simp]
+lemma m_pos : 0 < Q.m := Q.hm
+
+@[simp]
+lemma m_nonneg : 0 ≤ Q.m := Q.hm.le
+
+@[simp]
+lemma m_ne_zero : Q.m ≠ 0 := Q.hm.ne'
+
+/-!
+## B. Hilbert space
+-/
+
+abbrev HS := SpaceDHilbertSpace Q.d
+
+end FreeParticle
+end QuantumMechanics
+end

--- a/Physlib/QuantumMechanics/FreeParticle/Basic.lean
+++ b/Physlib/QuantumMechanics/FreeParticle/Basic.lean
@@ -14,6 +14,10 @@ public import Physlib.QuantumMechanics.QuantumSystem.Basic
 
 ## i. Overview
 
+The free quantum particle is one of the simplest quantum systems.
+States for a particle of mass `m` are elements of `SpaceDHilbertSpace d` and evolve according
+to the Hamiltonian `p²/2m` with no potential.
+
 ## ii. Key results
 
 ## iii. Table of contents

--- a/Physlib/QuantumMechanics/InfiniteSquareWell/Basic.lean
+++ b/Physlib/QuantumMechanics/InfiniteSquareWell/Basic.lean
@@ -15,17 +15,18 @@ public import Physlib.QuantumMechanics.QuantumSystem.Basic
 ## i. Overview
 
 The particle in an infinite square well is one of the simplest quantum systems.
-The domain is an axis-aligned cuboid (box) and energy eigenstates are (products of) trigonometric
-functions satisfying appropriate boundary conditions.
+The domain is an axis-aligned cuboid (the well) and energy eigenstates are (products of)
+trigonometric functions satisfying appropriate boundary conditions.
 
 ## ii. Key results
 
 ## iii. Table of contents
 
 - A. Basic properties
-- B. Hilbert space
-- C. Hamiltonian
-- D. As a quantum system
+- B. Domain
+- C. Hilbert space
+- D. Hamiltonian
+- E. As a quantum system
 
 ## iv. References
 
@@ -40,7 +41,7 @@ open Set MeasureTheory
 
 /-- A spinless quantum particle with mass `m > 0` confined to a cuboid in `Space d`.
 
-  The bounds of the cuboid are specified by two functions `lower upper : Fin d → ℝ`
+  The bounds of the well are specified by two functions `lower upper : Fin d → ℝ`
   satisfying `∀ i, lower i < upper i`. -/
 structure InfiniteSquareWell where
   /-- The number of spatial dimensions. -/
@@ -48,11 +49,11 @@ structure InfiniteSquareWell where
   /-- The mass (positive). -/
   m : ℝ
   hm : 0 < m
-  /-- The lower bounds of the box. -/
+  /-- The lower bounds of the well. -/
   lower : Fin d → ℝ
-  /-- The upper bounds of the box. -/
+  /-- The upper bounds of the well. -/
   upper : Fin d → ℝ
-  /-- The box is non-empty. -/
+  /-- The well is a non-empty set. -/
   h_bounds : ∀ i, lower i < upper i
 
 variable {Q : InfiniteSquareWell}
@@ -73,18 +74,18 @@ lemma m_nonneg : 0 ≤ Q.m := Q.hm.le
 lemma m_ne_zero : Q.m ≠ 0 := Q.hm.ne'
 
 /-!
-## B. The domain
+## B. Domain
 -/
 
 /-- The domain of the infinite square well as a Cartesian product of closed intervals. -/
-def box : Set (Space Q.d) := Space.val ⁻¹' Icc Q.lower Q.upper
+def well : Set (Space Q.d) := Space.val ⁻¹' Icc Q.lower Q.upper
 
 /-!
 ## C. Hilbert space
 -/
 
 /-- The measure associated with the domain of the infinite square well. -/
-def measure : Measure (Space Q.d) := volume.restrict Q.box
+def measure : Measure (Space Q.d) := volume.restrict Q.well
 
 /-- The Hilbert space for the infinite square well. -/
 abbrev HS := SpaceDHilbertSpace Q.d Q.measure

--- a/Physlib/QuantumMechanics/InfiniteSquareWell/Basic.lean
+++ b/Physlib/QuantumMechanics/InfiniteSquareWell/Basic.lean
@@ -14,6 +14,10 @@ public import Physlib.QuantumMechanics.QuantumSystem.Basic
 
 ## i. Overview
 
+The particle in an infinite square well is one of the simplest quantum systems.
+The domain is an axis-aligned cuboid (box) and energy eigenstates are (products of) trigonometric
+functions satisfying appropriate boundary conditions.
+
 ## ii. Key results
 
 ## iii. Table of contents
@@ -34,7 +38,10 @@ namespace QuantumMechanics
 
 open Set MeasureTheory
 
-/-- A spinless quantum particle with mass `m > 0` confined to a cuboid in `Space d`. -/
+/-- A spinless quantum particle with mass `m > 0` confined to a cuboid in `Space d`.
+
+  The bounds of the cuboid are specified by two functions `lower upper : Fin d → ℝ`
+  satisfying `∀ i, lower i < upper i`. -/
 structure InfiniteSquareWell where
   /-- The number of spatial dimensions. -/
   d : ℕ
@@ -46,7 +53,7 @@ structure InfiniteSquareWell where
   /-- The upper bounds of the box. -/
   upper : Fin d → ℝ
   /-- The box is non-empty. -/
-  hbounds : ∀ i, lower i < upper i
+  h_bounds : ∀ i, lower i < upper i
 
 variable {Q : InfiniteSquareWell}
 

--- a/Physlib/QuantumMechanics/InfiniteSquareWell/Basic.lean
+++ b/Physlib/QuantumMechanics/InfiniteSquareWell/Basic.lean
@@ -5,6 +5,7 @@ Authors: Gregory J. Loges
 -/
 module
 
+public import Physlib.Meta.Informal.Basic
 public import Physlib.QuantumMechanics.Operators.Momentum
 public import Physlib.QuantumMechanics.QuantumSystem.Basic
 /-!
@@ -20,6 +21,7 @@ public import Physlib.QuantumMechanics.QuantumSystem.Basic
 - A. Basic properties
 - B. Hilbert space
 - C. Hamiltonian
+- D. As a quantum system
 
 ## iv. References
 
@@ -79,6 +81,32 @@ def measure : Measure (Space Q.d) := volume.restrict Q.box
 
 /-- The Hilbert space for the infinite square well. -/
 abbrev HS := SpaceDHilbertSpace Q.d Q.measure
+
+/-!
+## D. Hamiltonian
+-/
+
+/-- The Hamiltonian for the infinite square well is `(2m)⁻¹momentumSqOperator` with respect
+  to `InfiniteSquareWell.measure`. This requires first generalizing `momentumSqOperator`
+  to `Space d` measures other than `volume`. -/
+informal_definition hamiltonian where
+  deps := [``InfiniteSquareWell]
+  tag := "QM-ISW-ham"
+
+/-- The Hamiltonian for the infinite square well is essentially self-adjoint. -/
+informal_lemma hamiltonian_essentially_self_adjoint where
+  deps := [``InfiniteSquareWell]
+  tag := "QM-ISW-hamESA"
+
+/-!
+## E. As a quantum system
+-/
+
+/-- The particle in an infinite square well as a quantum system
+  (self-adjoint Hamiltonian acting on a Hilbert space). -/
+informal_definition toQuantumSystem where
+  deps := [``InfiniteSquareWell]
+  tag := "QM-ISW-sys"
 
 end InfiniteSquareWell
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/InfiniteSquareWell/Basic.lean
+++ b/Physlib/QuantumMechanics/InfiniteSquareWell/Basic.lean
@@ -43,9 +43,7 @@ open Set MeasureTheory
 
   The bounds of the well are specified by two functions `lower upper : Fin d → ℝ`
   satisfying `∀ i, lower i < upper i`. -/
-structure InfiniteSquareWell where
-  /-- The number of spatial dimensions. -/
-  d : ℕ
+structure InfiniteSquareWell (d : ℕ) where
   /-- The mass (positive). -/
   m : ℝ
   hm : 0 < m
@@ -56,7 +54,7 @@ structure InfiniteSquareWell where
   /-- The well is a non-empty set. -/
   h_bounds : ∀ i, lower i < upper i
 
-variable {Q : InfiniteSquareWell}
+variable {d : ℕ} (Q : InfiniteSquareWell d)
 
 namespace InfiniteSquareWell
 
@@ -78,17 +76,17 @@ lemma m_ne_zero : Q.m ≠ 0 := Q.hm.ne'
 -/
 
 /-- The domain of the infinite square well as a Cartesian product of closed intervals. -/
-def well : Set (Space Q.d) := Space.val ⁻¹' Icc Q.lower Q.upper
+def well : Set (Space d) := Space.val ⁻¹' Icc Q.lower Q.upper
 
 /-!
 ## C. Hilbert space
 -/
 
 /-- The measure associated with the domain of the infinite square well. -/
-def measure : Measure (Space Q.d) := volume.restrict Q.well
+def measure : Measure (Space d) := volume.restrict Q.well
 
 /-- The Hilbert space for the infinite square well. -/
-abbrev HS := SpaceDHilbertSpace Q.d Q.measure
+abbrev HS : Type _ := SpaceDHilbertSpace d Q.measure
 
 /-!
 ## D. Hamiltonian

--- a/Physlib/QuantumMechanics/InfiniteSquareWell/Basic.lean
+++ b/Physlib/QuantumMechanics/InfiniteSquareWell/Basic.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 Gregory J. Loges. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gregory J. Loges
+-/
+module
+
+public import Physlib.QuantumMechanics.Operators.Momentum
+public import Physlib.QuantumMechanics.QuantumSystem.Basic
+/-!
+
+# The infinite square well
+
+## i. Overview
+
+## ii. Key results
+
+## iii. Table of contents
+
+- A. Basic properties
+- B. Hilbert space
+- C. Hamiltonian
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+noncomputable section
+namespace QuantumMechanics
+
+open Set MeasureTheory
+
+/-- A spinless quantum particle with mass `m > 0` confined to a cuboid in `Space d`. -/
+structure InfiniteSquareWell where
+  /-- The number of spatial dimensions. -/
+  d : ℕ
+  /-- The mass (positive). -/
+  m : ℝ
+  hm : 0 < m
+  /-- The lower bounds of the box. -/
+  lower : Fin d → ℝ
+  /-- The upper bounds of the box. -/
+  upper : Fin d → ℝ
+  /-- The box is non-empty. -/
+  hbounds : ∀ i, lower i < upper i
+
+variable {Q : InfiniteSquareWell}
+
+namespace InfiniteSquareWell
+
+/-!
+## A. Basic properties
+-/
+
+@[simp]
+lemma m_pos : 0 < Q.m := Q.hm
+
+@[simp]
+lemma m_nonneg : 0 ≤ Q.m := Q.hm.le
+
+@[simp]
+lemma m_ne_zero : Q.m ≠ 0 := Q.hm.ne'
+
+/-!
+## B. The domain
+-/
+
+/-- The domain of the infinite square well as a Cartesian product of closed intervals. -/
+def box : Set (Space Q.d) := Space.val ⁻¹' Icc Q.lower Q.upper
+
+/-!
+## C. Hilbert space
+-/
+
+/-- The measure associated with the domain of the infinite square well. -/
+def measure : Measure (Space Q.d) := volume.restrict Q.box
+
+/-- The Hilbert space for the infinite square well. -/
+abbrev HS := SpaceDHilbertSpace Q.d Q.measure
+
+end InfiniteSquareWell
+end QuantumMechanics
+end

--- a/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
+++ b/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
@@ -76,7 +76,7 @@ instance (Q : QuantumSystem) : CompleteSpace Q.HS := Q.instComplete
 /-!
 ## B. Creation from an essentially self-adjoint operator
 
-An operator is essentially self-adjoint has a unique self-adjoint extension
+An essentially self-adjoint operator has a unique self-adjoint extension
 (c.f. `IsEssentiallySelfAdjoint.unique_self_adjoint_extension`).
 For this reason, a quantum system can be uniquely associated to an e.s.a. Hamiltonian operator.
 -/

--- a/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
+++ b/Physlib/QuantumMechanics/QuantumSystem/Basic.lean
@@ -31,8 +31,9 @@ Definitions
 ## iii. Table of contents
 
 - A. Definition
-- B. Zero
-- C. Unitary equivalence
+- B. Creation from an essentially self-adjoint operator
+- C. Zero
+- D. Unitary equivalence
 
 ## iv. References
 
@@ -73,13 +74,26 @@ instance (Q : QuantumSystem) : InnerProductSpace ℂ Q.HS := Q.instInner
 instance (Q : QuantumSystem) : CompleteSpace Q.HS := Q.instComplete
 
 /-!
-## B. Zero
+## B. Creation from an essentially self-adjoint operator
+
+An operator is essentially self-adjoint has a unique self-adjoint extension
+(c.f. `IsEssentiallySelfAdjoint.unique_self_adjoint_extension`).
+For this reason, a quantum system can be uniquely associated to an e.s.a. Hamiltonian operator.
+-/
+
+/-- Create a quantum system from a Hamiltonian operator which is merely
+  essentially self-adjoint by taking its closure. -/
+def mk_esa {HS : Type*} [NormedAddCommGroup HS] [InnerProductSpace ℂ HS] [CompleteSpace HS]
+    {ℋ : HS →ₗ.[ℂ] HS} (hℋ : IsEssentiallySelfAdjoint ℋ) : QuantumSystem := ⟨HS, ℋ.closure, hℋ⟩
+
+/-!
+## C. Zero
 -/
 
 instance instZero : Zero QuantumSystem := ⟨EuclideanSpace ℂ (Fin 0), 0, adjoint_zero⟩
 
 /-!
-## C. Unitary equivalence
+## D. Unitary equivalence
 -/
 
 /-- The relation on quantum systems where `Q₁` is related to `Q₂` if there exists a linear isometry


### PR DESCRIPTION
Introduces two of the basic examples of non-relativistic quantum mechanics.
- Defines `FreeParticle` and `InfiniteSquareWell` as structures containing data specifying the systems.
- Adds informal results for the essential self-adjointness of the Hamiltonians. These depend on improving the definition of `momentumSqOperator` and proving it is ess. self-adjoint.
- Defines `QuantumSystem.mk_esa` for use in `FreeParticle.toQuantumSystem`, `InfiniteSquareWell.toQuantumSystem` and other examples to come. This creates a quantum system from the closure of an ess. self-adjoint operator (its unique self-adjoint extension).