### PR TITLE
docs(fluid-dynamics): add fluid API map

### DIFF
--- a/Physlib/FluidDynamics/API-map.yaml
+++ b/Physlib/FluidDynamics/API-map.yaml
@@ -1,0 +1,84 @@
+version: v0.1
+
+Title: "Fluid"
+
+Overview: |
+  A fluid is described by the spatial distribution of its velocity, density, and
+  pressure fields. This is a core data structure of fluid dynamics from which the
+  continuity equation, the equations of motion, and thermodynamic balance laws are
+  built (Landau and Lifshitz, Fluid Mechanics, Chapter 1).
+
+  This map records the current state of Physlib/FluidDynamics.
+  Partial infrastructure exists. `FluidState` (density and velocity fields) is
+  defined in `FluidDynamics/FluidState.lean`, together with the field-type
+  abbreviations and the `FluidInMomentumBalance` extension. The mass flux density
+  `rho u` is available as `momentumDensity`, and the equation of continuity is fully
+  formalized in the conservative, residual, and smooth forms with an implication
+  between them.
+
+  Several requirements are not implemented. `FluidState` carries no pressure
+  field, so the fluid data structure is only part of the required one. There is no Euler equation (the momentum equations in
+  `FluidDynamics/NavierStokes/Momentum.lean` keep the stress tensor general and are
+  explicitly not specialized to an ideal, pressure-only fluid), no definition of an
+  ideal fluid, no entropy flux density, no Bernoulli equation, no energy flux, and no
+  notion of flow out of a volume. Those requirements are recorded below with
+  location N/A so future work can be tracked against them.
+
+ParentAPIs:
+  - Space (Physlib/SpaceAndTime/Space)
+  - Time (Physlib/SpaceAndTime/Time)
+
+References:
+  - "Landau, L. D. and Lifshitz, E. M., Fluid Mechanics (Course of Theoretical Physics, vol. 6), 2nd ed., Chapter 1 (continuity, Euler equation, Bernoulli equation, energy and momentum flux)"
+
+Requirements:
+
+  - description: >
+      The key data structure for a fluid, given by the spatial distribution of its
+      velocity, density, and pressure, is defined. (FluidState currently provides
+      the density and velocity fields; pressure is not yet part of the structure.)
+    done: false
+    location: "Physlib/FluidDynamics/FluidState.lean (FluidState, FluidInMomentumBalance, ScalarField, VectorField, MassDensity, VelocityField, StressTensor)"
+
+  - description: >
+      Flow out of a volume: the flux of fluid through the boundary of a spatial
+      region.
+    done: false
+    location: "N/A"
+
+  - description: >
+      Mass flux density rho u, the vector whose divergence enters the continuity
+      equation. (Defined as momentumDensity, which equals rho u.)
+    done: true
+    location: "Physlib/FluidDynamics/NavierStokes/Momentum.lean (momentumDensity)"
+
+  - description: >
+      Equation of continuity, expressing local conservation of mass as
+      partial_t rho + div (rho u) = 0.
+    done: true
+    location: "Physlib/FluidDynamics/NavierStokes/Continuity.lean (ClassicalContinuityEquation, continuityResidual, SmoothContinuityEquation, SmoothContinuityEquation.toClassical)"
+
+  - description: >
+      Euler's equation, the equation of motion of an ideal (inviscid) fluid.
+    done: false
+    location: "N/A"
+
+  - description: >
+      Definition of an ideal fluid.
+    done: false
+    location: "N/A"
+
+  - description: >
+      Definition of the entropy flux density.
+    done: false
+    location: "N/A"
+
+  - description: >
+      Bernoulli's equation.
+    done: false
+    location: "N/A"
+
+  - description: >
+      Energy flux of a fluid.
+    done: false
+    location: "N/A"

--- a/Physlib/FluidDynamics/API-map.yaml
+++ b/Physlib/FluidDynamics/API-map.yaml
@@ -6,23 +6,14 @@ Overview: |
   A fluid is described by the spatial distribution of its velocity, density, and
   pressure fields. This is a core data structure of fluid dynamics from which the
   continuity equation, the equations of motion, and thermodynamic balance laws are
-  built (Landau and Lifshitz, Fluid Mechanics, Chapter 1).
+  built (Landau and Lifshitz, Fluid Mechanics, vol. 6, 2nd ed., Chapter 1).
 
-  This map records the current state of Physlib/FluidDynamics.
-  Partial infrastructure exists. `FluidState` (density and velocity fields) is
-  defined in `FluidDynamics/FluidState.lean`, together with the field-type
-  abbreviations and the `FluidInMomentumBalance` extension. The mass flux density
-  `rho u` is available as `momentumDensity`, and the equation of continuity is fully
-  formalized in the conservative, residual, and smooth forms with an implication
-  between them.
-
-  Several requirements are not implemented. `FluidState` carries no pressure
-  field, so the fluid data structure is only part of the required one. There is no Euler equation (the momentum equations in
-  `FluidDynamics/NavierStokes/Momentum.lean` keep the stress tensor general and are
-  explicitly not specialized to an ideal, pressure-only fluid), no definition of an
-  ideal fluid, no entropy flux density, no Bernoulli equation, no energy flux, and no
-  notion of flow out of a volume. Those requirements are recorded below with
-  location N/A so future work can be tracked against them.
+  At present the fluid state carries density and velocity but not pressure, so the
+  data structure covers only part of the requirement. The mass flux density and
+  the equation of continuity are fully formalized, the latter in conservative,
+  residual, and smooth forms with the implication between them. The Euler
+  equation, the ideal fluid, entropy flux, the Bernoulli equation, energy flux,
+  and flow out of a volume are open; they are recorded below with location N/A.
 
 ParentAPIs:
   - Space (Physlib/SpaceAndTime/Space)

