### PR TITLE
docs(space-and-time): add SpaceTime API map

### DIFF
--- a/Physlib/SpaceAndTime/SpaceTime/API-map.yaml
+++ b/Physlib/SpaceAndTime/SpaceTime/API-map.yaml
@@ -1,0 +1,62 @@
+version: v0.1
+
+Title: SpaceTime
+
+Overview: |
+    The key data structure is `SpaceTime d`, an abbreviation for `Lorentz.Vector d`,
+    Minkowski space-time with an arbitrary but fixed choice of units and origin, for
+    an arbitrary spatial dimension `d`. The API contains the coordinate maps, the
+    measure-space structure, the projections onto `Space d` and `Time` and the
+    equivalence with `Time × Space d`, derivatives of functions and of distributions
+    along a coordinate, the splitting of integrals over `SpaceTime` into integrals
+    over time and space, time slicing, and the action of the Lorentz group.
+
+ParentAPIs:
+  - "Lorentz vectors (Physlib/Relativity/Tensors/RealTensor/Vector)"
+  - "Space (Physlib/SpaceAndTime/Space)"
+  - "Time (Physlib/SpaceAndTime/Time)"
+  - "Lorentz group (Physlib/Relativity/LorentzGroup)"
+
+References: []
+
+Requirements:
+
+  - description: "The key data structure `SpaceTime`, Minkowski space-time with an arbitrary but fixed choice of units and origin, is defined."
+    done: true
+    location: "Physlib/SpaceAndTime/SpaceTime/Basic.lean (SpaceTime (d : ℕ := 3), coord, coordCLM)"
+
+  - description: "The API contains a map from `SpaceTime` to `Space` and `Time`."
+    done: true
+    location: "Physlib/SpaceAndTime/SpaceTime/Basic.lean (space, time, toTimeAndSpace)"
+
+  - description: "The API contains the derivatives of functions from `SpaceTime` to a normed space."
+    done: true
+    location: "Physlib/SpaceAndTime/SpaceTime/Derivatives.lean (deriv, tensorDeriv)"
+
+  - description: "The API contains the derivatives of functions from `SpaceTime` to manifolds."
+    done: true
+    location: "Physlib/SpaceAndTime/SpaceTime/Derivatives.lean (manifoldDeriv, manifoldDeriv_eq)"
+
+  - description: "The API contains derivatives of distributions from `SpaceTime` to normed spaces."
+    done: true
+    location: "Physlib/SpaceAndTime/SpaceTime/Derivatives.lean (distDeriv, distTensorDeriv)"
+
+  - description: "The API contains derivatives of distributions from `SpaceTime` to manifolds."
+    done: false
+    location: ""
+
+  - description: "The API contains the splitting of integrals over `SpaceTime` into integrals over `Space` and `Time`."
+    done: true
+    location: "Physlib/SpaceAndTime/SpaceTime/Basic.lean (spaceTime_integral_eq_time_space_integral, spaceTime_integral_eq_time_integral_space_integral, spaceTime_integral_eq_space_integral_time_integral)"
+
+  - description: "The API contains an action of the Lorentz group on `SpaceTime`."
+    done: true
+    location: "Physlib/SpaceAndTime/SpaceTime/LorentzAction.lean (schwartzAction, SMul (LorentzGroup d), DistribMulAction (LorentzGroup d), SMulCommClass, distActionLinearMap)"
+
+  - description: "The API contains the measure-space structure on `SpaceTime` used for integration."
+    done: true
+    location: "Physlib/SpaceAndTime/SpaceTime/Basic.lean (MeasurableSpace, BorelSpace, MeasureSpace, IsOpenPosMeasure, IsFiniteMeasureOnCompacts, Measure.IsAddHaarMeasure)"
+
+  - description: "The API contains time slicing of functions and distributions on `SpaceTime`."
+    done: true
+    location: "Physlib/SpaceAndTime/SpaceTime/TimeSlice.lean (timeSlice, timeSliceLinearEquiv, distTimeSlice)"


### PR DESCRIPTION
## Motivation

Related to #1414, the tracking map for the SpaceTime API in #856. An API map records the implemented status and source location of each requirement for an API, so the gap between a planned API and the current library stays visible in-tree.

## Changes

Adds `Physlib/SpaceAndTime/SpaceTime/API-map.yaml`.

The completed entries cover the definition of `SpaceTime d` and its coordinates, the projections onto `Space d` and `Time` with the equivalence to `Time × Space d`, derivatives of functions and of distributions along a coordinate, the splitting of integrals over `SpaceTime` into integrals over time and space, time slicing, and the action of the Lorentz group. Two entries beyond the requirements record the measure-space structure used for integration and the time-slicing maps.

Two entries differ from the checklist on #856. Derivatives of functions to manifolds are recorded as done, since `manifoldDeriv` in `Derivatives.lean` provides exactly that. Derivatives of distributions to manifolds are recorded as not done, which matches the checklist.

## Checks

`scripts/api_map_linter.py --repo .` passes with no missing files and no missing names, resolving 27 declarations against the Lean sources.
