### PR TITLE
feat(Mathematics): Levi-Civita symbol in general dimension

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -116,6 +116,7 @@ public import Physlib.Mathematics.InnerProductSpace.Gaussian
 public import Physlib.Mathematics.InnerProductSpace.Submodule
 public import Physlib.Mathematics.KroneckerDelta.Basic
 public import Physlib.Mathematics.KroneckerDelta.Contraction
+public import Physlib.Mathematics.LeviCivita.Basic
 public import Physlib.Mathematics.LinearMaps
 public import Physlib.Mathematics.LinearPMap
 public import Physlib.Mathematics.List

--- a/Physlib/Mathematics/LeviCivita/Basic.lean
+++ b/Physlib/Mathematics/LeviCivita/Basic.lean
@@ -30,6 +30,7 @@ permutation via `Matrix.det_permutation`.
 - `leviCivitaSymbol_id` : the normalization `ε_{0 1 ⋯ (d-1)} = 1`.
 - `leviCivitaSymbol_perm` : on a permutation `σ` the symbol is the sign of `σ`.
 - `leviCivitaSymbol_comp_swap` : antisymmetry under transposition of two indices.
+- `leviCivitaSymbol_swap_comp` : antisymmetry under transposition of two index values.
 - `leviCivitaSymbol_eq_zero_iff` : the symbol vanishes exactly on repeated indices.
 
 ## iii. Table of contents
@@ -107,6 +108,18 @@ precomposing with the swap of two distinct index positions negates it. -/
 lemma leviCivitaSymbol_comp_swap (g : ι → ι) {i j : ι} (hij : i ≠ j) :
     leviCivitaSymbol (g ∘ Equiv.swap i j) = - leviCivitaSymbol g :=
   generalizedKroneckerDelta_swap g id hij
+
+/-- The Levi-Civita symbol is antisymmetric under transposition of two index values:
+postcomposing with the swap of two distinct values exchanges those two values wherever
+they occur and negates it. -/
+lemma leviCivitaSymbol_swap_comp (g : ι → ι) {i j : ι} (hij : i ≠ j) :
+    leviCivitaSymbol (Equiv.swap i j ∘ g) = - leviCivitaSymbol g := by
+  have h : (fun a b => ((kroneckerDelta ((Equiv.swap i j ∘ g) a) b : ℕ) : ℤ))
+      = Matrix.submatrix (fun a b => ((kroneckerDelta (g a) b : ℕ) : ℤ)) id (Equiv.swap i j) :=
+    funext fun a => funext fun b => by simp [kroneckerDelta, Equiv.swap_apply_eq_iff]
+  rw [leviCivitaSymbol_eq_det, h, Matrix.det_permute', Equiv.Perm.sign_swap hij,
+    ← leviCivitaSymbol_eq_det]
+  simp
 
 /-!
 

