### PR TITLE
feat(QuantumMechanics): add `DirichletSubmoduleOn`

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -290,6 +290,7 @@ public import Physlib.QuantumMechanics.HilbertSpaces.OneDimension.PlaneWaves
 public import Physlib.QuantumMechanics.HilbertSpaces.OneDimension.PositionStates
 public import Physlib.QuantumMechanics.HilbertSpaces.OneDimension.SchwartzSubmodule
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Basic
+public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.DirichletSubmodule
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Fourier
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.PolyBddSchwartzSubmodule
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Basic.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Basic.lean
@@ -21,16 +21,16 @@ square-integrable with respect to `μ`, i.e. `∫ x, ‖f x‖ ^ 2 ∂μ` is fin
 in the same equivalence class if they are `μ`-a.e. equal.
 
 Given `SpaceDHilbertSpace d μ` and `Ω : Set (Space d)`, the Hilbert space
-`SpaceDHilbertSpace d (μ.restrict Ω)` may be interpreted as the sub-Hilbert space
-consisting of those vectors with domain contained in `Ω`.
-The reason is that for each `f` in `SpaceDHilbertSpace d (μ.restrict Ω)` we have
+`SpaceDHilbertSpaceOn Ω μ ≔ SpaceDHilbertSpace d (μ.restrict Ω)` may be interpreted as the
+sub-Hilbert space consisting of those vectors with domain contained in `Ω`.
+The reason is that for each `f` in `SpaceDHilbertSpaceOn Ω μ` we have
 `f =ᵐ[μ.restrict Ω] Ω.indicator f`, namely the equivalence class of `f` always
 contains a representative which vanishes on the complement of `Ω`.
 The linear isometry `restrictIncl Ω` defined below describes this sub-Hilbert space relationship
 by mapping each `f` to this special representative in its equivalence class.
 
 Similarly, we may project `SpaceDHilbertSpace d μ` onto the sub-Hilbert space
-`SpaceDHilbertSpace d (μ.restrict Ω)` by enlarging the equivalence classes, essentially dropping
+`SpaceDHilbertSpaceOn Ω μ` by enlarging the equivalence classes, essentially dropping
 information about the functions on the complement of `Ω`.
 
 ## ii. Key results
@@ -40,20 +40,19 @@ information about the functions on the complement of `Ω`.
     sends each ket to its corresponding bra and _vice versa_.
 - `MemHS f μ` : The proposition capturing exactly when the function `f : Space d → ℂ` can be lifted
     to an element of the Hilbert space.
-- `subspaceProjection` : The projection of `SpaceDHilbertSpace d μ` onto a sub-Hilbert space
-    `SpaceDHilbertSpace d (μ.restrict Ω)`.
-- `restrictIncl Ω` : The linear isometry including `SpaceDHilbertSpace d (μ.restrict Ω)`
+- `subspaceProjection` : The projection of `SpaceDHilbertSpace d μ` onto `SpaceDHilbertSpaceOn Ω μ`.
+- `subsetIncl` : The linear isometry including `SpaceDHilbertSpaceOn Ω μ`
     as a sub-Hilbert space of `SpaceDHilbertspace d μ`.
 
 ## iii. Table of contents
 
-- A. Definition
-- B. Dual space
-- C. Membership
-- D. Construction of elements
-- E. Coersions
-- F. Sub-Hilbert spaces
-- G. Misc.
+- A. SpaceDHilbertSpace
+  - A.1. Dual space
+  - A.2. Membership
+  - A.3. Construction of elements
+  - A.4. Coersions
+  - A.5. Misc.
+- B. SpaceDHilbertSpaceOn
 
 ## iv. References
 
@@ -68,7 +67,7 @@ namespace QuantumMechanics
 open Function InnerProductSpace MeasureTheory Measure Set
 
 /-!
-## A. Definition
+## A. SpaceDHilbertSpace
 -/
 
 /-- The Hilbert space for single-particle quantum mechanics on `Space d` with measure `μ`
@@ -86,7 +85,7 @@ variable {ψ φ} in
 lemma ext_iff : ψ = φ ↔ ψ =ᵐ[μ] φ := Lp.ext_iff
 
 /-!
-## B. Dual space
+### A.1. Dual space
 -/
 
 /-- The anti-linear equivalence between `SpaceDHilbertSpace d μ` and its dual.
@@ -103,7 +102,7 @@ lemma toBra_symm_apply (f : StrongDual ℂ (SpaceDHilbertSpace d μ)) : ⟪toBra
   toDual_symm_apply
 
 /-!
