### PR TITLE
feat(ClassicalMechanics): inertia tensor about a point and the parallel-axis theorem

### DIFF
--- a/Physlib/ClassicalMechanics/RigidBody/API-map.yaml
+++ b/Physlib/ClassicalMechanics/RigidBody/API-map.yaml
@@ -6,7 +6,9 @@ Overview: |
     The key data structure is `RigidBody d`, a rigid body in `d` dimensions specified by
     its mass distribution (a linear map from smooth functions on `Space d` to `ℝ`). The API
     provides the body's total mass, centre of mass and inertia tensor, and works out the
-    solid sphere as a concrete example.
+    solid sphere as a concrete example. The inertia tensor is also available about an arbitrary
+    point, and the parallel-axis theorem expresses it in terms of the inertia tensor about the
+    centre of mass.
 
     A rigid body *in motion*, `RigidBodyMotion d`, additionally records the centre-of-mass
     trajectory and the time-dependent orientation. From these the API builds the
@@ -48,6 +50,14 @@ Requirements:
   - description: The inertia tensor of the rigid body is symmetric.
     done: true
     location: Physlib/ClassicalMechanics/RigidBody/Basic.lean (RigidBody.inertiaTensor_symmetric)
+
+  - description: >
+      The API allows the calculation of the inertia tensor about an arbitrary point, and contains
+      the parallel-axis theorem relating it to the inertia tensor about the centre of mass.
+    done: true
+    location: >
+      Physlib/ClassicalMechanics/RigidBody/Basic.lean
+      (RigidBody.inertiaTensorAbout, RigidBody.inertiaTensorAbout_eq_centerOfMass_add_pointMass)
 
   - description: >
       The API provides the solid sphere as a worked example, with its total mass and centre

--- a/Physlib/ClassicalMechanics/RigidBody/Basic.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Basic.lean
@@ -19,6 +19,11 @@ In this module we will define the basic properties of a rigid body, including
 - mass
 - center of mass
 - inertia tensor
+- inertia tensor about an arbitrary point
+
+The moments of the last are taken about the given point rather than about the origin of the
+reference frame. The parallel-axis theorem expresses it in terms of the inertia tensor about the
+centre of mass.
 
 ## References
 - Landau and Lifshitz, Mechanics, page 100, Section 32
@@ -26,7 +31,7 @@ In this module we will define the basic properties of a rigid body, including
 
 @[expose] public section
 
-open Manifold
+open Manifold InnerProductSpace
 
 TODO "The definition of a rigid body is currently defined via linear maps
   from the space of smooth functions to ℝ. When possible, it should be change
@@ -90,6 +95,87 @@ lemma rho_coord_sub_centerOfMass {d : ℕ} (R : RigidBody d) (h : R.mass ≠ 0) 
     rw [hc, smul_eq_mul, one_div, ← mul_assoc, mul_inv_cancel₀ h, one_mul]
   rw [hsplit, map_sub, map_smul, R.rho_one, hcoord, smul_eq_mul]
   ring