--- a/Physlib/Mathematics/LeviCivita/Basic.lean
+++ b/Physlib/Mathematics/LeviCivita/Basic.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2026 Robert Sneiderman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Sneiderman
+-/
+module
+
+public import Physlib.Mathematics.KroneckerDelta.Basic
+public import Mathlib.LinearAlgebra.Matrix.Permutation
+/-!
+
+# The Levi-Civita symbol in general dimension
+
+## i. Overview
+
+This module defines the Levi-Civita symbol `leviCivitaSymbol` on a general finite index
+type `ι`: for `g : ι → ι` it is the sign of `g` when `g` is a permutation and `0`
+otherwise. Taking `ι = Fin d` gives the Levi-Civita symbol `ε_{i₁ ⋯ i_d}` in dimension
+`d`, normalized by `ε_{0 1 ⋯ (d-1)} = 1`.
+
+The definition is the `generalizedKroneckerDelta` of `g` against the identity, i.e. the
+determinant of the matrix of Kronecker deltas `δ[g i, j]`, so the basic properties are
+inherited from the determinant: the value `1` on the identity, antisymmetry under
+transposition of two indices, vanishing on repeated indices, and the sign of a
+permutation via `Matrix.det_permutation`.
+
+## ii. Key results
+
+- `leviCivitaSymbol` : the Levi-Civita symbol on a finite index type, valued in `ℤ`.
+- `leviCivitaSymbol_id` : the normalization `ε_{0 1 ⋯ (d-1)} = 1`.
+- `leviCivitaSymbol_perm` : on a permutation `σ` the symbol is the sign of `σ`.
+- `leviCivitaSymbol_comp_swap` : antisymmetry under transposition of two indices.
+- `leviCivitaSymbol_eq_zero_iff` : the symbol vanishes exactly on repeated indices.
+
+## iii. Table of contents
+
+- A. Definition
+- B. Value on permutations
+- C. Antisymmetry
+- D. Vanishing on repeated indices
+
+## iv. References
+
+- https://en.wikipedia.org/wiki/Levi-Civita_symbol
+
+-/
+
+@[expose] public section
+
+open KroneckerDelta
+
+/-!
+
+## A. Definition
+
+-/
+
+variable {ι : Type} [DecidableEq ι] [Fintype ι]
+
+/-- The Levi-Civita symbol on a finite index type `ι`: `leviCivitaSymbol g` is the sign
+of `g` when `g : ι → ι` is a permutation, and `0` otherwise. It is the generalized
+Kronecker delta of `g` against the identity, i.e. the determinant of the matrix of
+Kronecker deltas `δ[g i, j]`.
+
+For `ι = Fin d` this is the Levi-Civita symbol `ε_{i₁ ⋯ i_d}` in dimension `d`,
+normalized by `ε_{0 1 ⋯ (d-1)} = 1`. -/
+def leviCivitaSymbol (g : ι → ι) : ℤ :=
+  generalizedKroneckerDelta g (id : ι → ι)
+
+/-- The Levi-Civita symbol as the determinant of the matrix of Kronecker deltas
+`δ[g i, j]`. -/
+lemma leviCivitaSymbol_eq_det (g : ι → ι) :
+    leviCivitaSymbol g = Matrix.det (fun i j => ((kroneckerDelta (g i) j : ℕ) : ℤ)) :=
+  rfl
+
+/-- The Levi-Civita symbol of the identity, i.e. `ε_{0 1 ⋯ (d-1)}`, is `1`. -/
+@[simp]
+lemma leviCivitaSymbol_id : leviCivitaSymbol (id : ι → ι) = 1 := by
+  rw [leviCivitaSymbol_eq_det, show (fun i j => ((kroneckerDelta (id i : ι) j : ℕ) : ℤ))
+    = (1 : Matrix ι ι ℤ) from funext fun i => funext fun j => by
+      simp [kroneckerDelta, Matrix.one_apply]]
+  exact Matrix.det_one
+
+/-!
+
+## B. Value on permutations
+
+-/
+
+/-- The Levi-Civita symbol of a permutation `σ` is the sign of `σ`. -/
+@[simp]
+lemma leviCivitaSymbol_perm (σ : Equiv.Perm ι) :
+    leviCivitaSymbol ⇑σ = (Equiv.Perm.sign σ : ℤ) := by
+  rw [leviCivitaSymbol_eq_det, show (fun i j => ((kroneckerDelta (σ i) j : ℕ) : ℤ))
+    = σ.permMatrix ℤ from funext fun i => funext fun j => by
+      simp [kroneckerDelta, PEquiv.toMatrix_apply, Equiv.toPEquiv_apply, eq_comm]]
+  exact Matrix.det_permutation σ
+
+/-!
+
+## C. Antisymmetry
+
+-/
+
+/-- The Levi-Civita symbol is antisymmetric under transposition of two of its indices:
+precomposing with the swap of two distinct index positions negates it. -/
+lemma leviCivitaSymbol_comp_swap (g : ι → ι) {i j : ι} (hij : i ≠ j) :
+    leviCivitaSymbol (g ∘ Equiv.swap i j) = - leviCivitaSymbol g :=
+  generalizedKroneckerDelta_swap g id hij
+
+/-!
+
+## D. Vanishing on repeated indices
+
+-/
+
+/-- The Levi-Civita symbol vanishes on a repeated index: if two distinct index positions
+`i ≠ j` carry the same value, the symbol is zero. -/
+lemma leviCivitaSymbol_eq_zero_of_eq {g : ι → ι} {i j : ι} (hij : i ≠ j) (h : g i = g j) :
+    leviCivitaSymbol g = 0 := by
+  rw [leviCivitaSymbol_eq_det]
+  exact Matrix.det_zero_of_row_eq hij (funext fun c => by rw [h])
+
+/-- The Levi-Civita symbol vanishes on maps which are not injective. -/
+lemma leviCivitaSymbol_eq_zero_of_not_injective {g : ι → ι} (h : ¬ Function.Injective g) :
+    leviCivitaSymbol g = 0 := by
+  simp only [Function.Injective, not_forall] at h
+  obtain ⟨i, j, hgij, hij⟩ := h
+  exact leviCivitaSymbol_eq_zero_of_eq hij hgij
+
+/-- The Levi-Civita symbol vanishes exactly on maps with a repeated index, i.e. on maps
+which are not injective. -/
+lemma leviCivitaSymbol_eq_zero_iff {g : ι → ι} :
+    leviCivitaSymbol g = 0 ↔ ¬ Function.Injective g := by
+  refine ⟨fun h hinj => ?_, leviCivitaSymbol_eq_zero_of_not_injective⟩
+  obtain ⟨σ, rfl⟩ : ∃ σ : Equiv.Perm ι, ⇑σ = g :=
+    ⟨Equiv.ofBijective g (Finite.injective_iff_bijective.mp hinj), rfl⟩
+  rw [leviCivitaSymbol_perm] at h
+  exact Units.ne_zero (Equiv.Perm.sign σ) h

