### PR TITLE
docs(space-and-time): add Galilean group and TimeAndSpace API maps

### DIFF
--- a/Physlib/SpaceAndTime/GalileanGroup/API-map.yaml
+++ b/Physlib/SpaceAndTime/GalileanGroup/API-map.yaml
@@ -1,0 +1,57 @@
+version: v0.1
+
+Title: Galilean group
+
+Overview: |
+    The key data structure is `GalileanGroup d`, a structure carrying a spatial
+    rotation, a boost velocity, a space translation and a time translation, for
+    an arbitrary spatial dimension `d`. It is the group of transformations of
+    non-relativistic space and time, acting on `Time × Space d` by rotating and
+    boosting, then translating. The API contains the group structure, the action,
+    and inclusions of the Euclidean, orthogonal, rotation, space-translation and
+    time-translation subgroups.
+
+ParentAPIs:
+  - "Space (Physlib/SpaceAndTime/Space)"
+  - "Time (Physlib/SpaceAndTime/Time)"
+  - "Euclidean group (Physlib/SpaceAndTime/Space/EuclideanGroup)"
+
+References: []
+
+Requirements:
+
+  - description: "The key data structure corresponding to the Galilean group is defined."
+    done: true
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (GalileanGroup, with fields rotation, velocity, spaceTranslation, timeTranslation)"
+
+  - description: "The API contains an instance of a group on the type corresponding to the Galilean group."
+    done: true
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (One, Mul, Inv, Group (GalileanGroup d), with simp lemmas for each field under one, mul and inv)"
+
+  - description: "The API contains an instance of a Lie group on the type corresponding to the Galilean group."
+    done: false
+    location: ""
+
+  - description: "The API contains an inclusion from the group of rotations."
+    done: true
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (rotation.incl : EuclideanGroup.RotationGroup d →* GalileanGroup d, orthogonal.incl, ofOrthogonal)"
+
+  - description: "The API contains an inclusion from the space-translation group."
+    done: true
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (spaceTranslation.incl, spaceTranslationGroup.incl, ofSpaceTranslation)"
+
+  - description: "The API contains an inclusion from the time-translation group."
+    done: true
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (timeTranslation.incl : Multiplicative Time →* GalileanGroup d, ofTimeTranslation)"
+
+  - description: "The API is general for any dimension."
+    done: true
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (GalileanGroup (d : ℕ := 3), with every definition and instance parameterised by d)"
+
+  - description: "The API contains the action of the Galilean group on time and space."
+    done: true
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (actSpace, act, MulAction (GalileanGroup d) (Time × Space d), smul_fst, smul_snd, smul_mk)"
+
+  - description: "The API contains an inclusion from the Euclidean group."
+    done: true
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (euclidean.incl : EuclideanGroup d →* GalileanGroup d, ofEuclidean)"

--- a/Physlib/SpaceAndTime/GalileanGroup/API-map.yaml
+++ b/Physlib/SpaceAndTime/GalileanGroup/API-map.yaml
@@ -22,11 +22,11 @@ Requirements:
 
   - description: "The key data structure corresponding to the Galilean group is defined."
     done: true
-    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (GalileanGroup, with fields rotation, velocity, spaceTranslation, timeTranslation)"
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (GalileanGroup, rotation, velocity, spaceTranslation, timeTranslation)"
 
   - description: "The API contains an instance of a group on the type corresponding to the Galilean group."
     done: true
-    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (One, Mul, Inv, Group (GalileanGroup d), with simp lemmas for each field under one, mul and inv)"
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (One (GalileanGroup d), Mul (GalileanGroup d), Inv (GalileanGroup d), Group (GalileanGroup d), one_rotation, one_velocity, one_spaceTranslation, one_timeTranslation, mul_rotation, mul_velocity, mul_spaceTranslation, mul_timeTranslation, inv_rotation, inv_velocity, inv_spaceTranslation, inv_timeTranslation)"
 
   - description: "The API contains an instance of a Lie group on the type corresponding to the Galilean group."
     done: false
@@ -46,7 +46,7 @@ Requirements:
 
   - description: "The API is general for any dimension."
     done: true
-    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (GalileanGroup (d : ℕ := 3), with every definition and instance parameterised by d)"
+    location: "Physlib/SpaceAndTime/GalileanGroup/Basic.lean (GalileanGroup)"
 
   - description: "The API contains the action of the Galilean group on time and space."
     done: true