--- a/Physlib/FluidDynamics/API-map.yaml
+++ b/Physlib/FluidDynamics/API-map.yaml
@@ -8,12 +8,19 @@ Overview: |
   continuity equation, the equations of motion, and thermodynamic balance laws are
   built (Landau and Lifshitz, Fluid Mechanics, vol. 6, 2nd ed., Chapter 1).
 
-  At present the fluid state carries density and velocity but not pressure, so the
-  data structure covers only part of the requirement. The mass flux density and
-  the equation of continuity are fully formalized, the latter in conservative,
-  residual, and smooth forms with the implication between them. The Euler
-  equation, the ideal fluid, entropy flux, the Bernoulli equation, energy flux,
-  and flow out of a volume are open; they are recorded below with location N/A.
+  The independent data is split across a tower of structures. `FluidFlow` carries
+  density and velocity, `CauchyFlow` adds the stress tensor and the specific body
+  force, and `ThermodynamicCauchyFlow` adds entropy and enthalpy. Pressure is not
+  a field of any of them; it enters as a separate scalar field through the stress
+  laws, so the requirement below that asks for a single structure carrying
+  velocity, density, and pressure is still only partly met.
+
+  The mass flux density and the equation of continuity are fully formalized, the
+  latter in conservative, residual, and smooth forms with the implication between
+  them. The Euler equation, the ideal fluid, and the Bernoulli equation are now
+  formalized. The entropy flux density, the energy flux, and flow out of a volume
+  are open; they are recorded below with location N/A. Entropy itself exists as a
+  field of `ThermodynamicCauchyFlow`, but the flux density built from it does not.
 
 ParentAPIs:
   - Space (Physlib/SpaceAndTime/Space)
@@ -26,10 +33,11 @@ Requirements:
 
   - description: >
       The key data structure for a fluid, given by the spatial distribution of its
-      velocity, density, and pressure, is defined. (FluidState currently provides
-      the density and velocity fields; pressure is not yet part of the structure.)
+      velocity, density, and pressure, is defined. (FluidFlow currently provides
+      the density and velocity fields; pressure is not a field of the structure and
+      enters separately through the stress laws.)
     done: false
-    location: "Physlib/FluidDynamics/FluidState.lean (FluidState, FluidInMomentumBalance, ScalarField, VectorField, MassDensity, VelocityField, StressTensor)"
+    location: "Physlib/FluidDynamics/FluidFlow/Basic.lean (FluidFlow, rho, velocity)"
 
   - description: >
       Flow out of a volume: the flux of fluid through the boundary of a spatial
@@ -41,23 +49,23 @@ Requirements:
       Mass flux density rho u, the vector whose divergence enters the continuity
       equation. (Defined as momentumDensity, which equals rho u.)
     done: true
-    location: "Physlib/FluidDynamics/NavierStokes/Momentum.lean (momentumDensity)"
+    location: "Physlib/FluidDynamics/FluidFlow/Momentum.lean (momentumDensity, momentumFlux)"
 
   - description: >
       Equation of continuity, expressing local conservation of mass as
       partial_t rho + div (rho u) = 0.
     done: true
-    location: "Physlib/FluidDynamics/NavierStokes/Continuity.lean (ClassicalContinuityEquation, continuityResidual, SmoothContinuityEquation, SmoothContinuityEquation.toClassical)"
+    location: "Physlib/FluidDynamics/FluidFlow/Continuity.lean (ClassicalContinuityEquation, continuityResidual, SmoothContinuityEquation, classicalContinuityEquation_of_smoothContinuityEquation)"
 
   - description: >
       Euler's equation, the equation of motion of an ideal (inviscid) fluid.
-    done: false
-    location: "N/A"
+    done: true
+    location: "Physlib/FluidDynamics/Euler/Basic.lean (Euler, ConvectiveEuler, euler_iff_convectiveEuler)"
 
   - description: >
       Definition of an ideal fluid.
-    done: false
-    location: "N/A"
+    done: true
+    location: "Physlib/FluidDynamics/CauchyFlow/Inviscid.lean (IsInviscid, matrixDiv_stress_eq_neg_grad_pressure_of_is_inviscid)"
 
   - description: >
       Definition of the entropy flux density.
@@ -66,8 +74,8 @@ Requirements:
 
   - description: >
       Bernoulli's equation.
-    done: false
-    location: "N/A"
+    done: true
+    location: "Physlib/FluidDynamics/ThermodynamicCauchyFlow/Bernoulli.lean (bernoulliFunction, LocalBernoulliLaw, BernoulliLaw)"
 
   - description: >
       Energy flux of a fluid.


### PR DESCRIPTION
## Motivation

Related to #1414, the tracking map for the fluid API in #887. An API map records the implemented status and source location of each requirement for an API, so the gap between a planned API and the current library stays visible in-tree.

## Changes

Adds `Physlib/FluidDynamics/API-map.yaml`.

The completed entries cover what exists: the mass flux density `momentumDensity` and the equation of continuity in its conservative, residual and smooth forms with the implication between them. The fluid data structure is recorded as not done, since `FluidState` currently provides density and velocity but the requirement also asks for pressure. The Euler equation, ideal fluid, entropy flux, Bernoulli equation, energy flux and flow out of a volume are not implemented and carry location `N/A`.

References cite Landau and Lifshitz, Fluid Mechanics, vol. 6, 2nd ed., Chapter 1.

## Testing

Ran the API-map linter:

```
python3 scripts/api_map_linter.py --repo .
```

Every declared source file and name resolves; no completed entry is missing a location.