+
+/-- The inertia tensor of the rigid body about the point `p`, that is with the moments taken
+about `p` rather than about the origin of the reference frame. Taking `p` to be the origin
+recovers `RigidBody.inertiaTensor`, see `RigidBody.inertiaTensorAbout_zero`. -/
+noncomputable def inertiaTensorAbout {d : ℕ} (R : RigidBody d) (p : Space d) :
+    Matrix (Fin d) (Fin d) ℝ := fun i j =>
+  R.ρ (cmap (fun y => (if i = j then 1 else 0) * ∑ k : Fin d, (y k - p k) ^ 2
+    - (y i - p i) * (y j - p j)) (by fun_prop))
+
+/-- The `(i, j)` entry of the inertia tensor about `p` as a moment of the mass distribution. -/
+lemma inertiaTensorAbout_apply {d : ℕ} (R : RigidBody d) (p : Space d) (i j : Fin d) :
+    R.inertiaTensorAbout p i j = R.ρ (cmap (fun y => (if i = j then 1 else 0) *
+      ∑ k : Fin d, (y k - p k) ^ 2 - (y i - p i) * (y j - p j)) (by fun_prop)) := rfl
+
+/-- The inertia tensor about the origin is the inertia tensor. -/
+@[simp]
+lemma inertiaTensorAbout_zero {d : ℕ} (R : RigidBody d) :
+    R.inertiaTensorAbout 0 = R.inertiaTensor := by
+  ext i j
+  simp [inertiaTensorAbout, inertiaTensor, cmap]
+
+/-- The inertia tensor about any point is symmetric. -/
+lemma inertiaTensorAbout_symmetric {d : ℕ} (R : RigidBody d) (p : Space d) (i j : Fin d) :
+    R.inertiaTensorAbout p i j = R.inertiaTensorAbout p j i := by
+  simp only [inertiaTensorAbout, eq_comm, mul_comm]
+
+/-- The integrand of the inertia tensor about `p` splits into the integrand about the centre of
+mass, terms linear in the centred coordinates `y − c`, and a constant built from the
+displacement `c − p`. -/
+lemma inertiaTensorAbout_integrand_split {d : ℕ} (R : RigidBody d) (p : Space d) (i j : Fin d) :
+    cmap (fun y => (if i = j then 1 else 0) * ∑ k : Fin d, (y k - p k) ^ 2
+        - (y i - p i) * (y j - p j)) (by fun_prop)
+      = cmap (fun y => (if i = j then 1 else 0) * ∑ k : Fin d, (y k - R.centerOfMass k) ^ 2
+            - (y i - R.centerOfMass i) * (y j - R.centerOfMass j)) (by fun_prop)
+        + ∑ k : Fin d, (2 * (if i = j then 1 else 0) * (R.centerOfMass k - p k)) •
+            cmap (fun y => y k - R.centerOfMass k) (by fun_prop)
+        - (R.centerOfMass j - p j) • cmap (fun y => y i - R.centerOfMass i) (by fun_prop)
+        - (R.centerOfMass i - p i) • cmap (fun y => y j - R.centerOfMass j) (by fun_prop)
+        + ((if i = j then 1 else 0) * ∑ k : Fin d, (R.centerOfMass k - p k) ^ 2
+            - (R.centerOfMass i - p i) * (R.centerOfMass j - p j)) •
+          (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) := by
+  ext y
+  simp only [cmap_apply, ContMDiffMap.coe_add, ContMDiffMap.coe_sub, ContMDiffMap.coe_smul,
+    ContMDiffMap.coe_one, Pi.add_apply, Pi.sub_apply, Pi.smul_apply, Pi.one_apply]
+  rw [← ContMDiffMap.coeFnAddMonoidHom_apply, map_sum, Finset.sum_apply]
+  simp only [ContMDiffMap.coeFnAddMonoidHom_apply, ContMDiffMap.coe_smul, Pi.smul_apply,
+    cmap_apply, smul_eq_mul]
+  have hlin (a : ℝ) : ∑ k : Fin d, a * (R.centerOfMass k - p k) * (y k - R.centerOfMass k)
+      = a * ∑ k : Fin d, (R.centerOfMass k - p k) * (y k - R.centerOfMass k) := by
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl fun k _ => by ring
+  have hsum : ∑ k : Fin d, (y k - p k) ^ 2
+      = ∑ k : Fin d, ((y k - R.centerOfMass k) ^ 2
+        + 2 * (R.centerOfMass k - p k) * (y k - R.centerOfMass k)
+        + (R.centerOfMass k - p k) ^ 2) := Finset.sum_congr rfl fun k _ => by ring
+  rw [hsum, Finset.sum_add_distrib, Finset.sum_add_distrib, hlin, hlin]
+  ring
+
+/-- **The parallel-axis theorem**: the inertia tensor about a point `p` is the inertia tensor
+about the centre of mass `c` plus the inertia tensor about `p` of a point particle carrying the
+total mass of the body and sitting at `c`, that is `M (|c − p|² 1 − (c − p) ⊗ (c − p))`. -/
+theorem inertiaTensorAbout_eq_centerOfMass_add_pointMass {d : ℕ} (R : RigidBody d) (h : R.mass ≠ 0)
+    (p : Space d) :
+    R.inertiaTensorAbout p = R.inertiaTensorAbout R.centerOfMass
+      + R.mass • (⟪R.centerOfMass - p, R.centerOfMass - p⟫_ℝ • (1 : Matrix (Fin d) (Fin d) ℝ)
+        - Matrix.vecMulVec ⇑(R.centerOfMass - p) ⇑(R.centerOfMass - p)) := by
+  ext i j
+  rw [inertiaTensorAbout_apply, inertiaTensorAbout_integrand_split R p i j, map_add, map_sub,
+    map_sub, map_add, map_sum, ← inertiaTensorAbout_apply]
+  simp only [map_smul, R.rho_coord_sub_centerOfMass h, smul_eq_mul, mul_zero,
+    Finset.sum_const_zero, R.rho_one, Matrix.add_apply, Matrix.smul_apply, Matrix.sub_apply,
+    Matrix.one_apply, Matrix.vecMulVec_apply, Space.inner_eq_sum, Space.sub_apply, pow_two]
+  ring
+
+/-- The inertia tensor about the origin is the inertia tensor about the centre of mass `c` plus
+`M (|c|² 1 − c ⊗ c)`. -/
+lemma inertiaTensor_eq_centerOfMass_add_pointMass {d : ℕ} (R : RigidBody d) (h : R.mass ≠ 0) :
+    R.inertiaTensor = R.inertiaTensorAbout R.centerOfMass
+      + R.mass • (⟪R.centerOfMass, R.centerOfMass⟫_ℝ • (1 : Matrix (Fin d) (Fin d) ℝ)
+        - Matrix.vecMulVec ⇑R.centerOfMass ⇑R.centerOfMass) := by
+  simpa using R.inertiaTensorAbout_eq_centerOfMass_add_pointMass h 0
 
 /-- One can describe the motion of rigid body with a fixed (inertial) coordinate system (X,Y,Z)
     and a moving system (x₁,x₂,x₃) rigidly attached to the body. -/
