### PR TITLE
feat(Mathematics): ContDiff and HasTemperateGrowth for `physHermite`

### DIFF
--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -364,7 +364,7 @@ lemma integral_physHermite_mul_physHermite_eq_integral_deriv_inductive (n m : �
         - ∫ (x : ℝ), deriv (deriv^[p] (physHermite n)) x *
         deriv^[m - (p + 1)] (fun x => Real.exp (-x ^ 2)) x := by
       apply MeasureTheory.integral_mul_deriv_eq_deriv_mul_of_integrable
-      · exact fun _ _ ↦ DifferentiableAt.hasDerivAt (deriv_physHermite_differentiableAt n p _)
+      · exact fun _ _ ↦ DifferentiableAt.hasDerivAt (deriv_physHermite_differentiable n p _)
       · intro x
         rw [hasDerivAt_deriv_iff]
         have h1 : (deriv^[m - (p + 1)] fun x => Real.exp (-x ^ 2)) =

--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -36,7 +36,7 @@ and, up to numerical factors, satisfy all of the same properties.
   - D.1. Recursion
   - D.2. Parity
   - D.3. Differentiability
-  - D.5. Temperate growth
+  - D.4. Temperate growth
 - E. Relationship to Gaussians
 
 ## iv. References
@@ -170,14 +170,13 @@ lemma iterate_derivative_physHermite_self (n : ℕ) :
     rw [Polynomial.coeff_C_zero]
     simp [Nat.descFactorial_self]
   | m + 1 =>
-    rw [coeff_physHermite_of_lt (by omega), Polynomial.coeff_C_of_ne_zero (by omega)]
-    rfl
+    rw [coeff_physHermite_of_lt (by omega), Polynomial.coeff_C_of_ne_zero (by omega), smul_zero]
 
 /-!
 ## D. As functions `ℝ → ℝ`
 -/
 
-/-- Cast an integer polynomial to a function `ℝ → ℝ` by evaluation. -/
+/-- Cast an integer polynomial to a function `ℝ → ℝ` by evaluation of the indeterminant. -/
 @[coe]
 noncomputable abbrev realEval (p : Polynomial ℤ) : ℝ → ℝ := fun x ↦ p.aeval x
 
@@ -200,6 +199,7 @@ lemma physHermite_succ_apply (n : ℕ) (x : ℝ) :
     physHermite (n + 1) x = 2 * x * physHermite n x - deriv (physHermite n) x := by
   simp [physHermite_succ_coe]
 
+/-- The two-term recursion for `physHermite` as functions `ℝ → ℝ` (c.f. `physHermite_succ'`). -/
 lemma physHermite_succ_coe' (n : ℕ) :
     (physHermite (n + 1) : ℝ → ℝ) =
       2 • (fun x => x) * (physHermite n : ℝ → ℝ) - (2 * n) • (physHermite (n - 1) : ℝ → ℝ) := by

--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Tomas Skrivan, Joseph Tooby-Smith
+Authors: Gregory J. Loges, Tomas Skrivan, Joseph Tooby-Smith
 -/
 module
 
@@ -14,11 +14,16 @@ public import Mathlib.Tactic.Cases
 public import Mathlib.Topology.Algebra.Polynomial
 /-!
 
-# Physicists Hermite Polynomial
+# Physicist's Hermite Polynomials
 
 This file may eventually be upstreamed to Mathlib.
 
 ## i. Overview
+
+The physicist's Hermite polynomials are a family of orthogonal polynomials defined by the recursion
+$H_0(x) = 1$ and $H_{n+1}(x) = 2x\,H_n(x) - H_n'(x)$.
+These are a rescaling of the so-called probabalist's Hermite polynomials (`Polynomial.hermite`)
+and, up to numerical factors, satisfy all of the same properties.
 
 ## ii. Key results
 
@@ -48,7 +53,7 @@ open Function Nat
 ## A. Recursive definition
 -/
 
-/-- The Physicists Hermite polynomial are defined as polynomials over `ℤ` in `X` recursively
+/-- The physicist's Hermite polynomials are defined as polynomials over `ℤ` in `X` recursively
   with `physHermite 0 = 1` and
 
   `physHermite (n + 1) = 2 • X * physHermite n - derivative (physHermite n)`.
@@ -59,10 +64,12 @@ noncomputable def physHermite : ℕ → Polynomial ℤ
   | 0 => 1
   | n + 1 => 2 • X * physHermite n - derivative (physHermite n)
 
+/-- The defining recursion `physHermite (n + 1) = (2x - d/dx) (physHermite n)`. -/
 lemma physHermite_succ (n : ℕ) :
     physHermite (n + 1) = 2 • X * physHermite n - derivative (physHermite n) := by
   simp [physHermite]
 
+/-- The Rodrigues formula `physHermite n = (2x - d/dx)ⁿ 1`. -/
 lemma physHermite_eq_iterate (n : ℕ) :
     physHermite n = (fun p => 2 * X * p - derivative p)^[n] 1 := by
   induction n with
@@ -99,7 +106,7 @@ lemma physHermite_succ' (n : ℕ) :
 ## B. Coefficients & degree
 -/
 
-lemma coeff_physHhermite_succ_zero (n : ℕ) :
+lemma coeff_physHermite_succ_zero (n : ℕ) :
     coeff (physHermite (n + 1)) 0 = - coeff (physHermite n) 1 := by
   simp [physHermite_succ, coeff_derivative]
 
@@ -120,7 +127,7 @@ lemma coeff_physHermite_of_lt {n k : ℕ} (hnk : n < k) : coeff (physHermite n) 
     simp
 
 @[simp]
-lemma coeff_physHermite_self_succ (n : ℕ) : coeff (physHermite n) n = 2 ^ n := by
+lemma coeff_physHermite_self (n : ℕ) : coeff (physHermite n) n = 2 ^ n := by
   induction n with
   | zero => exact coeff_C
   | succ n ih =>
@@ -134,15 +141,15 @@ lemma degree_physHermite (n : ℕ) : degree (physHermite n) = n := by
   exact fun _ => coeff_physHermite_of_lt
 
 @[simp]
-lemma natDegree_physHermite {n : ℕ} : (physHermite n).natDegree = n :=
+lemma natDegree_physHermite (n : ℕ) : (physHermite n).natDegree = n :=
   natDegree_eq_of_degree_eq_some (degree_physHermite n)
 
 @[simp]
-lemma physHermite_leadingCoeff {n : ℕ} : (physHermite n).leadingCoeff = 2 ^ n := by
+lemma physHermite_leadingCoeff (n : ℕ) : (physHermite n).leadingCoeff = 2 ^ n := by
   simp [leadingCoeff]
 
 @[simp]
-lemma physHermite_ne_zero {n : ℕ} : physHermite n ≠ 0 :=
+lemma physHermite_ne_zero (n : ℕ) : physHermite n ≠ 0 :=
   leadingCoeff_ne_zero.mp (by simp)
 
 /-!
@@ -154,8 +161,8 @@ lemma iterate_derivative_physHermite_of_gt {n m : ℕ} (h : n < m) :
   iterate_derivative_eq_zero (by simpa using h)
 
 @[simp]
-lemma iterate_derivative_physHermite_self {n : ℕ} :
-    derivative^[n] (physHermite n) = C ((n ! : ℤ) * 2 ^ n) := by
+lemma iterate_derivative_physHermite_self (n : ℕ) :
+    derivative^[n] (physHermite n) = C (n ! * 2 ^ n : ℤ) := by
   ext m
   rw [Polynomial.coeff_iterate_derivative]
   match m with
@@ -170,6 +177,7 @@ lemma iterate_derivative_physHermite_self {n : ℕ} :
 ## D. As functions `ℝ → ℝ`
 -/
 
+/-- Cast an integer polynomial to a function `ℝ → ℝ` by evaluation. -/
 @[coe]
 noncomputable abbrev realEval (p : Polynomial ℤ) : ℝ → ℝ := fun x ↦ p.aeval x
 
@@ -181,6 +189,7 @@ noncomputable instance : CoeFun (Polynomial ℤ) (fun _ ↦ ℝ → ℝ) := ⟨r
 
 lemma physHermite_zero_coe : (physHermite 0 : ℝ → ℝ) = fun _ ↦ 1 := by ext; simp
 
+/-- The defining recursion for `physHermite` as functions `ℝ → ℝ` (c.f. `physHermite_succ`). -/
 lemma physHermite_succ_coe (n : ℕ) :
     (physHermite (n + 1) : ℝ → ℝ) =
       2 • (fun x => x) * (physHermite n : ℝ → ℝ) - deriv (physHermite n) := by
@@ -201,7 +210,7 @@ lemma physHermite_succ_apply' (n : ℕ) (x : ℝ) :
     physHermite (n + 1) x = 2 * x * physHermite n x - 2 * n * physHermite (n - 1) x := by
   simp [physHermite_succ_coe']
 
-lemma deriv_physHermite (n : ℕ) : deriv (physHermite n) = 2 * n * (physHermite (n - 1)) := by
+lemma deriv_physHermite (n : ℕ) : deriv (physHermite n) = 2 * n * physHermite (n - 1) := by
   ext
   simp [derivative_physHermite, map_ofNat, mul_assoc]
 
@@ -221,6 +230,7 @@ lemma fderiv_physHermite (n : ℕ) (x : ℝ) :
 ### D.2. Parity
 -/
 
+/-- The `physHermite` polynomials are alternately even and odd. -/
 @[simp]
 lemma physHermite_neg (n : ℕ) (x : ℝ) : physHermite n (-x) = (-1) ^ n * physHermite n x := by
   match n with
@@ -446,7 +456,7 @@ lemma polynomial_mem_physHermite_span_induction (P : Polynomial ℤ) : (n : ℕ)
         = (2 ^ (n + 1) : ℝ) • (fun (x : ℝ) => (aeval x) P) - ↑(P.coeff (n + 1) : ℝ) •
         (fun (x : ℝ)=> (aeval x) (physHermite (n + 1))) := by
       funext x
-      simp [coeff_physHermite_self_succ, map_ofNat]
+      simp [coeff_physHermite_self, map_ofNat]
     rw [hl, Submodule.sub_mem_iff_left] at hP'mem
     · rwa [Submodule.smul_mem_iff] at hP'mem
       simp
@@ -455,12 +465,12 @@ decreasing_by
   rw [Polynomial.natDegree_lt_iff_degree_lt]
   · apply (Polynomial.degree_lt_iff_coeff_zero _ _).mpr
     intro m hm'
-    simp only [coeff_physHermite_self_succ, coeff_sub]
+    simp only [coeff_physHermite_self, coeff_sub]
     change n + 1 ≤ m at hm'
     rw [coeff_smul, coeff_smul]
     by_cases hm : m = n + 1
     · subst hm
-      simp only [smul_eq_mul, coeff_physHermite_self_succ]
+      simp only [smul_eq_mul, coeff_physHermite_self]
       ring
     · rw [coeff_eq_zero_of_natDegree_lt (by omega), coeff_physHermite_of_lt (by omega)]
       simp

--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -15,13 +15,31 @@ public import Mathlib.Tactic.Cases
 
 This file may eventually be upstreamed to Mathlib.
 
+## i. Overview
+
+## ii. Key results
+
+## iii. Table of contents
+
+- A. Recursive definition
+- B. Coefficients & degree
+- C. Iterated derivatives
+- D. As functions `ℝ → ℝ`
+- E. Relationship to Gaussians
+
+## iv. References
+
 -/
 
 @[expose] public section
 
-open Polynomial
+namespace Polynomial
 
-namespace Physlib
+open Nat
+
+/-!
+## A. Recursive definition
+-/
 
 /-- The Physicists Hermite polynomial are defined as polynomials over `ℤ` in `X` recursively
   with `physHermite 0 = 1` and
@@ -69,6 +87,10 @@ lemma physHermite_succ' (n : ℕ) :
     physHermite (n + 1) = 2 • X * physHermite n - 2 * n • physHermite (n - 1) := by
   rw [physHermite_succ, derivative_physHermite]
 
+/-!
+## B. Coefficients & degree
+-/
+
 lemma coeff_physHhermite_succ_zero (n : ℕ) :
     coeff (physHermite (n + 1)) 0 = - coeff (physHermite n) 1 := by
   simp [physHermite_succ, coeff_derivative]
@@ -107,11 +129,21 @@ lemma degree_physHermite (n : ℕ) : degree (physHermite n) = n := by
 lemma natDegree_physHermite {n : ℕ} : (physHermite n).natDegree = n :=
   natDegree_eq_of_degree_eq_some (degree_physHermite n)
 
+@[simp]
+lemma physHermite_leadingCoeff {n : ℕ} : (physHermite n).leadingCoeff = 2 ^ n := by
+  simp [leadingCoeff]
+
+@[simp]
+lemma physHermite_ne_zero {n : ℕ} : physHermite n ≠ 0 :=
+  leadingCoeff_ne_zero.mp (by simp)
+
+/-!
+## C. Iterated derivatives
+-/
+
 lemma iterate_derivative_physHermite_of_gt {n m : ℕ} (h : n < m) :
     derivative^[m] (physHermite n) = 0 :=
   iterate_derivative_eq_zero (by simpa using h)
-
-open Nat
 
 @[simp]
 lemma iterate_derivative_physHermite_self {n : ℕ} :
@@ -126,13 +158,9 @@ lemma iterate_derivative_physHermite_self {n : ℕ} :
     rw [coeff_physHermite_of_lt (by omega), Polynomial.coeff_C_of_ne_zero (by omega)]
     rfl
 
-@[simp]
-lemma physHermite_leadingCoeff {n : ℕ} : (physHermite n).leadingCoeff = 2 ^ n := by
-  simp [leadingCoeff]
-
-@[simp]
-lemma physHermite_ne_zero {n : ℕ} : physHermite n ≠ 0 :=
-  leadingCoeff_ne_zero.mp (by simp)
+/-!
+## D. As functions `ℝ → ℝ`
+-/
 
 noncomputable instance : CoeFun (Polynomial ℤ) (fun _ ↦ ℝ → ℝ)where
   coe p := fun x => p.aeval x
@@ -215,7 +243,7 @@ lemma physHermite_parity: (n : ℕ) → (x : ℝ) →
 
 /-!
 
-## Relationship to Gaussians
+## E. Relationship to Gaussians
 
 -/
 
@@ -314,8 +342,9 @@ lemma integral_physHermite_mul_physHermite_eq_integral_deriv_inductive (n m : �
         rw [hasDerivAt_deriv_iff]
         have h1 : (deriv^[m - (p + 1)] fun x => Real.exp (-x ^ 2)) =
             fun x => (-1 : ℝ) ^ (m - (p + 1)) * physHermite (m - (p + 1)) x *
-            Real.exp (- x ^ 2) := funext fun x =>
-          deriv_gaussian_eq_physHermite_mul_gaussian (m - (p + 1)) x
+            Real.exp (- x ^ 2) := by
+          ext x
+          exact deriv_gaussian_eq_physHermite_mul_gaussian (m - (p + 1)) x
         rw [h1]
         fun_prop
       · rw [← Function.iterate_succ_apply' deriv]
@@ -429,9 +458,10 @@ lemma cos_mem_physHermite_span_topologicalClosure (c : ℝ) :
       exact Finset.sum_congr rfl fun i _ => by ring
     rw [h0]
     refine Submodule.sum_mem _ fun l _ => Submodule.smul_mem _ _ ?_
-    have hy : (fun (y : ℝ) => y ^ (2 * l)) = fun y => ((X ^ (2 * l) : Polynomial ℤ)).aeval y :=
-      funext fun y => by simp
+    have hy : (fun (y : ℝ) => y ^ (2 * l)) = fun y => ((X ^ (2 * l) : Polynomial ℤ)).aeval y := by
+      ext
+      simp
     exact hy ▸ polynomial_mem_physHermite_span _
   exact mem_closure_of_tendsto h1 (Filter.Eventually.of_forall h2)
 
-end Physlib
+end Polynomial

--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -25,6 +25,10 @@ This file may eventually be upstreamed to Mathlib.
 - B. Coefficients & degree
 - C. Iterated derivatives
 - D. As functions `ℝ → ℝ`
+  - D.1. Recursion
+  - D.2. Parity
+  - D.3. Differentiability
+  - D.5. Temperate growth
 - E. Relationship to Gaussians
 
 ## iv. References
@@ -162,8 +166,14 @@ lemma iterate_derivative_physHermite_self {n : ℕ} :
 ## D. As functions `ℝ → ℝ`
 -/
 
-noncomputable instance : CoeFun (Polynomial ℤ) (fun _ ↦ ℝ → ℝ)where
-  coe p := fun x => p.aeval x
+@[coe]
+noncomputable abbrev realEval (p : Polynomial ℤ) : ℝ → ℝ := fun x ↦ p.aeval x
+
+noncomputable instance : CoeFun (Polynomial ℤ) (fun _ ↦ ℝ → ℝ) := ⟨realEval⟩
+
+/-!
+### D.1. Recursion
+-/
 
 lemma physHermite_eq_aeval (n : ℕ) (x : ℝ) :
     physHermite n x = (physHermite n).aeval x := rfl
@@ -194,14 +204,9 @@ lemma iterated_deriv_physHermite_eq_aeval (n : ℕ) : (m : ℕ) →
     funext x
     rw [Polynomial.deriv_aeval]
 
-@[fun_prop]
-lemma physHermite_differentiableAt (n : ℕ) (x : ℝ) :
-    DifferentiableAt ℝ (physHermite n) x := Polynomial.differentiableAt_aeval (physHermite n)
-
-@[fun_prop]
-lemma deriv_physHermite_differentiableAt (n m : ℕ) (x : ℝ) :
-    DifferentiableAt ℝ (deriv^[m] (physHermite n)) x :=
-  iterated_deriv_physHermite_eq_aeval n m ▸ Polynomial.differentiableAt_aeval _
+lemma fderiv_physHermite (n : ℕ) (x : ℝ) :
+    fderiv ℝ (physHermite n) x = (1 : ℝ →L[ℝ] ℝ).smulRight (deriv (physHermite n) x) := by
+  simp
 
 lemma deriv_physHermite (n : ℕ) :
     deriv (physHermite n) = 2 * n * (physHermite (n - 1)) := by
@@ -209,27 +214,9 @@ lemma deriv_physHermite (n : ℕ) :
   rw [Polynomial.deriv_aeval (physHermite n), derivative_physHermite]
   simp [mul_assoc, map_ofNat]
 
-lemma fderiv_physHermite
-    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] (x : E)
-    (f : E → ℝ) (hf : DifferentiableAt ℝ f x) (n : ℕ) :
-    fderiv ℝ (fun x => physHermite n (f x)) x
-    = (2 * n * physHermite (n - 1) (f x)) • fderiv ℝ f x := by
-  rw [show (fun x => physHermite n (f x)) = physHermite n ∘ f from rfl,
-    fderiv_comp x (by fun_prop) hf]
-  ext dx
-  simp only [Polynomial.fderiv_aeval, derivative_physHermite, nsmul_eq_mul, map_mul, map_natCast,
-    ContinuousLinearMap.coe_comp, Function.comp_apply, ContinuousLinearMap.smulRight_apply,
-    one_apply_eq_self, smul_eq_mul, FunLike.coe_smul, Pi.smul_apply, map_ofNat]
-  ring
-
-@[simp]
-lemma deriv_physHermite' (x : ℝ)
-    (f : ℝ → ℝ) (hf : DifferentiableAt ℝ f x) (n : ℕ) :
-    deriv (fun x => physHermite n (f x)) x
-    = (2 * n * physHermite (n - 1) (f x)) * deriv f x := by
-  unfold deriv
-  rw [fderiv_physHermite (hf := hf)]
-  rfl
+/-!
+### D.2. Parity
+-/
 
 lemma physHermite_parity: (n : ℕ) → (x : ℝ) →
     physHermite n (-x) = (-1)^n * physHermite n x
@@ -240,6 +227,25 @@ lemma physHermite_parity: (n : ℕ) → (x : ℝ) →
     simp only [smul_neg, nsmul_eq_mul, cast_ofNat, physHermite_parity (n + 1) x, neg_mul, cast_add,
       cast_one, add_tsub_cancel_right, physHermite_parity n x, smul_eq_mul]
     ring
+
+/-!
+### D.3. Differentiability
+-/
+
+@[fun_prop]
+lemma physHermite_differentiableAt (n : ℕ) (x : ℝ) :
+    DifferentiableAt ℝ (physHermite n) x := Polynomial.differentiableAt_aeval (physHermite n)
+
+@[fun_prop]
+lemma deriv_physHermite_differentiableAt (n m : ℕ) (x : ℝ) :
+    DifferentiableAt ℝ (deriv^[m] (physHermite n)) x :=
+  iterated_deriv_physHermite_eq_aeval n m ▸ Polynomial.differentiableAt_aeval _
+
+/-!
+### D.4. Temperate growth
+-/
+
+
 
 /-!
 
@@ -404,7 +410,7 @@ lemma polynomial_mem_physHermite_span_induction (P : Polynomial ℤ) : (n : ℕ)
     simp
   | n + 1, h => by
     by_cases hP0 : P = 0
-    · simp [hP0, ← Pi.zero_def]
+    · grind
     let P' := ((coeff (physHermite (n + 1)) (n + 1)) • P -
         (coeff P (n + 1)) • physHermite (n + 1))
     have hP'mem : (fun x => P'.aeval x) ∈ Submodule.span ℝ

--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Calculus.Deriv.Polynomial
 public import Mathlib.Analysis.Calculus.ContDiff.Polynomial
+public import Mathlib.Analysis.Distribution.TemperateGrowth
 public import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Series
 public import Mathlib.Tactic.Cases
@@ -41,7 +42,7 @@ This file may eventually be upstreamed to Mathlib.
 
 namespace Polynomial
 
-open Nat
+open Function Nat
 
 /-!
 ## A. Recursive definition
@@ -178,7 +179,7 @@ noncomputable instance : CoeFun (Polynomial ℤ) (fun _ ↦ ℝ → ℝ) := ⟨r
 ### D.1. Recursion
 -/
 
-lemma physHermite_zero_coe (x : ℝ) : physHermite 0 x = 1 := by simp
+lemma physHermite_zero_coe : (physHermite 0 : ℝ → ℝ) = fun _ ↦ 1 := by ext; simp
 
 lemma physHermite_succ_coe (n : ℕ) :
     (physHermite (n + 1) : ℝ → ℝ) =
@@ -254,7 +255,18 @@ lemma physHermite_contDiff (n : ℕ) (m : WithTop ℕ∞) : ContDiff ℝ m (phys
 ### D.4. Temperate growth
 -/
 
-
+open HasTemperateGrowth in
+@[fun_prop]
+lemma physHermite_hasTemperateGrowth (n : ℕ) : HasTemperateGrowth (physHermite n) := by
+  match n with
+  | 0 =>
+    rw [physHermite_zero_coe]
+    fun_prop
+  | n + 1 =>
+    rw [physHermite_succ_coe', two_smul, nsmul_eq_mul]
+    refine sub ?_ ?_
+    · exact mul (by fun_prop) (physHermite_hasTemperateGrowth n)
+    · exact mul (const _) (physHermite_hasTemperateGrowth (n - 1))
 
 /-!
 

--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -69,6 +69,7 @@ lemma physHermite_eq_iterate (n : ℕ) :
 @[simp]
 lemma physHermite_zero : physHermite 0 = C 1 := rfl
 
+@[simp]
 lemma physHermite_one : physHermite 1 = 2 * X := by simp [physHermite_succ]
 
 lemma derivative_physHermite_succ : (n : ℕ) →
@@ -175,58 +176,53 @@ noncomputable instance : CoeFun (Polynomial ℤ) (fun _ ↦ ℝ → ℝ) := ⟨r
 ### D.1. Recursion
 -/
 
-lemma physHermite_eq_aeval (n : ℕ) (x : ℝ) :
-    physHermite n x = (physHermite n).aeval x := rfl
+lemma physHermite_zero_coe (x : ℝ) : physHermite 0 x = 1 := by simp
 
-lemma physHermite_zero_apply (x : ℝ) : physHermite 0 x = 1 := by simp
+lemma physHermite_succ_coe (n : ℕ) :
+    (physHermite (n + 1) : ℝ → ℝ) =
+      2 • (fun x => x) * (physHermite n : ℝ → ℝ) - deriv (physHermite n) := by
+  ext
+  simp [physHermite_succ, map_ofNat]
 
-lemma physHermite_pow (n m : ℕ) (x : ℝ) : physHermite n x ^ m = aeval x (physHermite n ^ m) := by
-  simp
+lemma physHermite_succ_apply (n : ℕ) (x : ℝ) :
+    physHermite (n + 1) x = 2 * x * physHermite n x - deriv (physHermite n) x := by
+  simp [physHermite_succ_coe]
 
-lemma physHermite_succ_fun (n : ℕ) :
-    (physHermite (n + 1) : ℝ → ℝ) = 2 • (fun x => x) *
-    (physHermite n : ℝ → ℝ)- (2 * n : ℝ) • (physHermite (n - 1) : ℝ → ℝ) := by
-  ext x
+lemma physHermite_succ_coe' (n : ℕ) :
+    (physHermite (n + 1) : ℝ → ℝ) =
+      2 • (fun x => x) * (physHermite n : ℝ → ℝ) - (2 * n) • (physHermite (n - 1) : ℝ → ℝ) := by
+  ext
   simp [physHermite_succ', mul_assoc, map_ofNat]
 
-lemma physHermite_succ_fun' (n : ℕ) :
-    (physHermite (n + 1) : ℝ → ℝ) = fun x => 2 • x *
-    physHermite n x -
-    (2 * n : ℝ) • physHermite (n - 1) x := by
-  rw [physHermite_succ_fun]
-  rfl
+lemma physHermite_succ_apply' (n : ℕ) (x : ℝ) :
+    physHermite (n + 1) x = 2 * x * physHermite n x - 2 * n * physHermite (n - 1) x := by
+  simp [physHermite_succ_coe']
 
-lemma iterated_deriv_physHermite_eq_aeval (n : ℕ) : (m : ℕ) →
-    deriv^[m] (physHermite n) = fun x => (derivative^[m] (physHermite n)).aeval x
-  | 0 => by simp
-  | m + 1 => by
-    simp only [Function.iterate_succ_apply', iterated_deriv_physHermite_eq_aeval n m]
-    funext x
-    rw [Polynomial.deriv_aeval]
+lemma deriv_physHermite (n : ℕ) : deriv (physHermite n) = 2 * n * (physHermite (n - 1)) := by
+  ext
+  simp [derivative_physHermite, map_ofNat, mul_assoc]
+
+lemma iterate_deriv_physHermite_eq_iterate_derivative (n m : ℕ) :
+    deriv^[m] (physHermite n) = derivative^[m] (physHermite n) := by
+  match m with
+  | 0 => simp
+  | m + 1 =>
+    ext
+    simp [Function.iterate_succ_apply', iterate_deriv_physHermite_eq_iterate_derivative n m]
 
 lemma fderiv_physHermite (n : ℕ) (x : ℝ) :
     fderiv ℝ (physHermite n) x = (1 : ℝ →L[ℝ] ℝ).smulRight (deriv (physHermite n) x) := by
   simp
 
-lemma deriv_physHermite (n : ℕ) :
-    deriv (physHermite n) = 2 * n * (physHermite (n - 1)) := by
-  ext x
-  rw [Polynomial.deriv_aeval (physHermite n), derivative_physHermite]
-  simp [mul_assoc, map_ofNat]
-
 /-!
 ### D.2. Parity
 -/
 
-lemma physHermite_parity: (n : ℕ) → (x : ℝ) →
-    physHermite n (-x) = (-1)^n * physHermite n x
-  | 0, x => by simp
-  | 1, x => by simp [physHermite_one, map_ofNat]
-  | n + 2, x => by
-    rw [physHermite_succ_fun']
-    simp only [smul_neg, nsmul_eq_mul, cast_ofNat, physHermite_parity (n + 1) x, neg_mul, cast_add,
-      cast_one, add_tsub_cancel_right, physHermite_parity n x, smul_eq_mul]
-    ring
+lemma physHermite_neg (n : ℕ) (x : ℝ) : physHermite n (-x) = (-1) ^ n * physHermite n x := by
+  match n with
+  | 0 => simp
+  | 1 => simp [map_ofNat]
+  | n + 2 => grind [physHermite_succ_apply', physHermite_neg (n + 1), physHermite_neg n]
 
 /-!
 ### D.3. Differentiability
@@ -239,7 +235,7 @@ lemma physHermite_differentiableAt (n : ℕ) (x : ℝ) :
 @[fun_prop]
 lemma deriv_physHermite_differentiableAt (n m : ℕ) (x : ℝ) :
     DifferentiableAt ℝ (deriv^[m] (physHermite n)) x :=
-  iterated_deriv_physHermite_eq_aeval n m ▸ Polynomial.differentiableAt_aeval _
+  iterate_deriv_physHermite_eq_iterate_derivative n m ▸ Polynomial.differentiableAt_aeval _
 
 /-!
 ### D.4. Temperate growth
@@ -310,7 +306,7 @@ lemma physHermite_gaussian_integrable (n p m : ℕ) :
       (-1 : ℝ) ^ n • fun x => (derivative^[m] (physHermite p) * physHermite n).aeval x *
       Real.exp (-1 * x ^ 2) := by
     funext x
-    rw [iterated_deriv_physHermite_eq_aeval]
+    rw [iterate_deriv_physHermite_eq_iterate_derivative]
     simp only [Pi.mul_apply, deriv_gaussian_eq_physHermite_mul_gaussian, map_mul, Pi.smul_apply,
       smul_eq_mul, neg_one_mul]
     ring
@@ -368,7 +364,7 @@ lemma integral_physHermite_mul_physHermite_eq_integral_deriv (n m : ℕ) :
 lemma physHermite_orthogonal_lt {n m : ℕ} (hnm : n < m) :
     ∫ x : ℝ, (physHermite n x * physHermite m x) * Real.exp (- x ^ 2) = 0 := by
   rw [integral_physHermite_mul_physHermite_eq_integral_deriv]
-  simp [iterated_deriv_physHermite_eq_aeval, iterate_derivative_physHermite_of_gt hnm]
+  simp [iterate_deriv_physHermite_eq_iterate_derivative, iterate_derivative_physHermite_of_gt hnm]
 
 theorem physHermite_orthogonal {n m : ℕ} (hnm : n ≠ m) :
     ∫ x : ℝ, (physHermite n x * physHermite m x) * Real.exp (- x ^ 2) = 0 := by
@@ -387,7 +383,8 @@ lemma physHermite_orthogonal_cons {n m : ℕ} (hnm : n ≠ m) (c : ℝ) :
 theorem physHermite_norm (n : ℕ) :
     ∫ x : ℝ, (physHermite n x * physHermite n x) * Real.exp (- x ^ 2) =
     ↑n ! * 2 ^ n * √Real.pi := by
-  rw [integral_physHermite_mul_physHermite_eq_integral_deriv, iterated_deriv_physHermite_eq_aeval]
+  rw [integral_physHermite_mul_physHermite_eq_integral_deriv,
+    iterate_deriv_physHermite_eq_iterate_derivative]
   simp [MeasureTheory.integral_const_mul, map_ofNat,
     show (∫ x : ℝ, Real.exp (-x ^ 2)) = √Real.pi by simpa using integral_gaussian 1]
 

--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -6,9 +6,11 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 module
 
 public import Mathlib.Analysis.Calculus.Deriv.Polynomial
+public import Mathlib.Analysis.Calculus.ContDiff.Polynomial
 public import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Series
 public import Mathlib.Tactic.Cases
+public import Mathlib.Topology.Algebra.Polynomial
 /-!
 
 # Physicists Hermite Polynomial
@@ -234,13 +236,19 @@ lemma physHermite_odd {n : ℕ} (hn : Odd n) : Function.Odd (physHermite n) := b
 -/
 
 @[fun_prop]
-lemma physHermite_differentiableAt (n : ℕ) (x : ℝ) :
-    DifferentiableAt ℝ (physHermite n) x := Polynomial.differentiableAt_aeval (physHermite n)
+lemma physHermite_differentiable (n : ℕ) : Differentiable ℝ (physHermite n) :=
+  Polynomial.differentiable_aeval _
 
 @[fun_prop]
-lemma deriv_physHermite_differentiableAt (n m : ℕ) (x : ℝ) :
-    DifferentiableAt ℝ (deriv^[m] (physHermite n)) x :=
-  iterate_deriv_physHermite_eq_iterate_derivative n m ▸ Polynomial.differentiableAt_aeval _
+lemma deriv_physHermite_differentiable (n m : ℕ) : Differentiable ℝ (deriv^[m] (physHermite n)) :=
+  iterate_deriv_physHermite_eq_iterate_derivative n m ▸ Polynomial.differentiable_aeval _
+
+@[fun_prop]
+lemma physHermite_continuous (n : ℕ) : Continuous (physHermite n) := Polynomial.continuous_aeval _
+
+@[fun_prop]
+lemma physHermite_contDiff (n : ℕ) (m : WithTop ℕ∞) : ContDiff ℝ m (physHermite n) :=
+  Polynomial.contDiff_aeval _ _
 
 /-!
 ### D.4. Temperate growth

--- a/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
+++ b/Physlib/Mathematics/SpecialFunctions/PhysHermite.lean
@@ -218,11 +218,16 @@ lemma fderiv_physHermite (n : ℕ) (x : ℝ) :
 ### D.2. Parity
 -/
 
+@[simp]
 lemma physHermite_neg (n : ℕ) (x : ℝ) : physHermite n (-x) = (-1) ^ n * physHermite n x := by
   match n with
   | 0 => simp
   | 1 => simp [map_ofNat]
   | n + 2 => grind [physHermite_succ_apply', physHermite_neg (n + 1), physHermite_neg n]
+
+lemma physHermite_even {n : ℕ} (hn : Even n) : Function.Even (physHermite n) := by intro; simp [hn]
+
+lemma physHermite_odd {n : ℕ} (hn : Odd n) : Function.Odd (physHermite n) := by intro; simp [hn]
 
 /-!
 ### D.3. Differentiability

--- a/Physlib/QuantumMechanics/HarmonicOscillator/OneDimension/Completeness.lean
+++ b/Physlib/QuantumMechanics/HarmonicOscillator/OneDimension/Completeness.lean
@@ -31,7 +31,7 @@ namespace HarmonicOscillator
 variable (Q : HarmonicOscillator)
 
 open Module Nat
-open Physlib
+open Polynomial
 open MeasureTheory HilbertSpace InnerProductSpace
 
 /-

--- a/Physlib/QuantumMechanics/HarmonicOscillator/OneDimension/Eigenfunction.lean
+++ b/Physlib/QuantumMechanics/HarmonicOscillator/OneDimension/Eigenfunction.lean
@@ -22,7 +22,7 @@ namespace HarmonicOscillator
 
 variable (Q : HarmonicOscillator)
 
-open Nat Physlib HilbertSpace MeasureTheory Constants
+open Nat Polynomial HilbertSpace MeasureTheory Constants
 
 /-- The `n`th eigenfunction of the Harmonic oscillator is defined as the function `ℝ → ℂ`
   taking `x : ℝ` to
@@ -129,7 +129,7 @@ lemma eigenfunction_square_integrable (n : ℕ) :
   conv =>
     enter [1, x]
     rw [eigenfunction_point_norm_sq]
-    rw [physHermite_pow, h0]
+    rw [← map_pow, h0]
     enter [2, 1, 1, 1]
     rw [← one_div_mul_eq_div]
   apply MeasureTheory.Integrable.const_mul
@@ -169,7 +169,7 @@ lemma eigenfunction_parity (n : ℕ) :
   simp only [parityOperator, LinearMap.coe_mk, AddHom.coe_mk, Pi.mul_apply, Pi.pow_apply,
     Pi.neg_apply, Pi.one_apply]
   rw [show -x / Q.ξ = - (x / Q.ξ) by ring]
-  rw [← physHermite_eq_aeval, physHermite_parity]
+  rw [physHermite_neg]
   simp only [Complex.ofReal_mul, Complex.ofReal_pow, Complex.ofReal_neg, Complex.ofReal_one]
   ring_nf
 

--- a/Physlib/QuantumMechanics/HarmonicOscillator/OneDimension/TISE.lean
+++ b/Physlib/QuantumMechanics/HarmonicOscillator/OneDimension/TISE.lean
@@ -21,7 +21,7 @@ namespace HarmonicOscillator
 
 variable (Q : HarmonicOscillator)
 
-open Nat Physlib HilbertSpace Constants
+open Nat Polynomial HilbertSpace Constants
 
 /-- The `n`th eigenvalues for a Harmonic oscillator is defined as `(n + 1/2) * ℏ * ω`. -/
 noncomputable def eigenValue (n : ℕ) : ℝ := (n + 1/2) * ℏ * Q.ω
@@ -67,11 +67,12 @@ lemma deriv_eigenfunction_zero' : deriv (Q.eigenfunction 0) =
 lemma deriv_physHermite_characteristic_length (n : ℕ) :
     deriv (fun x => Complex.ofReal (physHermite n (x/Q.ξ))) = fun x =>
     Complex.ofReal (1/Q.ξ) * 2 * n * physHermite (n-1) (x/Q.ξ) := by
+  change deriv (fun x ↦ Complex.ofReal ((physHermite n ∘ fun x ↦ x / Q.ξ) x)) = _
   funext x
-  have hd : DifferentiableAt ℝ (fun x => physHermite n (x / Q.ξ)) x := by fun_prop
-  rw [(hd.hasDerivAt.ofReal_comp).deriv, deriv_physHermite' x (fun x => x / Q.ξ) (by fun_prop)]
-  simp only [deriv_div_const, deriv_id'']
-  push_cast
+  have hd : DifferentiableAt ℝ (physHermite n ∘ fun x ↦ x / Q.ξ) x := by fun_prop
+  rw [(hd.hasDerivAt.ofReal_comp).deriv, deriv_comp _ (by fun_prop) (by fun_prop)]
+  simp only [deriv_physHermite, Pi.mul_apply, Pi.ofNat_apply, Pi.natCast_apply, deriv_div_const,
+    deriv_id'', Complex.ofReal_mul, Complex.ofReal_ofNat, Complex.ofReal_natCast]
   ring
 
 lemma deriv_eigenfunction_succ (n : ℕ) :
@@ -162,8 +163,7 @@ lemma deriv_deriv_eigenfunction (n : ℕ) (x : ℝ) :
       rw [deriv_physHermite_characteristic_length]
       have hr : (physHermite (n + 1) (x / Q.ξ) : ℝ) =
           2 * (x / Q.ξ) * physHermite n (x / Q.ξ) - 2 * n * physHermite (n - 1) (x / Q.ξ) := by
-        rw [physHermite_succ_fun']
-        simp [nsmul_eq_mul]
+        rw [physHermite_succ_apply']
       rw [hr]
       push_cast
       ring


### PR DESCRIPTION
- Organizes the first half of `Physlib/Mathematics/SpecialFunctions/PhysHermite.lean` into sections and adds some basic documentation.
- Adds `ContDiff` and `HasTemperateGrowth` properties for the coercions to `ℝ → ℝ`; these will be needed when constructing the QHO eigenstates using `SchwartzMap.smulLeftCLM`.