--- a/Physlib/SpaceAndTime/TimeAndSpace/API-map.yaml
+++ b/Physlib/SpaceAndTime/TimeAndSpace/API-map.yaml
@@ -1,0 +1,44 @@
+version: v0.1
+
+Title: TimeAndSpace
+
+Overview: |
+    The key data structure is `TimeAndSpace d`, an abbreviation for `Time × Space d`,
+    the Euclidean space-time of non-relativistic physics in an arbitrary spatial
+    dimension `d`. The API contains the continuous linear projections onto `Time`
+    and `Space d` with their distance bounds, the commutation of time and space
+    derivatives, the action of the Euclidean group, and the induced action on
+    Schwartz maps out of `TimeAndSpace d`.
+
+ParentAPIs:
+  - "Time (Physlib/SpaceAndTime/Time)"
+  - "Space (Physlib/SpaceAndTime/Space)"
+  - "Euclidean group (Physlib/SpaceAndTime/Space/EuclideanGroup)"
+
+References: []
+
+Requirements:
+
+  - description: "The key data structure `TimeAndSpace d`, an abbreviation of `Time × Space d`, is defined."
+    done: true
+    location: "Physlib/SpaceAndTime/TimeAndSpace/Basic.lean (TimeAndSpace (d : ℕ := 3))"
+
+  - description: "The API contains projections from `TimeAndSpace d` to `Time` and to `Space d`."
+    done: true
+    location: "Physlib/SpaceAndTime/TimeAndSpace/Basic.lean (time, space, as continuous linear maps →L[ℝ], with time_apply, space_apply, dist_time_le, dist_space_le)"
+
+  - description: "The API contains an action of the Euclidean group on `TimeAndSpace d`."
+    done: true
+    location: "Physlib/SpaceAndTime/TimeAndSpace/EuclideanGroup/Action.lean (smul_mk, fst_smul, snd_smul, time_smul, space_smul, dist_smul, isometry_smul, antilipschitz_smul, actionLinearMap, actionTranslation)"
+
+  - description: "The API contains an action of the Euclidean group on Schwartz maps with source `TimeAndSpace d`."
+    done: true
+    location: "Physlib/SpaceAndTime/TimeAndSpace/EuclideanGroup/SchwartzAction.lean (schwartzEuclideanAction, schwartzEuclideanAction_apply, schwartzEuclideanAction_mul_apply, schwartzEuclideanAction_injective, schwartzEuclideanAction_surjective)"
+
+  - description: "The API contains the commutation of time and space derivatives for functions on `TimeAndSpace d`."
+    done: true
+    location: "Physlib/SpaceAndTime/TimeAndSpace/Basic.lean (fderiv_time_commute_fderiv_space, time_deriv_comm_space_deriv, time_deriv_curl_commute)"
+
+  - description: "The API contains the characterisation of functions with vanishing time or space derivative."
+    done: true
+    location: "Physlib/SpaceAndTime/TimeAndSpace/Basic.lean (space_fun_of_time_deriv_eq_zero, time_fun_of_space_deriv_eq_zero, const_of_time_deriv_space_deriv_eq_zero)"

--- a/Physlib/SpaceAndTime/TimeAndSpace/API-map.yaml
+++ b/Physlib/SpaceAndTime/TimeAndSpace/API-map.yaml
@@ -25,7 +25,7 @@ Requirements:
 
   - description: "The API contains projections from `TimeAndSpace d` to `Time` and to `Space d`."
     done: true
-    location: "Physlib/SpaceAndTime/TimeAndSpace/Basic.lean (time, space, as continuous linear maps →L[ℝ], with time_apply, space_apply, dist_time_le, dist_space_le)"
+    location: "Physlib/SpaceAndTime/TimeAndSpace/Basic.lean (time, space, time_apply, space_apply, dist_time_le, dist_space_le)"
 
   - description: "The API contains an action of the Euclidean group on `TimeAndSpace d`."
     done: true


### PR DESCRIPTION
## Motivation

Related to #1414, the tracking maps for the Galilean group API in #911 and the TimeAndSpace API in #939. An API map records the implemented status and source location of each requirement for an API, so the gap between a planned API and the current library stays visible in-tree.

## Changes

Adds `Physlib/SpaceAndTime/GalileanGroup/API-map.yaml` and `Physlib/SpaceAndTime/TimeAndSpace/API-map.yaml`.

For the Galilean group, the completed entries cover the group structure on `GalileanGroup d`, its action on `Time × Space d`, and the inclusions of the Euclidean, orthogonal, rotation, space-translation and time-translation subgroups, together with the parameterisation by arbitrary spatial dimension. One requirement from #911 is recorded as not met: there is no Lie group instance on `GalileanGroup`.

For TimeAndSpace, the entries cover the abbreviation itself, the continuous linear projections onto `Time` and `Space d` with their distance bounds, the Euclidean group action, and the induced action on Schwartz maps out of `TimeAndSpace d`. Two entries beyond the requirements in #939 record the commutation of time and space derivatives and the characterisation of functions whose time or space derivative vanishes, both of which the API already provides.

## Checks

`scripts/api_map_linter.py --repo .` passes on both files with no missing files and no missing names, resolving 23 and 27 declarations respectively against the Lean sources.