@@ -155,12 +241,6 @@ informal_lemma rotational_equation_inertial where
     Here V is the velocity of the centre of mass and I_CM is the inertia tensor about that point. -/
 informal_lemma kinetic_energy_decomposition where
   tag := "LL32-TK"
-  deps := [``RigidBody]
-
-/-- If I_O is the inertia tensor about a point O, then the inertia tensor about a parallel point O'
-    displaced by a is I_{O'} = I_O + M(|a|² 1 − a ⊗ a). This is the parallel-axis theorem. -/
-informal_lemma parallel_axis_theorem where
-  tag := "LL32-PA"
   deps := [``RigidBody]
 
 /-- Because the inertia tensor is real symmetric, there exists an orthonormal basis of principal


### PR DESCRIPTION
Adds the inertia tensor of a rigid body **about an arbitrary point** and proves the
**parallel-axis theorem**, discharging the `parallel_axis_theorem` informal lemma
(tag `LL32-PA`, Landau & Lifshitz, *Mechanics*, §32).

Everything lives in `Physlib/ClassicalMechanics/RigidBody/Basic.lean`, next to `inertiaTensor`
(+95 / −8 lines, one file, plus the API map).

### What is added

| Declaration | What it is |
| --- | --- |
| `RigidBody.inertiaTensorAbout R p` | the inertia tensor with the moments taken about `p` rather than about the origin of the reference frame |
| `RigidBody.inertiaTensorAbout_apply` | its `(i, j)` entry as a moment of the mass distribution (`rfl`) |
| `RigidBody.inertiaTensorAbout_zero` | `inertiaTensorAbout 0 = inertiaTensor`, identifying the new definition with the existing one |
| `RigidBody.inertiaTensorAbout_symmetric` | symmetry, about any point |
| `RigidBody.inertiaTensorAbout_integrand_split` | the algebraic split of the integrand about `p` into the integrand about the centre of mass, terms linear in the centred coordinates `y − c`, and a constant |
| `RigidBody.inertiaTensorAbout_eq_centerOfMass_add_pointMass` | **the parallel-axis theorem**, `I(p) = I(c) + M (\|c − p\|² 1 − (c − p) ⊗ (c − p))` |
| `RigidBody.inertiaTensor_eq_centerOfMass_add_pointMass` | its specialisation to the origin, `I(0) = I(c) + M (\|c\|² 1 − c ⊗ c)` |

The `parallel_axis_theorem` informal lemma is removed (replaced by the formal statement) and the
API map gains the corresponding requirement.

### Reading order

1. `inertiaTensorAbout` and `inertiaTensorAbout_apply` — the definition.
2. `inertiaTensorAbout_integrand_split` — pure algebra on test functions: `y − p = (y − c) + (c − p)`
   expands the integrand into the centred integrand, terms linear in `y − c`, and a constant.
3. `inertiaTensorAbout_eq_centerOfMass_add_pointMass` — apply `ρ`; the linear terms die by
   `rho_coord_sub_centerOfMass` (the first moment about the centre of mass vanishes, whence the
   `R.mass ≠ 0` hypothesis) and the constant contributes `M` times itself.

### Two points I would flag

* **The informal statement was true only about the centre of mass.** Its docstring read
  `I_{O'} = I_O + M(|a|² 1 − a ⊗ a)` for a displacement `a` between two arbitrary points; that
  holds when `O` is the centre of mass, otherwise first-moment terms survive. The formal theorem
  therefore takes the centre of mass as the base point, which is the L&L §32 statement.
* **Why `inertiaTensor` is not redefined as `inertiaTensorAbout 0`.** `inertiaTensor` is the
  origin-based notion already used by `angularMomentum` and `rotationalKineticEnergy`, so I left
  it as the primitive and added `inertiaTensorAbout_zero` (a `simp` lemma) as the bridge, keeping
  the diff to one file. Happy to invert the definitional order if you prefer it the other way.

If the inertia API grows further (principal axes, the spatial tensor `R I Rᵀ`), these declarations
would naturally move together into a dedicated `RigidBody/Inertia.lean`; that seemed premature for
this PR.

### Verification

* `lake build` — full aggregate, 9264 jobs, green; `Basic.lean` recompiles from scratch with no
  warnings.
* `lake exe runPhyslibLinters` — `Linting passed for Physlib.`
* `lake exe check_file_imports`, `lake exe check_dup_tags`, `lake exe sorry_lint` — all pass.
* `./scripts/lint-style.sh` — exit 0; `python scripts/api_map_linter.py --repo .` — `[ok]` for
  `RigidBody/API-map.yaml`.
* `#print axioms` on all seven new declarations — `[propext, Classical.choice, Quot.sound]` only.

AI disclosure: drafted with Claude Code (see the commit trailer); every statement and proof has
been read and checked by me.