--- a/Physlib/Relativity/Tensors/LeviCivita/Basic.lean
+++ b/Physlib/Relativity/Tensors/LeviCivita/Basic.lean
@@ -9,7 +9,7 @@ public import Physlib.Relativity.Tensors.RealTensor.Basic
 public import Physlib.Relativity.Tensors.UnitTensor
 public import Physlib.Meta.Sorry
 public import Physlib.Relativity.Tensors.OfInt
-public import Physlib.Mathematics.KroneckerDelta.Basic
+public import Physlib.Mathematics.LeviCivita.Basic
 /-!
 
 # The Levi-Civita tensor as a real Lorentz tensor
@@ -28,6 +28,8 @@ components are carried by `TensorSpecies.Tensor.TensorInt.toTensor`.
 
 - `leviCivita` : the rank-four Levi-Civita tensor `ε4`, with `ε⁰¹²³ = 1`.
 - `leviCivita_basis_repr_apply` : its standard-basis components as a generalized Kronecker delta.
+- `leviCivita_basis_repr_eq_leviCivitaSymbol` : its standard-basis components as the
+  general-dimension Levi-Civita symbol `leviCivitaSymbol` at `ι = Fin 4`.
 - `leviCivita_antisymm`, `leviCivita_antisymm_mid`, `leviCivita_antisymm_last` : antisymmetry
   under each adjacent transposition of the indices.
 
@@ -82,6 +84,12 @@ lemma leviCivita_eq_ofInt : ε4 =
 def _root_.euclidLeviCivita (g : Fin 4 → Fin 4) : ℝ :=
   generalizedKroneckerDelta g (id : Fin 4 → Fin 4)
 
+/-- The Euclidean Levi-Civita symbol in dimension 4 is the general-dimension
+Levi-Civita symbol `leviCivitaSymbol` at `ι = Fin 4`, carried to the reals. -/
+lemma _root_.euclidLeviCivita_eq_leviCivitaSymbol (g : Fin 4 → Fin 4) :
+    euclidLeviCivita g = (leviCivitaSymbol g : ℝ) :=
+  rfl
+
 /-!
 
 ## B. Components in the standard basis
@@ -95,6 +103,15 @@ lemma leviCivita_basis_repr_apply
     (Tensor.basis _).repr ε4 b
       = (generalizedKroneckerDelta (fun i => finSumFinEquiv (b i)) (id : Fin 4 → Fin 4) : ℝ) := by
   rw [leviCivita_eq_ofInt, TensorInt.basis_repr_apply]
