### PR TITLE
auto-task(QuantumInfo.ClassicalInfo.Capacity): minimize imports

### DIFF
--- a/QuantumInfo/ClassicalInfo/Capacity.lean
+++ b/QuantumInfo/ClassicalInfo/Capacity.lean
@@ -5,9 +5,7 @@ Authors: Alex Meiburg
 -/
 module
 
-public import QuantumInfo.ClassicalInfo.Entropy
-public import Mathlib.Data.Finset.Fin
-public import Mathlib.Data.Fintype.Fin
+public import Mathlib.Data.Fin.Basic
 
 @[expose] public section
 


### PR DESCRIPTION
## Summary

Minimizes the imports of `QuantumInfo/ClassicalInfo/Capacity.lean`.

The file only defines `Code`, `FixedLengthCode`, and `BlockCode` structures over
`List`, `Fin`, and `ℕ` — it never uses anything from `QuantumInfo.ClassicalInfo.Entropy`
(entropy/probability/channel definitions), nor `Fintype`/`Finset` instances for `Fin`.
Replaced the three imports with the single, more basic import that the file actually
needs for its `Fin block_in`/`Fin block_out` usage:

- Removed `QuantumInfo.ClassicalInfo.Entropy` (unused)
- Removed `Mathlib.Data.Finset.Fin` (unused)
- Removed `Mathlib.Data.Fintype.Fin` (unused; replaced by the more basic `Mathlib.Data.Fin.Basic`)

## Downstream impact

None. `QuantumInfo.ClassicalInfo.Capacity` is not imported by any other file in the
repo (its import in `QuantumInfo.lean` is commented out), so no other files needed
changes.

## Verification

- `lake build QuantumInfo.ClassicalInfo.Capacity` — succeeds (510 jobs, down from 2216
  with the original imports)
- `lake build QuantumInfo` — succeeds (8733 jobs)
- `lake build Physlib` — succeeds (4448 jobs)

No `sorry`s or axioms were added; only `import` lines were touched.
