### PR TITLE
feat(QuantumMechanics): the basic criterion of essential self-adjoint…

### DIFF
--- a/Physlib/QuantumMechanics/Operators/SpectralTheory/SelfAdjoint.lean
+++ b/Physlib/QuantumMechanics/Operators/SpectralTheory/SelfAdjoint.lean
@@ -126,8 +126,16 @@ lemma unitaryConj_isSelfAdjoint (u : H ≃ₗᵢ[ℂ] H') {A : H →ₗ.[ℂ] H}
     simpa only [neg_smul, sub_neg_eq_add] using hsurj (z := -I) (by norm_num) φ
   have hminus (φ : H') : ∃ ψ : (A.unitaryConj u).domain, A.unitaryConj u ψ - I • (ψ : H') = φ :=
     hsurj (by norm_num) φ
-  exact IsSelfAdjoint.of_surjective_add_sub
+  refine IsSymmetric.isSelfAdjoint_of_range_eq_top
     (IsFormalAdjoint.unitaryConj (IsSelfAdjoint.isSymmetric hA))
-    (HasDenseDomain.unitaryConj_dense_domain (IsSelfAdjoint.dense_domain hA)) hplus hminus
+    (HasDenseDomain.unitaryConj_dense_domain (IsSelfAdjoint.dense_domain hA)) ?_ ?_
+  · rw [LinearMap.range_eq_top]
+    intro φ
+    obtain ⟨ψ, hψ⟩ := hplus φ
+    exact ⟨⟨(ψ : H'), Submodule.mem_inf.mpr ⟨ψ.2, Submodule.mem_top⟩⟩, hψ⟩
+  · rw [LinearMap.range_eq_top]
+    intro φ
+    obtain ⟨ψ, hψ⟩ := hminus φ
+    exact ⟨⟨(ψ : H'), Submodule.mem_inf.mpr ⟨ψ.2, Submodule.mem_top⟩⟩, hψ⟩
 
 end LinearPMap

--- a/Physlib/QuantumMechanics/Operators/SpectralTheory/SelfAdjoint.lean
+++ b/Physlib/QuantumMechanics/Operators/SpectralTheory/SelfAdjoint.lean
@@ -118,24 +118,16 @@ variable {H H' : Type*}
 the two deficiency surjectivities of `A` all transfer through `u`. -/
 lemma unitaryConj_isSelfAdjoint (u : H ≃ₗᵢ[ℂ] H') {A : H →ₗ.[ℂ] H} (hA : IsSelfAdjoint A) :
     IsSelfAdjoint (A.unitaryConj u) := by
-  have hsurj {z : ℂ} (hz : z.im ≠ 0) (φ : H') :
-      ∃ ψ : (A.unitaryConj u).domain, A.unitaryConj u ψ - z • (ψ : H') = φ := by
-    obtain ⟨ξ, hξ⟩ := unitaryConj_sub_smul_surjective (IsSelfAdjoint.sub_smul_surjective hA hz) φ
-    exact ⟨⟨(ξ : H'), (Submodule.mem_inf.mp ξ.2).1⟩, hξ⟩
-  have hplus (φ : H') : ∃ ψ : (A.unitaryConj u).domain, A.unitaryConj u ψ + I • (ψ : H') = φ := by
-    simpa only [neg_smul, sub_neg_eq_add] using hsurj (z := -I) (by norm_num) φ
-  have hminus (φ : H') : ∃ ψ : (A.unitaryConj u).domain, A.unitaryConj u ψ - I • (ψ : H') = φ :=
-    hsurj (by norm_num) φ
+  have hrange {z : ℂ} (hz : z.im ≠ 0) : (A.unitaryConj u - z • 1).toFun.range = ⊤ :=
+    LinearMap.range_eq_top.mpr
+      (unitaryConj_sub_smul_surjective (IsSelfAdjoint.sub_smul_surjective hA hz))
   refine IsSymmetric.isSelfAdjoint_of_range_eq_top
     (IsFormalAdjoint.unitaryConj (IsSelfAdjoint.isSymmetric hA))
     (HasDenseDomain.unitaryConj_dense_domain (IsSelfAdjoint.dense_domain hA)) ?_ ?_
-  · rw [LinearMap.range_eq_top]
-    intro φ
-    obtain ⟨ψ, hψ⟩ := hplus φ
-    exact ⟨⟨(ψ : H'), Submodule.mem_inf.mpr ⟨ψ.2, Submodule.mem_top⟩⟩, hψ⟩
-  · rw [LinearMap.range_eq_top]
-    intro φ
-    obtain ⟨ψ, hψ⟩ := hminus φ
-    exact ⟨⟨(ψ : H'), Submodule.mem_inf.mpr ⟨ψ.2, Submodule.mem_top⟩⟩, hψ⟩
+  · have hI : A.unitaryConj u + I • 1 = A.unitaryConj u - (-I) • 1 :=
+      LinearPMap.ext rfl fun x hf hg => by simp [sub_apply, add_apply, smul_apply, sub_neg_eq_add]
+    rw [hI]
+    exact hrange (by norm_num)
+  · exact hrange (by norm_num)
 
 end LinearPMap

--- a/Physlib/QuantumMechanics/Operators/SpectralTheory/Symmetric.lean
+++ b/Physlib/QuantumMechanics/Operators/SpectralTheory/Symmetric.lean
@@ -27,10 +27,8 @@ simply reinterprets the numerical range as a subset of ℝ.
     all complex numbers with non-zero imaginary part.
 - `regularityDomain_isConnected_iff` : The regularity domain of a symmetric operator is connected
     if and only if it contains a real number.
-- `IsSymmetric.closure_sub_smul_surjective` : For symmetric, densely-defined `A` and non-real `z`,
-    a dense range of `A - z • 1` gives a surjective `A.closure - z • 1`.
-- `IsEssentiallySelfAdjoint.of_dense_range_add_sub` : The basic criterion for essential
-    self-adjointness: symmetric + densely defined + `A ± i` dense range.
+- `IsSymmetric.isEssentiallySelfAdjoint_of_defectNumber_eq_zero` : The basic criterion for
+    essential self-adjointness: symmetric + densely defined + vanishing defect numbers at `± i`.
 
 ## iii. Table of contents
 
@@ -220,40 +218,32 @@ lemma pointSpectrum_real : σᵖ T ⊆ range ofReal := by
     _ = ⟪x, z • x⟫_ℂ := by simp [← toFun_eq_coe, LinearMap.mem_ker.mp hx]
     _ = ↑(‖x‖ ^ 2) * z := by simp [inner_smul_right, mul_comm]
 
-end IsSymmetric
-
 /-!
 ## D. Essential self-adjointness
 -/
 
-open Complex
+variable [CompleteSpace H]
 
-variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
-
-/-- For symmetric, densely-defined `A` and non-real `z`, density of the range of `A - z • 1`
-upgrades to surjectivity of `A.closure - z • 1`. -/
-lemma IsSymmetric.closure_sub_smul_surjective {A : H →ₗ.[ℂ] H} (hsym : A.IsSymmetric)
-    (hdense : A.HasDenseDomain) {z : ℂ} (hz : z.im ≠ 0)
-    (hd : Dense ((A - z • 1).toFun.range : Set H)) :
-    Function.Surjective (A.closure - z • 1).toFun := by
-  have hrange : (A.closure - z • 1).toFun.range = ⊤ := by
-    rw [← (hsym.isClosable hdense).closure_range_sub_eq_range_closure_sub
-      (hsym.mem_regularityDomain_of_im_ne_zero hz)]
-    exact Submodule.dense_iff_topologicalClosure_eq_top.mp hd
-  exact LinearMap.range_eq_top.mp hrange
-
-/-- A symmetric, densely-defined `A` with `A ± i • 1` of dense range is essentially self-adjoint. -/
-lemma IsEssentiallySelfAdjoint.of_dense_range_add_sub {A : H →ₗ.[ℂ] H}
-    (hsym : A.IsSymmetric) (hdense : A.HasDenseDomain)
-    (hplus : Dense ((A - (-I) • 1).toFun.range : Set H))
-    (hminus : Dense ((A - I • 1).toFun.range : Set H)) : A.IsEssentiallySelfAdjoint := by
-  have hsurj {z : ℂ} (hz : z.im ≠ 0) (hd : Dense ((A - z • 1).toFun.range : Set H)) (φ : H) :
-      ∃ ψ : A.closure.domain, A.closure ψ - z • (ψ : H) = φ := by
-    obtain ⟨ξ, hξ⟩ := hsym.closure_sub_smul_surjective hdense hz hd φ
-    exact ⟨⟨(ξ : H), (Submodule.mem_inf.mp ξ.2).1⟩, hξ⟩
+/-- The basic criterion for essential self-adjointness: a symmetric, densely-defined operator
+whose defect numbers at `I` and `-I` both vanish is essentially self-adjoint. -/
+lemma isEssentiallySelfAdjoint_of_defectNumber_eq_zero
+    (hdense : T.HasDenseDomain) (hpos : T.defectNumber I = 0) (hneg : T.defectNumber (-I) = 0) :
+    T.IsEssentiallySelfAdjoint := by
+  have hrange {z : ℂ} (hz : z.im ≠ 0) (hd : T.defectNumber z = 0) :
+      (T.closure - z • 1).toFun.range = ⊤ := by
+    have hz' : z ∈ T.regularityDomain := hT.mem_regularityDomain_of_im_ne_zero hz
+    have hcl : T.closure.IsClosed := (hT.isClosable hdense).closure_isClosed
+    rw [← hcl.defectNumber_eq_zero_iff (T.regularityDomain_closure ▸ hz'),
+      defectNumber_closure hz']
+    exact hd
   rw [isEssentiallySelfAdjoint_def]
-  apply IsSelfAdjoint.of_surjective_add_sub (hsym.closure hdense) hdense.closure _ _
-  · simpa only [neg_smul, sub_neg_eq_add] using hsurj (by norm_num) hplus
-  · exact hsurj (by norm_num) hminus
+  apply (hT.closure hdense).isSelfAdjoint_of_range_eq_top hdense.closure
+  · have hI : T.closure + I • 1 = T.closure - (-I) • 1 :=
+      LinearPMap.ext rfl fun x hf hg => by simp [sub_apply, add_apply, smul_apply, sub_neg_eq_add]
+    rw [hI]
+    exact hrange (by norm_num) hneg
+  · exact hrange (by norm_num) hpos
+
+end IsSymmetric
 
 end LinearPMap

--- a/Physlib/QuantumMechanics/Operators/SpectralTheory/Symmetric.lean
+++ b/Physlib/QuantumMechanics/Operators/SpectralTheory/Symmetric.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Gregory J. Loges. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Gregory J. Loges
+Authors: Adam Bornemann, Gregory J. Loges
 -/
 module
 
@@ -27,11 +27,17 @@ simply reinterprets the numerical range as a subset of ℝ.
     all complex numbers with non-zero imaginary part.
 - `regularityDomain_isConnected_iff` : The regularity domain of a symmetric operator is connected
     if and only if it contains a real number.
+- `IsSymmetric.closure_sub_smul_surjective` : For symmetric, densely-defined `A` and non-real `z`,
+    a dense range of `A - z • 1` gives a surjective `A.closure - z • 1`.
+- `IsEssentiallySelfAdjoint.of_dense_range_add_sub` : The basic criterion for essential
+    self-adjointness: symmetric + densely defined + `A ± i` dense range.
 
 ## iii. Table of contents
 
 - A. Numerical range
 - B. Regularity domain
+- C. Point spectrum
+- D. Essential self-adjointness
 
 ## iv. References
 
@@ -215,4 +221,39 @@ lemma pointSpectrum_real : σᵖ T ⊆ range ofReal := by
     _ = ↑(‖x‖ ^ 2) * z := by simp [inner_smul_right, mul_comm]
 
 end IsSymmetric
+
+/-!
+## D. Essential self-adjointness
+-/
+
+open Complex
+
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
+
+/-- For symmetric, densely-defined `A` and non-real `z`, density of the range of `A - z • 1`
+upgrades to surjectivity of `A.closure - z • 1`. -/
+lemma IsSymmetric.closure_sub_smul_surjective {A : H →ₗ.[ℂ] H} (hsym : A.IsSymmetric)
+    (hdense : A.HasDenseDomain) {z : ℂ} (hz : z.im ≠ 0)
+    (hd : Dense ((A - z • 1).toFun.range : Set H)) :
+    Function.Surjective (A.closure - z • 1).toFun := by
+  have hrange : (A.closure - z • 1).toFun.range = ⊤ := by
+    rw [← (hsym.isClosable hdense).closure_range_sub_eq_range_closure_sub
+      (hsym.mem_regularityDomain_of_im_ne_zero hz)]
+    exact Submodule.dense_iff_topologicalClosure_eq_top.mp hd
+  exact LinearMap.range_eq_top.mp hrange
+
+/-- A symmetric, densely-defined `A` with `A ± i • 1` of dense range is essentially self-adjoint. -/
+lemma IsEssentiallySelfAdjoint.of_dense_range_add_sub {A : H →ₗ.[ℂ] H}
+    (hsym : A.IsSymmetric) (hdense : A.HasDenseDomain)
+    (hplus : Dense ((A - (-I) • 1).toFun.range : Set H))
+    (hminus : Dense ((A - I • 1).toFun.range : Set H)) : A.IsEssentiallySelfAdjoint := by
+  have hsurj {z : ℂ} (hz : z.im ≠ 0) (hd : Dense ((A - z • 1).toFun.range : Set H)) (φ : H) :
+      ∃ ψ : A.closure.domain, A.closure ψ - z • (ψ : H) = φ := by
+    obtain ⟨ξ, hξ⟩ := hsym.closure_sub_smul_surjective hdense hz hd φ
+    exact ⟨⟨(ξ : H), (Submodule.mem_inf.mp ξ.2).1⟩, hξ⟩
+  rw [isEssentiallySelfAdjoint_def]
+  apply IsSelfAdjoint.of_surjective_add_sub (hsym.closure hdense) hdense.closure _ _
+  · simpa only [neg_smul, sub_neg_eq_add] using hsurj (by norm_num) hplus
+  · exact hsurj (by norm_num) hminus
+
 end LinearPMap

--- a/Physlib/QuantumMechanics/Operators/SpectralTheory/Symmetric.lean
+++ b/Physlib/QuantumMechanics/Operators/SpectralTheory/Symmetric.lean
@@ -245,5 +245,4 @@ lemma isEssentiallySelfAdjoint_of_defectNumber_eq_zero
   · exact hrange (by norm_num) hpos
 
 end IsSymmetric
-
 end LinearPMap

--- a/Physlib/QuantumMechanics/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/Operators/Unbounded.lean
@@ -401,6 +401,16 @@ lemma adjoint_pow_le_pow_adjoint [CompleteSpace H] {n : ℕ} (h : (T ^ n).HasDen
     refine le_trans ?_ (adjoint_compRestricted_le_compRestricted_adjoint hTn h)
     exact pow_succ' T† n ▸ compRestricted_mono_right T† (ih hTn)
 
+/-- A densely-defined closable operator and its closure have the same adjoint. -/
+lemma adjoint_closure_eq_adjoint [CompleteSpace H] (hdense : U.HasDenseDomain)
+    (hcl : U.IsClosable) : U.closure† = U† := by
+  refine eq_of_eq_graph ?_
+  ext
+  rw [adjoint_graph_eq_graph_adjoint hdense, adjoint_graph_eq_graph_adjoint hdense.closure,
+    ← IsClosable.graph_closure_eq_closure_graph hcl,
+    mem_submodule_closure_adjoint_iff_mem_submoduleToLp_closure_orthogonal, orthogonal_closure,
+    mem_submodule_adjoint_iff_mem_submoduleToLp_orthogonal]
+
 /-!
 ### B.4. Continuity / boundedness
 -/
@@ -733,6 +743,14 @@ lemma IsSymmetric.of_le (h₁ : T₁.IsSymmetric) (h_le : T₂ ≤ T₁) : T₂.
   have hy : T₂ y = T₁ ⟨y, h_le.1 y.2⟩ := @h_le.2 y ⟨y, h_le.1 y.2⟩ rfl
   exact hx ▸ hy ▸ h₁ ⟨x, h_le.1 x.2⟩ ⟨y, h_le.1 y.2⟩
 
+/-- The closure of a symmetric densely-defined operator is symmetric. -/
+lemma IsSymmetric.closure [CompleteSpace H] (hsym : T.IsSymmetric) (hdense : T.HasDenseDomain) :
+    T.closure.IsSymmetric := by
+  have hadj_closed : T.adjoint.IsClosed := adjoint_isClosed hdense
+  rw [isSymmetric_iff_le_adjoint hdense.closure,
+    adjoint_closure_eq_adjoint hdense (hsym.isClosable hdense), ← hadj_closed.closure_eq]
+  exact hadj_closed.isClosable.closure_mono (hsym.le_adjoint hdense)
+
 /-!
 ### C.2. Self-adjoint operators
 -/
@@ -775,12 +793,18 @@ lemma IsSelfAdjoint.real_smul [CompleteSpace H] (h : IsSelfAdjoint T) {r : ℝ} 
 lemma IsSelfAdjoint.neg [CompleteSpace H] (h : IsSelfAdjoint T) : IsSelfAdjoint (-T) :=
   neg_eq_neg_one_smul T ▸ smul h (by norm_num) (by norm_num)
 
-/-- Self-adjointness from surjectivity of `T ± i`. A symmetric (`T.IsSymmetric`),densely-defined
-operator `T` for which `T + i` and `T - i` are both surjective onto `H`, is self-adjoint. -/
-lemma IsSelfAdjoint.of_surjective_add_sub [CompleteSpace H] (hsym : T.IsSymmetric)
-    (hdense : Dense (T.domain : Set H))
-    (hplus : ∀ φ : H, ∃ ψ : T.domain, T ψ + I • (ψ : H) = φ)
-    (hminus : ∀ φ : H, ∃ ψ : T.domain, T ψ - I • (ψ : H) = φ) : IsSelfAdjoint T := by
+/-- Self-adjointness from surjectivity of `T ± i`: a symmetric, densely-defined operator `T` for
+which `T + I • 1` and `T - I • 1` both have full range is self-adjoint. -/
+lemma IsSymmetric.isSelfAdjoint_of_range_eq_top [CompleteSpace H] (hsym : T.IsSymmetric)
+    (hdense : T.HasDenseDomain)
+    (hadd : (T + I • 1).toFun.range = ⊤) (hsub : (T - I • 1).toFun.range = ⊤) :
+    IsSelfAdjoint T := by
+  have hplus : ∀ φ : H, ∃ ψ : T.domain, T ψ + I • (ψ : H) = φ := fun φ => by
+    obtain ⟨ψ, hψ⟩ := LinearMap.range_eq_top.mp hadd φ
+    exact ⟨⟨(ψ : H), (Submodule.mem_inf.mp ψ.2).1⟩, hψ⟩
+  have hminus : ∀ φ : H, ∃ ψ : T.domain, T ψ - I • (ψ : H) = φ := fun φ => by
+    obtain ⟨ψ, hψ⟩ := LinearMap.range_eq_top.mp hsub φ
+    exact ⟨⟨(ψ : H), (Submodule.mem_inf.mp ψ.2).1⟩, hψ⟩
   rw [isSelfAdjoint_def]
   have hle : T ≤ T.adjoint := (isSymmetric_def.mp hsym).le_adjoint hdense
   apply le_antisymm _ hle
@@ -879,13 +903,8 @@ lemma IsUnbounded.closure (h : U.IsUnbounded) : U.closure.IsUnbounded :=
 
 @[simp]
 lemma IsUnbounded.adjoint_closure_eq_adjoint [CompleteSpace H] (h : U.IsUnbounded) :
-    U.closure† = U† := by
-  refine eq_of_eq_graph ?_
-  ext
-  rw [adjoint_graph_eq_graph_adjoint h.1, adjoint_graph_eq_graph_adjoint h.1.closure,
-    ← IsClosable.graph_closure_eq_closure_graph h.2,
-    mem_submodule_closure_adjoint_iff_mem_submoduleToLp_closure_orthogonal, orthogonal_closure,
-    mem_submodule_adjoint_iff_mem_submoduleToLp_orthogonal]
+    U.closure† = U† :=
+  LinearPMap.adjoint_closure_eq_adjoint h.1 h.2
 
 @[simp]
 lemma IsUnbounded.adjoint_adjoint_eq_closure [CompleteSpace H] [CompleteSpace H']
@@ -929,13 +948,5 @@ lemma isUnbounded_of_dense_of_isSymmetric' [CompleteSpace H]
     (mk E (E.subtype ∘ₗ f)).IsUnbounded :=
   ⟨hE, IsSymmetric.isClosable h hE⟩
 
-/-- The closure of a symmetric densely-defined operator is symmetric. -/
-lemma IsSymmetric.closure [CompleteSpace H] (hsym : T.IsSymmetric) (hdense : T.HasDenseDomain) :
-    T.closure.IsSymmetric := by
-  have hub : T.IsUnbounded := ⟨hdense, hsym.isClosable hdense⟩
-  have hadj_closed : T.adjoint.IsClosed := adjoint_isClosed hdense
-  rw [isSymmetric_iff_le_adjoint hdense.closure, hub.adjoint_closure_eq_adjoint]
-  rw [← hadj_closed.closure_eq]
-  exact hadj_closed.isClosable.closure_mono (hsym.le_adjoint hdense)
 
 end LinearPMap

--- a/Physlib/QuantumMechanics/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/Operators/Unbounded.lean
@@ -929,4 +929,13 @@ lemma isUnbounded_of_dense_of_isSymmetric' [CompleteSpace H]
     (mk E (E.subtype ∘ₗ f)).IsUnbounded :=
   ⟨hE, IsSymmetric.isClosable h hE⟩
 
+/-- The closure of a symmetric densely-defined operator is symmetric. -/
+lemma IsSymmetric.closure [CompleteSpace H] (hsym : T.IsSymmetric) (hdense : T.HasDenseDomain) :
+    T.closure.IsSymmetric := by
+  have hub : T.IsUnbounded := ⟨hdense, hsym.isClosable hdense⟩
+  have hadj_closed : T.adjoint.IsClosed := adjoint_isClosed hdense
+  rw [isSymmetric_iff_le_adjoint hdense.closure, hub.adjoint_closure_eq_adjoint]
+  rw [← hadj_closed.closure_eq]
+  exact hadj_closed.isClosable.closure_mono (hsym.le_adjoint hdense)
+
 end LinearPMap

--- a/Physlib/QuantumMechanics/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/Operators/Unbounded.lean
@@ -401,16 +401,6 @@ lemma adjoint_pow_le_pow_adjoint [CompleteSpace H] {n : ℕ} (h : (T ^ n).HasDen
     refine le_trans ?_ (adjoint_compRestricted_le_compRestricted_adjoint hTn h)
     exact pow_succ' T† n ▸ compRestricted_mono_right T† (ih hTn)
 
-/-- A densely-defined closable operator and its closure have the same adjoint. -/
-lemma adjoint_closure_eq_adjoint [CompleteSpace H] (hdense : U.HasDenseDomain)
-    (hcl : U.IsClosable) : U.closure† = U† := by
-  refine eq_of_eq_graph ?_
-  ext
-  rw [adjoint_graph_eq_graph_adjoint hdense, adjoint_graph_eq_graph_adjoint hdense.closure,
-    ← IsClosable.graph_closure_eq_closure_graph hcl,
-    mem_submodule_closure_adjoint_iff_mem_submoduleToLp_closure_orthogonal, orthogonal_closure,
-    mem_submodule_adjoint_iff_mem_submoduleToLp_orthogonal]
-
 /-!
 ### B.4. Continuity / boundedness
 -/
@@ -743,13 +733,18 @@ lemma IsSymmetric.of_le (h₁ : T₁.IsSymmetric) (h_le : T₂ ≤ T₁) : T₂.
   have hy : T₂ y = T₁ ⟨y, h_le.1 y.2⟩ := @h_le.2 y ⟨y, h_le.1 y.2⟩ rfl
   exact hx ▸ hy ▸ h₁ ⟨x, h_le.1 x.2⟩ ⟨y, h_le.1 y.2⟩
 
-/-- The closure of a symmetric densely-defined operator is symmetric. -/
+/-- The closure of a symmetric densely-defined operator is symmetric: `T††` is a symmetric
+closed extension of `T`, so it extends `T.closure`, whose symmetry then descends. -/
 lemma IsSymmetric.closure [CompleteSpace H] (hsym : T.IsSymmetric) (hdense : T.HasDenseDomain) :
     T.closure.IsSymmetric := by
-  have hadj_closed : T.adjoint.IsClosed := adjoint_isClosed hdense
-  rw [isSymmetric_iff_le_adjoint hdense.closure,
-    adjoint_closure_eq_adjoint hdense (hsym.isClosable hdense), ← hadj_closed.closure_eq]
-  exact hadj_closed.isClosable.closure_mono (hsym.le_adjoint hdense)
+  have hle : T ≤ T† := (isSymmetric_def.mp hsym).le_adjoint hdense
+  have hadj_dense : T†.HasDenseDomain := hdense.mono hle.1
+  have hT_le : T ≤ T†† := (adjoint_isFormalAdjoint hdense).le_adjoint hadj_dense
+  have hc : (T††).IsClosed := adjoint_isClosed hadj_dense
+  have h1 : (T††).IsSymmetric :=
+    (isSymmetric_iff_le_adjoint (hdense.mono hT_le.1)).mpr
+      (adjoint_antitone (Or.inl (hdense.mono hT_le.1)) (adjoint_antitone (Or.inl hdense) hle))
+  exact h1.of_le (hc.closure_eq ▸ hc.isClosable.closure_mono hT_le)
 
 /-!
 ### C.2. Self-adjoint operators
@@ -903,8 +898,13 @@ lemma IsUnbounded.closure (h : U.IsUnbounded) : U.closure.IsUnbounded :=
 
 @[simp]
 lemma IsUnbounded.adjoint_closure_eq_adjoint [CompleteSpace H] (h : U.IsUnbounded) :
-    U.closure† = U† :=
-  LinearPMap.adjoint_closure_eq_adjoint h.1 h.2
+    U.closure† = U† := by
+  refine eq_of_eq_graph ?_
+  ext
+  rw [adjoint_graph_eq_graph_adjoint h.1, adjoint_graph_eq_graph_adjoint h.1.closure,
+    ← IsClosable.graph_closure_eq_closure_graph h.2,
+    mem_submodule_closure_adjoint_iff_mem_submoduleToLp_closure_orthogonal, orthogonal_closure,
+    mem_submodule_adjoint_iff_mem_submoduleToLp_orthogonal]
 
 @[simp]
 lemma IsUnbounded.adjoint_adjoint_eq_closure [CompleteSpace H] [CompleteSpace H']


### PR DESCRIPTION
…ness

Add §D to SpectralTheory/Symmetric.lean:
`IsSymmetric.closure_sub_smul_surjective` for symmetric, densely-defined `A` and non-real `z`, density of the range of `A - z • 1` upgrades to surjectivity of `A.closure - z • 1` and `IsEssentiallySelfAdjoint.of_dense_range_add_sub` (the basic criterion).

Downstream, this powers the essential self-adjointness of the momentum operator via density of its deficiency ranges in Fourier space.