+
+/-- The components of the Levi-Civita tensor in the standard basis are the
+general-dimension Levi-Civita symbol `leviCivitaSymbol` of the multi-index at
+`ι = Fin 4`. -/
+lemma leviCivita_basis_repr_eq_leviCivitaSymbol
+    (b : ComponentIdx (S := realLorentzTensor 3) ![Color.up, Color.up, Color.up, Color.up]) :
+    (Tensor.basis _).repr ε4 b
+      = (leviCivitaSymbol (fun i => finSumFinEquiv (b i)) : ℝ) :=
+  leviCivita_basis_repr_apply b
 
 /-- The Levi-Civita tensor vanishes on any multi-index with a repeated value: if two distinct
 index positions `i ≠ j` carry the same basis index, the component is zero. -/

--- a/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
@@ -9,6 +9,7 @@ public import Physlib.SpaceAndTime.Space.Derivatives.Laplacian
 public import Mathlib.MeasureTheory.Integral.CurveIntegral.Poincare
 public import Physlib.SpaceAndTime.Space.CrossProduct
 public import Mathlib.Analysis.Calculus.ParametricIntervalIntegral
+public import Physlib.Mathematics.LeviCivita.Basic
 
 /-!
 
@@ -27,6 +28,8 @@ We also prove some basic vector-identities involving of the curl operator.
 - `distCurl` : The curl operator on distributions from `Space 3` to `EuclideanSpace ℝ (Fin 3)`.
 - `div_of_curl_eq_zero` : The divergence of the curl of a function is zero.
 - `distCurl_distGrad_eq_zero` : The curl of the gradient of a distribution is zero.
+- `curl_eq_sum_leviCivitaSymbol` : The components of the curl as a contraction with the
+  Levi-Civita symbol.
 
 ## iii. Table of contents
 
@@ -41,6 +44,7 @@ We also prove some basic vector-identities involving of the curl operator.
   - A.8. The curl of a curl
   - A.9. A divergence-free field is a curl
   - A.10. A curl-free field is a gradient
+  - A.11. The curl in terms of the Levi-Civita symbol
 - B. The curl on distributions
   - B.1. The components of the curl
   - B.2. Basic equalities
@@ -651,6 +655,26 @@ lemma eq_grad_integral_of_curl_zero (f : Space → EuclideanSpace ℝ (Fin 3)) (
 
 TODO "Generalize the statement that a curl-free field is a gradient
   to time-dependent fields."
+
+/-!
+
+### A.11. The curl in terms of the Levi-Civita symbol
+
+-/
+
+open KroneckerDelta in
+/-- The components of the curl as a contraction with the Levi-Civita symbol,
+`(∇ ⨯ f) x i = ∑ j k, ε_{ijk} ∂[j] fₖ x`. -/
+lemma curl_eq_sum_leviCivitaSymbol (f : Space → EuclideanSpace ℝ (Fin 3))
+    (x : Space) (i : Fin 3) :
+    (∇ ⨯ f) x i = ∑ j, ∑ k, (leviCivitaSymbol ![i, j, k] : ℝ) * ∂[j] (fun y => f y k) x := by
+  fin_cases i <;>
+    simp only [curl, Fin.isValue, Fin.zero_eta, Fin.mk_one, Fin.reduceFinMk, Fin.reduceAdd,
+      Fin.sum_univ_three, leviCivitaSymbol_eq_det, Matrix.det_fin_three, kroneckerDelta,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.head_cons,
+      Matrix.tail_cons] <;>
+    norm_num <;>
+    ring
 
 /-!
 


### PR DESCRIPTION
This adds the Levi-Civita symbol in general dimension, with the basic lemmas: antisymmetry under swaps, vanishing exactly on repeated indices, the value on the identity, and agreement with the rank-4 Lorentz tensor in the existing relativity file. A lemma expresses the components of curl as a contraction with the symbol, leaving the definition of curl unchanged. This covers the epsilon items of #457; the remaining boxes there stay open.