-## C. Membership
+### A.2. Membership
 -/
 
 /-- For a function `f : Space d → ℂ`, the proposition `MemHS f μ` means that the function `f`
@@ -146,9 +145,8 @@ lemma MemHS.indicator {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (hf : MemHS 
     MemHS (Ω.indicator f) μ :=
   MemLp.indicator hΩ hf
 
-/-- If `f` is a member of the sub-Hilbert space `SpaceDHilbertSpace d (μ.restrict Ω)`
-  of `SpaceDHilbertSpace d μ` then the representative `Ω.indicator f` which vanishes outside `Ω`
-  is a member of the full Hilbert space. -/
+/-- If `f` is a member of the Hilbert space `SpaceDHilbertSpaceOn Ω μ` then the representative
+  `Ω.indicator f` which vanishes outside `Ω` is a member of `SpaceDHilbertSpace d μ`. -/
 lemma MemHS.indicator_of_restrict
     {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (hf : MemHS f (μ.restrict Ω)) :
     MemHS (Ω.indicator f) μ := by
@@ -158,7 +156,7 @@ lemma MemHS.indicator_of_restrict
   by_cases x ∈ Ω <;> simp_all
 
 /-!
-## D. Construction of elements
+### A.3. Construction of elements
 -/
 
 section
@@ -197,7 +195,7 @@ lemma inner_mk_mk : ⟪mk hf, mk hg⟫_ℂ = ∫ x, starRingEnd ℂ (f x) * g x 
 end
 
 /-!
-## E. Coersions
+### A.4. Coersions
 -/
 
 section
@@ -215,13 +213,35 @@ lemma coeFn_smul : ⇑(c • ψ) =ᵐ[μ] c • ψ := Lp.coeFn_smul _ _
 end
 
 /-!
-## F. Sub-Hilbert spaces
+### A.5. Misc.
 -/
 
-/-- The linear map projecting `SpaceDHilbertSpace d μ` onto the sub-Hilbert space
-  `SpaceDHilbertSpace d (μ.restrict Ω)`. -/
-def subspaceProjection (Ω : Set (Space d)) :
-    SpaceDHilbertSpace d μ →ₗ[ℂ] SpaceDHilbertSpace d (μ.restrict Ω) where
+open Filter in
+lemma tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq
+    {α : Type*} {l : Filter α} {ψ : α → SpaceDHilbertSpace d μ} :
+    Tendsto ψ l (nhds 0) ↔ Tendsto (fun a ↦ ∫⁻ x, ‖ψ a x‖ₑ ^ 2 ∂μ) l (nhds 0) := by
+  trans Tendsto (fun a ↦ (∫⁻ x, ‖ψ a x‖ₑ ^ 2 ∂μ) ^ (2⁻¹ : ℝ)) l (nhds 0)
+  · simp [tendsto_iff_edist_tendsto_0, edist_zero_right, Lp.enorm_def, eLpNorm, eLpNorm']
+  constructor <;> intro h
+  · apply Tendsto.ennrpow_const 2 at h
+    simp_all [← ENNReal.rpow_mul_natCast]
+  · apply Tendsto.ennrpow_const 2⁻¹ at h
+    simp_all
+
+/-!
+## B. SpaceDHilbertSpaceOn
+-/
+
+section
+
+abbrev SpaceDHilbertSpaceOn {d : ℕ} (Ω : Set (Space d)) (μ : Measure (Space d) := volume) :=
+  SpaceDHilbertSpace d (μ.restrict Ω)
+
+variable {d : ℕ} (Ω : Set (Space d)) (hΩ : MeasurableSet Ω) (μ : Measure (Space d))
+variable (ψ : SpaceDHilbertSpace d μ) (φ : SpaceDHilbertSpaceOn Ω μ)
+
+/-- The linear map projecting `SpaceDHilbertSpace d μ` onto `SpaceDHilbertSpaceOn Ω μ`. -/
+def subspaceProjection : SpaceDHilbertSpace d μ →ₗ[ℂ] SpaceDHilbertSpaceOn Ω μ where
   toFun ψ := mk ((memHS_coe ψ).restrict Ω)
   map_add' ψ φ := by
     rw [← mk_add, mk_eq_iff]
@@ -230,20 +250,20 @@ def subspaceProjection (Ω : Set (Space d)) :
     rw [← mk_const_smul, mk_eq_iff]
     exact (coeFn_smul c ψ).filter_mono ae_restrict_le
 
-lemma subspaceProjection_apply (Ω : Set (Space d)) (ψ : SpaceDHilbertSpace d μ) :
-    subspaceProjection Ω ψ =ᵐ[μ.restrict Ω] ψ :=
+variable {μ} in
+lemma subspaceProjection_apply : subspaceProjection Ω μ ψ =ᵐ[μ.restrict Ω] ψ :=
   coeFn_mk ((memHS_coe ψ).restrict Ω)
 
-lemma subspaceProjection_norm_le (Ω : Set (Space d)) (ψ : SpaceDHilbertSpace d μ) :
-    ‖subspaceProjection Ω ψ‖ ≤ ‖ψ‖ := by
+lemma subspaceProjection_norm_le : ‖subspaceProjection Ω μ ψ‖ ≤ ‖ψ‖ := by
   refine ENNReal.toReal_mono (Lp.eLpNorm_ne_top ψ) ?_
   refine (eLpNorm_congr_ae (subspaceProjection_apply Ω ψ)).trans_le ?_
   exact eLpNorm_mono_measure ψ restrict_le_self
 
-/-- The linear isometry including `SpaceDHilbertSpace d (μ.restrict Ω)` as a sub-Hilbert space of
-  `SpaceDHilbertSpace d μ` defined by mapping `ψ` to `Ω.indicator ψ`. -/
-def subspaceIncl {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
-    SpaceDHilbertSpace d (μ.restrict Ω) →ₗᵢ[ℂ] SpaceDHilbertSpace d μ where
+variable {Ω}
+
+/-- The linear isometry including `SpaceDHilbertSpaceOn Ω μ` as a sub-Hilbert space of
+  `SpaceDHilbertSpace d μ`, defined by mapping `ψ` to `Ω.indicator ψ`. -/
+def subspaceIncl : SpaceDHilbertSpaceOn Ω μ →ₗᵢ[ℂ] SpaceDHilbertSpace d μ where
   toFun ψ := mk ((memHS_coe ψ).indicator_of_restrict hΩ)
   map_add' ψ φ := by
     rw [← mk_add, mk_eq_iff, ← indicator_add']
@@ -257,46 +277,28 @@ def subspaceIncl {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
       _ = (eLpNorm (Ω.indicator ψ) 2 μ).toReal := congrArg _ (eLpNorm_congr_ae (coeFn_mk _))
       _ = ‖ψ‖ := congrArg _ (eLpNorm_indicator_eq_eLpNorm_restrict hΩ)
 
-lemma subspaceIncl_apply
-    {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (ψ : SpaceDHilbertSpace d (μ.restrict Ω)) :
-    subspaceIncl hΩ ψ =ᵐ[μ] Ω.indicator ψ :=
-  coeFn_mk ((memHS_coe ψ).indicator_of_restrict hΩ)
+variable {μ} in
+lemma subspaceIncl_apply : subspaceIncl hΩ μ φ =ᵐ[μ] Ω.indicator φ :=
+  coeFn_mk ((memHS_coe φ).indicator_of_restrict hΩ)
 
-lemma leftInverse_subspaceProjection {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
-    LeftInverse (subspaceProjection (μ := μ) Ω) (subspaceIncl hΩ) := by
+lemma leftInverse_subspaceProjection :
+    LeftInverse (subspaceProjection Ω μ) (subspaceIncl hΩ μ) := by
   intro ψ
   apply ext_iff.mpr
-  have h := subspaceProjection_apply Ω (subspaceIncl hΩ ψ)
+  have h := subspaceProjection_apply Ω (subspaceIncl hΩ μ ψ)
   rw [ae_eq_restrict_iff_indicator_ae_eq hΩ] at *
   filter_upwards [subspaceIncl_apply hΩ ψ, h] with x
   by_cases x ∈ Ω <;> simp_all
 
 @[simp]
-lemma subspaceProjection_subspaceIncl_apply
-    {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) (ψ : SpaceDHilbertSpace d (μ.restrict Ω)) :
-    subspaceProjection Ω (subspaceIncl hΩ ψ) = ψ :=
-  leftInverse_subspaceProjection hΩ ψ
+lemma subspaceProjection_subspaceIncl_apply : subspaceProjection Ω μ (subspaceIncl hΩ μ φ) = φ :=
+  leftInverse_subspaceProjection hΩ μ φ
 
-lemma subspaceProjection_surjective {Ω : Set (Space d)} (hΩ : MeasurableSet Ω) :
-    Surjective (subspaceProjection (μ := μ) Ω) :=
-  (leftInverse_subspaceProjection hΩ).surjective
+include hΩ in
+lemma subspaceProjection_surjective : Surjective (subspaceProjection Ω μ) :=
+  (leftInverse_subspaceProjection hΩ μ).surjective
 
-/-!
-## G. Misc.
--/
-
-open Filter
-
-lemma tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq
-    {α : Type*} {l : Filter α} {ψ : α → SpaceDHilbertSpace d μ} :
-    Tendsto ψ l (nhds 0) ↔ Tendsto (fun a ↦ ∫⁻ x, ‖ψ a x‖ₑ ^ 2 ∂μ) l (nhds 0) := by
-  trans Tendsto (fun a ↦ (∫⁻ x, ‖ψ a x‖ₑ ^ 2 ∂μ) ^ (2⁻¹ : ℝ)) l (nhds 0)
-  · simp [tendsto_iff_edist_tendsto_0, edist_zero_right, Lp.enorm_def, eLpNorm, eLpNorm']
-  constructor <;> intro h
-  · apply Tendsto.ennrpow_const 2 at h
-    simp_all [← ENNReal.rpow_mul_natCast]
-  · apply Tendsto.ennrpow_const 2⁻¹ at h
-    simp_all
+end
 
 end SpaceDHilbertSpace
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Basic.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Basic.lean
@@ -236,6 +236,9 @@ end SpaceDHilbertSpace
 TODO "Upgrade subspaceProjection to a ContinuousLinearMap when Lp.LpToLpOfMeasureLeSMul
   becomes available."
 
+/-- The Hilbert space for single-particle quantum mechanics on a set `Ω ⊆ Space d` with measure `μ`
+  is defined to be `SpaceDHilbertSpace d (μ.restrict Ω)`, the space of `μ`-a.e. equal on `Ω`
+  equivalence classes of functions `f : Space d → ℂ` for which `∫ x on Ω, ‖f x‖² ∂μ` is finite. -/
 abbrev SpaceDHilbertSpaceOn {d : ℕ} (Ω : Set (Space d)) (μ : Measure (Space d) := volume) :=
   SpaceDHilbertSpace d (μ.restrict Ω)
 

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Basic.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Basic.lean
@@ -228,14 +228,18 @@ lemma tendsto_zero_iff_tendsto_zero_lintegral_enorm_sq
   · apply Tendsto.ennrpow_const 2⁻¹ at h
     simp_all
 
+end SpaceDHilbertSpace
+
 /-!
 ## B. SpaceDHilbertSpaceOn
 -/
 
-section
-
 abbrev SpaceDHilbertSpaceOn {d : ℕ} (Ω : Set (Space d)) (μ : Measure (Space d) := volume) :=
   SpaceDHilbertSpace d (μ.restrict Ω)
+
+namespace SpaceDHilbertSpaceOn
+
+open SpaceDHilbertSpace
 
 variable {d : ℕ} (Ω : Set (Space d)) (hΩ : MeasurableSet Ω) (μ : Measure (Space d))
 variable (ψ : SpaceDHilbertSpace d μ) (φ : SpaceDHilbertSpaceOn Ω μ)
@@ -298,8 +302,7 @@ include hΩ in
 lemma subspaceProjection_surjective : Surjective (subspaceProjection Ω μ) :=
   (leftInverse_subspaceProjection hΩ μ).surjective
 
-end
+end SpaceDHilbertSpaceOn
 
-end SpaceDHilbertSpace
 end QuantumMechanics
 end

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Basic.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Basic.lean
@@ -23,15 +23,14 @@ in the same equivalence class if they are `μ`-a.e. equal.
 Given `SpaceDHilbertSpace d μ` and `Ω : Set (Space d)`, the Hilbert space
 `SpaceDHilbertSpaceOn Ω μ ≔ SpaceDHilbertSpace d (μ.restrict Ω)` may be interpreted as the
 sub-Hilbert space consisting of those vectors with domain contained in `Ω`.
-The reason is that for each `f` in `SpaceDHilbertSpaceOn Ω μ` we have
-`f =ᵐ[μ.restrict Ω] Ω.indicator f`, namely the equivalence class of `f` always
+The reason is that for each `ψ` in `SpaceDHilbertSpaceOn Ω μ` we have
+`ψ =ᵐ[μ.restrict Ω] Ω.indicator ψ`, namely the equivalence class of `ψ` always
 contains a representative which vanishes on the complement of `Ω`.
-The linear isometry `restrictIncl Ω` defined below describes this sub-Hilbert space relationship
-by mapping each `f` to this special representative in its equivalence class.
+The linear isometry `restrictIncl Ω μ` describes this sub-Hilbert space relationship
+by mapping each `ψ` to this special representative in its equivalence class.
 
-Similarly, we may project `SpaceDHilbertSpace d μ` onto the sub-Hilbert space
-`SpaceDHilbertSpaceOn Ω μ` by enlarging the equivalence classes, essentially dropping
-information about the functions on the complement of `Ω`.
+Similarly, we may project `SpaceDHilbertSpace d μ` onto `SpaceDHilbertSpaceOn Ω μ` by enlarging the
+equivalence classes, essentially dropping information about the functions on the complement of `Ω`.
 
 ## ii. Key results
 
@@ -41,7 +40,7 @@ information about the functions on the complement of `Ω`.
 - `MemHS f μ` : The proposition capturing exactly when the function `f : Space d → ℂ` can be lifted
     to an element of the Hilbert space.
 - `subspaceProjection` : The projection of `SpaceDHilbertSpace d μ` onto `SpaceDHilbertSpaceOn Ω μ`.
-- `subsetIncl` : The linear isometry including `SpaceDHilbertSpaceOn Ω μ`
+- `subspaceIncl` : The linear isometry including `SpaceDHilbertSpaceOn Ω μ`
     as a sub-Hilbert space of `SpaceDHilbertspace d μ`.
 
 ## iii. Table of contents

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Basic.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/Basic.lean
@@ -233,6 +233,9 @@ end SpaceDHilbertSpace
 ## B. SpaceDHilbertSpaceOn
 -/
 
+TODO "Upgrade subspaceProjection to a ContinuousLinearMap when Lp.LpToLpOfMeasureLeSMul
+  becomes available."
+
 abbrev SpaceDHilbertSpaceOn {d : ℕ} (Ω : Set (Space d)) (μ : Measure (Space d) := volume) :=
   SpaceDHilbertSpace d (μ.restrict Ω)
 

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/DirichletSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/DirichletSubmodule.lean
@@ -13,7 +13,8 @@ public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
 ## i. Overview
 
 In this module we define the Dirichlet submodule of `SpaceDHilbertSpaceOn Ω μ` consisting of
-equivalence classes of Schwartz maps which vanish on `frontier Ω`.
+equivalence classes of Schwartz maps which vanish on `frontier Ω`. The frontier (or boundary)
+of a set `Ω` contains all points whose neighborhoods always intersect with both `Ω` and `Ωᶜ`.
 
 These serve as a convenient dense domain for operators acting on wavefunctions satisfying
 homogeneous Dirichlet boundary conditions on `Ω`.

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/DirichletSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/DirichletSubmodule.lean
@@ -17,6 +17,7 @@ public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
 ## iii. Table of contents
 
 - A. Definitions
+- B. Contained in SchwartzSubmoduleOn
 
 ## iv. References
 
@@ -26,9 +27,9 @@ public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
 
 noncomputable section
 namespace QuantumMechanics
-namespace SpaceDHilbertSpace
+namespace SpaceDHilbertSpaceOn
 
-open MeasureTheory SchwartzMap
+open MeasureTheory SchwartzMap SpaceDHilbertSpace
 
 variable {d : ℕ} (Ω : Set (Space d)) (μ : Measure (Space d)) [μ.HasTemperateGrowth]
 
@@ -48,6 +49,24 @@ def DirichletSchwartz : Submodule ℂ 𝓢(Space d, ℂ) where
 def DirichletSubmoduleOn : Submodule ℂ (SpaceDHilbertSpaceOn Ω μ) :=
   (DirichletSchwartz Ω).map (subspaceProjection Ω μ ∘ₗ schwartzIncl μ)
 
-end SpaceDHilbertSpace
+namespace DirichletSubmoduleOn
+
+variable {Ω μ} in
+lemma mem_iff {ψ : SpaceDHilbertSpaceOn Ω μ} :
+    ψ ∈ DirichletSubmoduleOn Ω μ ↔
+      ∃ f : DirichletSchwartz Ω, subspaceProjection Ω μ (schwartzIncl μ f) = ψ := by
+  simp [DirichletSubmoduleOn]
+
+/-!
+## B. Contained in SchwartzSubmoduleOn
+-/
+
+lemma le_schwartzSubmodule : DirichletSubmoduleOn Ω μ ≤ SchwartzSubmoduleOn Ω μ := by
+  intro ψ hψ
+  obtain ⟨f, hf⟩ := mem_iff.mp hψ
+  apply SchwartzSubmoduleOn.mem_iff.mpr ⟨⟨schwartzIncl μ f, by simp⟩, hf⟩
+
+end DirichletSubmoduleOn
+end SpaceDHilbertSpaceOn
 end QuantumMechanics
 end

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/DirichletSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/DirichletSubmodule.lean
@@ -12,12 +12,22 @@ public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
 
 ## i. Overview
 
+In this module we define the Dirichlet submodule of `SpaceDHilbertSpaceOn Ω μ` consisting of
+equivalence classes of Schwartz maps which vanish on `frontier Ω`.
+
+These serve as a convenient dense domain for operators acting on wavefunctions satisfying
+homogeneous Dirichlet boundary conditions on `Ω`.
+
 ## ii. Key results
+
+- `DirichletSubmoduleOn Ω μ`: The subspace of `SchwartzSubmodule d μ` consisting of Schwartz maps
+  which vanish on the frontier of `Ω`.
 
 ## iii. Table of contents
 
 - A. Definitions
 - B. Contained in SchwartzSubmoduleOn
+- C. Density
 
 ## iv. References
 
@@ -46,7 +56,7 @@ def DirichletSchwartz : Submodule ℂ 𝓢(Space d, ℂ) where
 
 /-- The submodule of the Hilbert space on `Ω` consisting of the equivalence classes
   of Schwartz maps which vanish on `frontier Ω`. -/
-def DirichletSubmoduleOn : Submodule ℂ (SpaceDHilbertSpaceOn Ω μ) :=
+abbrev DirichletSubmoduleOn : Submodule ℂ (SpaceDHilbertSpaceOn Ω μ) :=
   (DirichletSchwartz Ω).map (subspaceProjection Ω μ ∘ₗ schwartzIncl μ)
 
 namespace DirichletSubmoduleOn
@@ -55,7 +65,7 @@ variable {Ω μ} in
 lemma mem_iff {ψ : SpaceDHilbertSpaceOn Ω μ} :
     ψ ∈ DirichletSubmoduleOn Ω μ ↔
       ∃ f : DirichletSchwartz Ω, subspaceProjection Ω μ (schwartzIncl μ f) = ψ := by
-  simp [DirichletSubmoduleOn]
+  simp
 
 /-!
 ## B. Contained in SchwartzSubmoduleOn
@@ -65,6 +75,13 @@ lemma le_schwartzSubmodule : DirichletSubmoduleOn Ω μ ≤ SchwartzSubmoduleOn 
   intro ψ hψ
   obtain ⟨f, hf⟩ := mem_iff.mp hψ
   apply SchwartzSubmoduleOn.mem_iff.mpr ⟨⟨schwartzIncl μ f, by simp⟩, hf⟩
+
+/-!
+## C. Density
+-/
+
+TODO "Prove that DirichletSubmoduleOn is dense in SpaceDHilbertSpaceOn
+  (perhaps with some assumptions on the measure μ)."
 
 end DirichletSubmoduleOn
 end SpaceDHilbertSpaceOn

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/DirichletSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/DirichletSubmodule.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 Gregory J. Loges. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gregory J. Loges
+-/
+module
+
+public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
+/-!
+
+# Dirichlet submodule
+
+## i. Overview
+
+## ii. Key results
+
+## iii. Table of contents
+
+- A. Definitions
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+noncomputable section
+namespace QuantumMechanics
+namespace SpaceDHilbertSpace
+
+open MeasureTheory SchwartzMap
+
+variable {d : ℕ} (Ω : Set (Space d)) (μ : Measure (Space d)) [μ.HasTemperateGrowth]
+
+/-!
+## A. Definitions
+-/
+
+/-- The Schwartz maps which vanish on `frontier Ω`. -/
+def DirichletSchwartz : Submodule ℂ 𝓢(Space d, ℂ) where
+  carrier := {f : 𝓢(Space d, ℂ) | ∀ x : frontier Ω, f x = 0}
+  add_mem' := by simp_all
+  zero_mem' := by simp
+  smul_mem' := by simp_all
+
+/-- The submodule of the Hilbert space on `Ω` consisting of the equivalence classes
+  of Schwartz maps which vanish on `frontier Ω`. -/
+def DirichletSubmoduleOn : Submodule ℂ (SpaceDHilbertSpaceOn Ω μ) :=
+  (DirichletSchwartz Ω).map (subspaceProjection Ω μ ∘ₗ schwartzIncl μ)
+
+end SpaceDHilbertSpace
+end QuantumMechanics
+end

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/DirichletSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/DirichletSubmodule.lean
@@ -48,7 +48,7 @@ variable {d : ℕ} (Ω : Set (Space d)) (μ : Measure (Space d)) [μ.HasTemperat
 -/
 
 /-- The Schwartz maps which vanish on `frontier Ω`. -/
-def DirichletSchwartz : Submodule ℂ 𝓢(Space d, ℂ) where
+def DirichletSchwartzMap : Submodule ℂ 𝓢(Space d, ℂ) where
   carrier := {f : 𝓢(Space d, ℂ) | ∀ x : frontier Ω, f x = 0}
   add_mem' := by simp_all
   zero_mem' := by simp
@@ -57,21 +57,21 @@ def DirichletSchwartz : Submodule ℂ 𝓢(Space d, ℂ) where
 /-- The submodule of the Hilbert space on `Ω` consisting of the equivalence classes
   of Schwartz maps which vanish on `frontier Ω`. -/
 abbrev DirichletSubmoduleOn : Submodule ℂ (SpaceDHilbertSpaceOn Ω μ) :=
-  (DirichletSchwartz Ω).map (subspaceProjection Ω μ ∘ₗ schwartzIncl μ)
+  (DirichletSchwartzMap Ω).map (subspaceProjection Ω μ ∘ₗ schwartzIncl μ)
 
 namespace DirichletSubmoduleOn
 
 variable {Ω μ} in
 lemma mem_iff {ψ : SpaceDHilbertSpaceOn Ω μ} :
     ψ ∈ DirichletSubmoduleOn Ω μ ↔
-      ∃ f : DirichletSchwartz Ω, subspaceProjection Ω μ (schwartzIncl μ f) = ψ := by
+      ∃ f : DirichletSchwartzMap Ω, subspaceProjection Ω μ (schwartzIncl μ f) = ψ := by
   simp
 
 /-!
 ## B. Contained in SchwartzSubmoduleOn
 -/
 
-lemma le_schwartzSubmodule : DirichletSubmoduleOn Ω μ ≤ SchwartzSubmoduleOn Ω μ := by
+lemma le_schwartzSubmoduleOn : DirichletSubmoduleOn Ω μ ≤ SchwartzSubmoduleOn Ω μ := by
   intro ψ hψ
   obtain ⟨f, hf⟩ := mem_iff.mp hψ
   apply SchwartzSubmoduleOn.mem_iff.mpr ⟨⟨schwartzIncl μ f, by simp⟩, hf⟩
@@ -80,8 +80,8 @@ lemma le_schwartzSubmodule : DirichletSubmoduleOn Ω μ ≤ SchwartzSubmoduleOn 
 ## C. Density
 -/
 
-TODO "Prove that DirichletSubmoduleOn is dense in SpaceDHilbertSpaceOn
-  (perhaps with some assumptions on the measure μ)."
+TODO "Prove that `DirichletSubmoduleOn Ω μ` is dense in `SpaceDHilbertSpaceOn Ω μ`
+  (perhaps with some assumptions on Ω and μ)."
 
 end DirichletSubmoduleOn
 end SpaceDHilbertSpaceOn

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/SchwartzSubmodule.lean
@@ -22,9 +22,10 @@ In this module we define the Schwartz submodule of `SpaceDHilbertSpace d μ`.
 
 ## iii. Table of contents
 
-- A. Definitions
-- B. Coercions
-- D. Misc.
+- A. SchwartzSubmodule
+  - A.1. Coercions
+  - A.2. Misc.
+- B. SchwartzSubmoduleOn
 
 ## iv. References
 
@@ -32,17 +33,17 @@ In this module we define the Schwartz submodule of `SpaceDHilbertSpace d μ`.
 
 @[expose] public section
 
-namespace QuantumMechanics
-namespace SpaceDHilbertSpace
-
 noncomputable section
+namespace QuantumMechanics
 
 open MeasureTheory
 open InnerProductSpace
 open SchwartzMap
 
+namespace SpaceDHilbertSpace
+
 /-!
-## A. Definitions
+## A. SchwartzSubmodule
 -/
 
 /-- The continuous linear map including Schwartz maps into `SpaceDHilbertSpace d μ`. -/
@@ -69,7 +70,7 @@ variable {μ : Measure (Space d)} [μ.HasTemperateGrowth] [μ.IsOpenPosMeasure]
 variable (f g : 𝓢(Space d, ℂ)) (ψ : SchwartzSubmodule d μ)
 
 /-!
-## B. Coercions
+### A.1. Coercions
 -/
 
 instance : CoeFun (SchwartzSubmodule d μ) fun _ ↦ Space d → ℂ := ⟨fun ψ ↦ ψ.val⟩
@@ -86,7 +87,7 @@ lemma schwartzEquiv_ae_eq (h : schwartzEquiv μ f =ᵐ[μ] schwartzEquiv μ g) :
   (EmbeddingLike.apply_eq_iff_eq _).mp (SetLike.coe_eq_coe.mp (ext_iff.mpr h))
 
 /-!
-## C. Misc.
+### A.2. Misc.
 -/
 
 @[simp]
@@ -128,6 +129,33 @@ lemma schwartzIncl_ker : (schwartzIncl μ).ker = (⊥ : Submodule ℂ 𝓢(Space
   ext; simp [← schwartzEquiv_apply_coe]
 
 end SchwartzSubmodule
-end
 end SpaceDHilbertSpace
+
+/-!
+## B. SchwartzSubmoduleOn
+-/
+
+namespace SpaceDHilbertSpaceOn
+
+open SpaceDHilbertSpace
+
+/-- The projection of `SchwartzSubmodule d μ` onto `SpaceDHilbertSpaceOn Ω μ`. -/
+abbrev SchwartzSubmoduleOn
+    {d : ℕ} (Ω : Set (Space d)) (μ : Measure (Space d) := volume) [μ.HasTemperateGrowth] :
+    Submodule ℂ (SpaceDHilbertSpaceOn Ω μ) :=
+  (SchwartzSubmodule d μ).map (subspaceProjection Ω μ)
+
+namespace SchwartzSubmoduleOn
+
+variable {d : ℕ} (Ω : Set (Space d)) (μ : Measure (Space d)) [μ.HasTemperateGrowth]
+
+variable {Ω μ} in
+lemma mem_iff {ψ : SpaceDHilbertSpaceOn Ω μ} :
+    ψ ∈ SchwartzSubmoduleOn Ω μ ↔ ∃ φ : SchwartzSubmodule d μ, subspaceProjection Ω μ φ = ψ := by
+  simp
+
+end SchwartzSubmoduleOn
+end SpaceDHilbertSpaceOn
+
 end QuantumMechanics
+end

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/SchwartzSubmodule.lean
@@ -14,11 +14,18 @@ public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Basic
 ## i. Overview
 
 In this module we define the Schwartz submodule of `SpaceDHilbertSpace d μ`.
+`SchwartzSubmodule d μ` consists of the `μ`-a.e. equal equivalence classes of Schwartz maps
+on `Space d`.
+
+This is an import subspace of the Hilbert space. For one, the Fourier transform maps the Schwartz
+submodule into itself. It also is a convenient dense domain on which to define derivative operators.
 
 ## ii. Key results
 
 - `SchwartzSubmodule d μ`: Submodule of `SpaceDHilbertSpace d μ` consisting of the L² equivalence
   classes of Schwartz maps `𝓢(Space d, ℂ)`.
+- `SchwartzSubmoduleOn Ω μ`: The projection of `SchwartzSubmodule d μ`
+  onto `SpaceDHilbertSpaceOn Ω μ`.
 
 ## iii. Table of contents
 


### PR DESCRIPTION
Adds submodules of the `Space d` Hilbert space on `Ω` consisting of Schwartz maps which vanish on `frontier Ω = closure Ω \ interior Ω`. These can serve as the domain for an operator which acts on wavefunctions satisfying Dirichlet boundary conditions (e.g. the Hamiltonian for the infinite square well).
- `Basic.lean`: defines `SpaceDHilbertSpaceOn` and reorganizes to add namespace and section variables.
- `SchwartzSubmodule.lean`: defines `SchwartzSubmoduleOn` as the projection of `SchwartzSubmodule` from `SpaceDHilbertSpace` onto `SpaceDHilbertSpaceOn`.
- `DirichletSubmodule.lean`: defines `DirichletSubmoduleOn` as the projection of a submodule of `𝓢(Space d, ℂ)` and proves that it is contained in `SchwartzSubmoduleOn`.
 