### PR TITLE
feat(Units): parameterize the typed unit side (UnitSystem, LTMCTUnitChoices, SIUnitChoices)

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -524,6 +524,7 @@ public import Physlib.Units.Integral
 public import Physlib.Units.LTMCTDimensionBase
 public import Physlib.Units.ParametricDimensionExamples
 public import Physlib.Units.ParametricUnits
+public import Physlib.Units.SIUnitChoices
 public import Physlib.Units.UnitDependent
 public import Physlib.Units.UnitSystem
 public import Physlib.Units.WithDim.Area

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -525,6 +525,7 @@ public import Physlib.Units.LTMCTDimensionBase
 public import Physlib.Units.ParametricDimensionExamples
 public import Physlib.Units.ParametricUnits
 public import Physlib.Units.UnitDependent
+public import Physlib.Units.UnitSystem
 public import Physlib.Units.WithDim.Area
 public import Physlib.Units.WithDim.Basic
 public import Physlib.Units.WithDim.Energy

--- a/Physlib/Units/Basic.lean
+++ b/Physlib/Units/Basic.lean
@@ -81,7 +81,7 @@ open NNReal
 
 /-- The choice of units. -/
 @[ext]
-structure UnitChoices where
+structure LTMCTUnitChoices where
   /-- The length unit. -/
   length : LengthUnit
   /-- The time unit. -/
@@ -93,12 +93,12 @@ structure UnitChoices where
   /-- The temperature unit. -/
   temperature : TemperatureUnit
 
-namespace UnitChoices
+namespace LTMCTUnitChoices
 
 /-- Given two choices of units `u1` and `u2` and a dimension `d`, the
   element of `ℝ≥0` corresponding to the scaling (by definition) of a quantity of dimension `d`
   when changing from units `u1` to `u2`. -/
-noncomputable def dimScale (u1 u2 : UnitChoices) :Dimension LTMCTDimensionBase →* ℝ≥0 where
+noncomputable def dimScale (u1 u2 : LTMCTUnitChoices) :Dimension LTMCTDimensionBase →* ℝ≥0 where
   toFun d :=
     (u1.length / u2.length) ^ (d.length : ℝ) *
     (u1.time / u2.time) ^ (d.time : ℝ) *
@@ -115,7 +115,7 @@ noncomputable def dimScale (u1 u2 : UnitChoices) :Dimension LTMCTDimensionBase �
     all_goals
       simp
 
-lemma dimScale_apply (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+lemma dimScale_apply (u1 u2 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     dimScale u1 u2 d =
       (u1.length / u2.length) ^ (d.length : ℝ) *
       (u1.time / u2.time) ^ (d.time : ℝ) *
@@ -124,16 +124,16 @@ lemma dimScale_apply (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
       (u1.temperature / u2.temperature) ^ (d.temperature : ℝ) := rfl
 
 @[simp]
-lemma dimScale_self (u : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+lemma dimScale_self (u : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     dimScale u u d = 1 := by
   simp [dimScale]
 
 @[simp]
-lemma dimScale_one (u1 u2 : UnitChoices) :
+lemma dimScale_one (u1 u2 : LTMCTUnitChoices) :
     dimScale u1 u2 1 = 1 := by
   simp [dimScale]
 
-lemma dimScale_transitive (u1 u2 u3 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+lemma dimScale_transitive (u1 u2 u3 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     dimScale u1 u2 d * dimScale u2 u3 d = dimScale u1 u3 d := by
   simp [dimScale]
   trans ((u1.length / u2.length) ^ (d.length : ℝ) * (u2.length / u3.length) ^ (d.length : ℝ)) *
@@ -151,23 +151,23 @@ lemma dimScale_transitive (u1 u2 u3 : UnitChoices) (d : Dimension LTMCTDimension
   field_simp
 
 @[simp]
-lemma dimScale_mul_symm (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+lemma dimScale_mul_symm (u1 u2 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     dimScale u1 u2 d * dimScale u2 u1 d = 1 := by
   rw [dimScale_transitive, dimScale_self]
 
 @[simp]
-lemma dimScale_coe_mul_symm (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+lemma dimScale_coe_mul_symm (u1 u2 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     (toReal (dimScale u1 u2 d)) * (toReal (dimScale u2 u1 d)) = 1 := by
   trans toReal (dimScale u1 u2 d * dimScale u2 u1 d)
   · rw [NNReal.coe_mul]
   simp
 
 @[simp]
-lemma dimScale_ne_zero (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+lemma dimScale_ne_zero (u1 u2 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     dimScale u1 u2 d ≠ 0 := by
   simp [dimScale]
 
-lemma dimScale_symm (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+lemma dimScale_symm (u1 u2 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     dimScale u1 u2 d = (dimScale u2 u1 d)⁻¹ := by
   simp only [dimScale_apply, mul_inv]
   congr
@@ -177,13 +177,13 @@ lemma dimScale_symm (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
   · rw [ChargeUnit.div_symm, inv_rpow]
   · rw [TemperatureUnit.div_symm, inv_rpow]
 
-lemma dimScale_of_inv_eq_swap (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+lemma dimScale_of_inv_eq_swap (u1 u2 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     dimScale u1 u2 d⁻¹ = dimScale u2 u1 d := by
   simp only [map_inv]
   conv_rhs => rw[dimScale_symm]
 
 @[simp]
-lemma smul_dimScale_injective {M : Type} [MulAction ℝ≥0 M] (u1 u2 : UnitChoices)
+lemma smul_dimScale_injective {M : Type} [MulAction ℝ≥0 M] (u1 u2 : LTMCTUnitChoices)
     (d : Dimension LTMCTDimensionBase) (m1 m2 : M) :
     (u1.dimScale u2 d) • m1 = (u1.dimScale u2 d) • m2 ↔ m1 = m2:= by
   refine IsUnit.smul_left_cancel ?_
@@ -192,13 +192,13 @@ lemma smul_dimScale_injective {M : Type} [MulAction ℝ≥0 M] (u1 u2 : UnitChoi
   simp
 
 @[simp]
-lemma dimScale_pos (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+lemma dimScale_pos (u1 u2 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     0 < (dimScale u1 u2 d) := by
   apply lt_of_le_of_ne
   · simp
   · exact Ne.symm (dimScale_ne_zero u1 u2 d)
 
-TODO "Make SI : UnitChoices computable, probably by
+TODO "Make SI : LTMCTUnitChoices computable, probably by
   replacing the axioms defining the units. See here:
   https://leanprover.zulipchat.com/#narrow/channel/479953-Physlib/topic/physical.20units/near/534914807"
 /-- The choice of units corresponding to SI units, that is
@@ -208,7 +208,7 @@ TODO "Make SI : UnitChoices computable, probably by
 - coulombs,
 - kelvin.
 -/
-noncomputable def SI : UnitChoices where
+noncomputable def SI : LTMCTUnitChoices where
   length := LengthUnit.meters
   time := TimeUnit.seconds
   mass := MassUnit.kilograms
@@ -230,10 +230,10 @@ lemma SI_charge : SI.charge = ChargeUnit.coulombs := rfl
 @[simp]
 lemma SI_temperature : SI.temperature = TemperatureUnit.kelvin := rfl
 
-/-- A `UnitChoices` which is related to `SI` by a prime scaling of each
+/-- A `LTMCTUnitChoices` which is related to `SI` by a prime scaling of each
   of the underlying units. This is useful in proving that a result is not
   dimensionally correct. -/
-noncomputable def SIPrimed : UnitChoices where
+noncomputable def SIPrimed : LTMCTUnitChoices where
   length := LengthUnit.scale 2 LengthUnit.meters
   time := TimeUnit.scale 3 TimeUnit.seconds
   mass := MassUnit.scale 5 MassUnit.kilograms
@@ -262,7 +262,7 @@ lemma dimScale_SIPrimed_SI (d : Dimension LTMCTDimensionBase) :
   simp [dimScale, SI, SIPrimed]
   rfl
 
-end UnitChoices
+end LTMCTUnitChoices
 
 /-!
 
@@ -293,7 +293,7 @@ class abbrev CarriesDimension (M : Type) := HasDim M, MulAction ℝ≥0 M
 
 Given a type `M` which carries a dimension `d`,
 we are interested in elements of `M` which depend on a choice of units, i.e. functions
-`UnitChoices → M`.
+`LTMCTUnitChoices → M`.
 
 We define both a proposition
 - `HasDimension f` which says that `f` scales correctly with units,
@@ -302,21 +302,21 @@ and a type
 
 -/
 
-/-- A quantity of type `M` which depends on a choice of units `UnitChoices` is said to be
-  of dimension `d` if it scales by `UnitChoices.dimScale u1 u2 d` under a change in units. -/
-def HasDimension {M : Type} [CarriesDimension M] (f : UnitChoices → M) : Prop :=
-  ∀ u1 u2 : UnitChoices, f u2 = UnitChoices.dimScale u1 u2 (dim M) • f u1
+/-- A quantity of type `M` which depends on a choice of units `LTMCTUnitChoices` is said to be
+  of dimension `d` if it scales by `LTMCTUnitChoices.dimScale u1 u2 d` under a change in units. -/
+def HasDimension {M : Type} [CarriesDimension M] (f : LTMCTUnitChoices → M) : Prop :=
+  ∀ u1 u2 : LTMCTUnitChoices, f u2 = LTMCTUnitChoices.dimScale u1 u2 (dim M) • f u1
 
-lemma hasDimension_iff {M : Type} [CarriesDimension M] (f : UnitChoices → M) :
-    HasDimension f ↔ ∀ u1 u2 : UnitChoices, f u2 =
-    UnitChoices.dimScale u1 u2 (dim M) • f u1 := by
+lemma hasDimension_iff {M : Type} [CarriesDimension M] (f : LTMCTUnitChoices → M) :
+    HasDimension f ↔ ∀ u1 u2 : LTMCTUnitChoices, f u2 =
+    LTMCTUnitChoices.dimScale u1 u2 (dim M) • f u1 := by
   rfl
 
-/-- The subtype of functions `UnitChoices → M`, for which `M` carries a dimension,
+/-- The subtype of functions `LTMCTUnitChoices → M`, for which `M` carries a dimension,
   which `HasDimension`. -/
 def Dimensionful (M : Type) [CarriesDimension M] := Subtype (HasDimension (M := M))
 
-instance {M : Type} [CarriesDimension M] : CoeFun (Dimensionful M) (fun _ => UnitChoices → M) where
+instance {M : Type} [CarriesDimension M] : CoeFun (Dimensionful M) (fun _ => LTMCTUnitChoices → M) where
   coe := Subtype.val
 
 @[ext]
@@ -342,19 +342,19 @@ instance {M : Type} [CarriesDimension M] : MulAction ℝ≥0 (Dimensionful M) wh
 
 @[simp]
 lemma Dimensionful.smul_apply {M : Type} [CarriesDimension M]
-    (a : ℝ≥0) (f : Dimensionful M) (u : UnitChoices) :
+    (a : ℝ≥0) (f : Dimensionful M) (u : LTMCTUnitChoices) :
     (a • f).1 u = a • f.1 u := rfl
 
 /-- For `M` carrying a dimension `d`, the equivalence between `M` and `Dimension M`,
   given a choice of units. -/
 noncomputable def CarriesDimension.toDimensionful {M : Type} [CarriesDimension M]
-    (u : UnitChoices) :
+    (u : LTMCTUnitChoices) :
     M ≃ Dimensionful M where
   toFun m := {
     val := fun u1 => (u.dimScale u1 (dim M)) • m
     property := fun u1 u2 => by
       simp [smul_smul]
-      rw [mul_comm, UnitChoices.dimScale_transitive]}
+      rw [mul_comm, LTMCTUnitChoices.dimScale_transitive]}
   invFun f := f.1 u
   left_inv m := by
     simp
@@ -364,5 +364,5 @@ noncomputable def CarriesDimension.toDimensionful {M : Type} [CarriesDimension M
     simpa using (f.2 u u1).symm
 
 lemma CarriesDimension.toDimensionful_apply_apply
-    {M : Type} [CarriesDimension M] (u1 u2 : UnitChoices) (m : M) :
+    {M : Type} [CarriesDimension M] (u1 u2 : LTMCTUnitChoices) (m : M) :
     (toDimensionful u1 m).1 u2 = (u1.dimScale u2 (dim M)) • m := by rfl

--- a/Physlib/Units/Basic.lean
+++ b/Physlib/Units/Basic.lean
@@ -316,7 +316,8 @@ lemma hasDimension_iff {M : Type} [CarriesDimension M] (f : LTMCTUnitChoices →
   which `HasDimension`. -/
 def Dimensionful (M : Type) [CarriesDimension M] := Subtype (HasDimension (M := M))
 
-instance {M : Type} [CarriesDimension M] : CoeFun (Dimensionful M) (fun _ => LTMCTUnitChoices → M) where
+instance {M : Type} [CarriesDimension M] :
+    CoeFun (Dimensionful M) (fun _ => LTMCTUnitChoices → M) where
   coe := Subtype.val
 
 @[ext]

--- a/Physlib/Units/Examples.lean
+++ b/Physlib/Units/Examples.lean
@@ -20,7 +20,7 @@ should not be used in the proofs of any other results other then those in this f
 @[expose] public section
 
 namespace UnitExamples
-open Dimension CarriesDimension UnitChoices UnitDependent HasDim
+open Dimension CarriesDimension LTMCTUnitChoices UnitDependent HasDim
 /-!
 
 ## Defining a length dependent on units
@@ -130,14 +130,14 @@ open DimSpeed
 /-- The equation `E = m c^2`, in this equation we `E` and `m` are implicitly in the
   units `u`, while the speed of light is explicitly written in those units. -/
 def EnergyMass (m : WithDim M𝓭 ℝ) (E : WithDim (M𝓭 * L𝓭 * L𝓭 * T𝓭⁻¹ * T𝓭⁻¹) ℝ)
-    (u : UnitChoices) : Prop :=
+    (u : LTMCTUnitChoices) : Prop :=
     E.1 = m.1 * (speedOfLight u).1 ^ 2
 
 /-- The equation `E = m c^2`, in this version everything is written explicitly in
   terms of a choice of units. -/
 def EnergyMass' (m : Dimensionful (WithDim M𝓭 ℝ))
     (E : Dimensionful (WithDim (M𝓭 * L𝓭 * L𝓭 * T𝓭⁻¹ * T𝓭⁻¹) ℝ))
-    (u : UnitChoices) : Prop :=
+    (u : LTMCTUnitChoices) : Prop :=
     (E.1 u).1 = (m.1 u).1 * (speedOfLight u).1 ^ 2
 
 /-- The lemma that the proposition `EnergyMass` is dimensionally correct-/
@@ -169,9 +169,9 @@ lemma example1_energyMass : EnergyMass ⟨2⟩ ⟨2 * 299792458 ^ 2⟩ SI := by
 /- The lemma `energyMass_isDimensionallyCorrect` allows us to scale the units
   of `example1_energyMass`, that is - we proved it in one set of units, but we get the result
   in any set of units. -/
-lemma example2_energyMass (u : UnitChoices) :
+lemma example2_energyMass (u : LTMCTUnitChoices) :
     EnergyMass (scaleUnit SI u ⟨2⟩) (scaleUnit SI u ⟨2 * 299792458 ^ 2⟩) u := by
-  conv_rhs => rw [← UnitChoices.scaleUnit_apply_fst SI u]
+  conv_rhs => rw [← LTMCTUnitChoices.scaleUnit_apply_fst SI u]
   rw [← energyMass_isDimensionallyCorrect SI u]
   simp only [scaleUnit_apply_fst, scaleUnit_apply_fun, scaleUnit_symm_apply,
     scaleUnit_apply_fun_left]

--- a/Physlib/Units/FDeriv.lean
+++ b/Physlib/Units/FDeriv.lean
@@ -34,7 +34,7 @@ variable {M1 M2 : Type} [NormedAddCommGroup M1] [NormedSpace ℝ M1]
     [SMulCommClass ℝ ℝ M2] [ContinuousConstSMul ℝ M2]
     [HasDim M2]
 
-lemma fderiv_apply_scaleUnit (u1 u2 : UnitChoices) (x dm : M1)
+lemma fderiv_apply_scaleUnit (u1 u2 : LTMCTUnitChoices) (x dm : M1)
     (f : M1 → M2) (hf : IsDimensionallyCorrect f) (f_diff : Differentiable ℝ f) :
     fderiv ℝ f (scaleUnit u2 u1 x) dm =
     u2.dimScale u1 (dim M2) • u1.dimScale u2 (dim M1) • fderiv ℝ f x dm := by
@@ -69,4 +69,4 @@ lemma fderiv_dimension_const_direction (dm : M1) (f : M1 → M2) (hf : IsDimensi
       fderiv ℝ f x dm = v.1) := by
   simp [isDimensionallyCorrect_fun_iff, funext_iff, WithDim.scaleUnit_val,
     fderiv_apply_scaleUnit _ _ _ dm f hf f_diff,
-    ← smul_smul, ← UnitChoices.dimScale_symm]
+    ← smul_smul, ← LTMCTUnitChoices.dimScale_symm]

--- a/Physlib/Units/Integral.lean
+++ b/Physlib/Units/Integral.lean
@@ -54,7 +54,7 @@ variable {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M] [HasDim M]
     {G : Type}
     [NormedAddCommGroup G] [NormedSpace ℝ G] [HasDim G]
 
-lemma scaleUnit_measure (u1 u2 : UnitChoices) (μ : MeasureTheory.Measure M) :
+lemma scaleUnit_measure (u1 u2 : LTMCTUnitChoices) (μ : MeasureTheory.Measure M) :
     scaleUnit u1 u2 μ = μ.map (fun m => scaleUnit u1 u2 m) := by rfl
 
 /-- The statement that for a measure `μ` of dimension `d`, and a function
@@ -109,6 +109,6 @@ lemma integral_isDimensionallyCorrect (d : Dimension LTMCTDimensionBase) :
         * (u2.dimScale u1 d * u1.dimScale u2 d)) • ∫ (x : M), f x ∂ μ := by
       congr 1
       conv_lhs => simp only [map_mul]
-      rw [UnitChoices.dimScale_of_inv_eq_swap]
+      rw [LTMCTUnitChoices.dimScale_of_inv_eq_swap]
       ring
     _ = ∫ (x : M), f x ∂ μ := by simp

--- a/Physlib/Units/ParametricDimensionExamples.lean
+++ b/Physlib/Units/ParametricDimensionExamples.lean
@@ -37,7 +37,7 @@ equality definitional, so a cast on a proven equality is the correct idiom.
 
 Because `Dimension` is parametric, the same dimensional algebra and the same
 `cast`-based comparison are available over *any* basis — not just the physical
-`LTMCTDimensionBase`. The unit-scaling layer (`UnitChoices`, `dimScale`) is not needed
+`LTMCTDimensionBase`. The unit-scaling layer (`LTMCTUnitChoices`, `dimScale`) is not needed
 for either the algebra or the comparison, so neither is referenced here.
 
 This module is illustrative and should not be imported by other modules.

--- a/Physlib/Units/ParametricUnits.lean
+++ b/Physlib/Units/ParametricUnits.lean
@@ -11,8 +11,8 @@ public import Physlib.Units.Basic
 # The unit side, parametrised in the same basis
 
 The dimension basis is parametric (`Dimension B`), but the *unit* side of the
-bridge is hardwired in parallel: `UnitChoices` has five named unit fields and
-`UnitChoices.dimScale` folds over exactly those five. This module provides the
+bridge is hardwired in parallel: `LTMCTUnitChoices` has five named unit fields and
+`LTMCTUnitChoices.dimScale` folds over exactly those five. This module provides the
 generic twin, parametrised in the same basis `B`.
 
 Every PhysLib base unit (`LengthUnit`, `TimeUnit`, …) is, structurally, a positive
@@ -24,8 +24,8 @@ scaling homomorphism folds the per-base unit ratio over `B`:
 * `UnitScale.dimScale : UnitScale B → UnitScale B → Dimension B →* ℝ≥0` — the
   `MonoidHom` `d ↦ ∏ b, (u₁ b / u₂ b) ^ d.exponent b`, generic in `B`.
 
-The current five-field `UnitChoices.dimScale` is the `LTMCTDimensionBase` instance of this
-fold, written out by hand; `UnitChoices.toScale` exhibits the correspondence.
+The current five-field `LTMCTUnitChoices.dimScale` is the `LTMCTDimensionBase` instance of this
+fold, written out by hand; `LTMCTUnitChoices.toScale` exhibits the correspondence.
 
 -/
 
@@ -35,7 +35,7 @@ open NNReal
 open scoped BigOperators
 
 /-- A choice of unit for each base dimension of `B`: a positive-real magnitude per
-  base. This is the basis-generic form of `UnitChoices`. -/
+  base. This is the basis-generic form of `LTMCTUnitChoices`. -/
 @[ext]
 structure UnitScale (B : Type) where
   /-- The positive-real magnitude of the chosen unit at each base dimension. -/
@@ -53,7 +53,7 @@ lemma ratio_ne_zero (u1 u2 : UnitScale B) (b : B) : u1.scale b / u2.scale b ≠ 
 /-- The dimension-scaling homomorphism, generic in the basis `B`: a quantity of
   dimension `d` rescales by `∏ b, (u1 b / u2 b) ^ d.exponent b` when changing the
   unit choice from `u1` to `u2`. This is the basis-generic form of
-  `UnitChoices.dimScale`. -/
+  `LTMCTUnitChoices.dimScale`. -/
 noncomputable def dimScale [Fintype B] (u1 u2 : UnitScale B) : Dimension B →* ℝ≥0 where
   toFun d := ∏ b, (u1.scale b / u2.scale b) ^ (d.exponent b : ℝ)
   map_one' := by simp
@@ -86,17 +86,17 @@ lemma dimScale_transitive [Fintype B] (u1 u2 u3 : UnitScale B) (d : Dimension B)
 end UnitScale
 
 /-!
-## The current five-field `UnitChoices` is the `LTMCTDimensionBase` instance
+## The current five-field `LTMCTUnitChoices` is the `LTMCTDimensionBase` instance
 
-`UnitChoices.toScale` reads the five typed units as a `UnitScale LTMCTDimensionBase`,
+`LTMCTUnitChoices.toScale` reads the five typed units as a `UnitScale LTMCTDimensionBase`,
 exhibiting the existing bespoke `dimScale` as the `LTMCTDimensionBase` case of the generic
 fold.
 -/
 
-namespace UnitChoices
+namespace LTMCTUnitChoices
 
-/-- Read a five-field `UnitChoices` as a `UnitScale` over `LTMCTDimensionBase`. -/
-noncomputable def toScale (u : UnitChoices) : UnitScale LTMCTDimensionBase where
+/-- Read a five-field `LTMCTUnitChoices` as a `UnitScale` over `LTMCTDimensionBase`. -/
+noncomputable def toScale (u : LTMCTUnitChoices) : UnitScale LTMCTDimensionBase where
   scale
     | .length => ⟨u.length.val, u.length.val_pos.le⟩
     | .time => ⟨u.time.val, u.time.val_pos.le⟩
@@ -111,4 +111,4 @@ noncomputable def toScale (u : UnitChoices) : UnitScale LTMCTDimensionBase where
     · exact NNReal.coe_pos.mp u.charge.val_pos
     · exact NNReal.coe_pos.mp u.temperature.val_pos
 
-end UnitChoices
+end LTMCTUnitChoices

--- a/Physlib/Units/ParametricUnits.lean
+++ b/Physlib/Units/ParametricUnits.lean
@@ -36,6 +36,7 @@ open scoped BigOperators
 
 /-- A choice of unit for each base dimension of `B`: a positive-real magnitude per
   base. This is the basis-generic form of `UnitChoices`. -/
+@[ext]
 structure UnitScale (B : Type) where
   /-- The positive-real magnitude of the chosen unit at each base dimension. -/
   scale : B → ℝ≥0

--- a/Physlib/Units/SIUnitChoices.lean
+++ b/Physlib/Units/SIUnitChoices.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2026 Nicolas Rouquette. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nicolas Rouquette
+-/
+module
+
+public import Physlib.Units.UnitSystem
+public import Physlib.Units.ISQDimensionBase
+/-!
+
+# A typed unit choice over the ISQ base quantities (the SI units)
+
+`LTMCTUnitChoices` is the typed unit choice over PhysLib's default dimension basis
+`LTMCTDimensionBase`. This module gives the *second* typed unit choice — over the
+seven ISQ base quantities `ISQDimensionBase` — realised through the basis-generic
+`UnitSystem` / `TypedChoice` machinery of `Physlib.Units.UnitSystem`. It is the concrete
+payoff of parametrising the unit side: the same generic layer produces a fully *typed*
+unit choice over a different basis, and the scaling homomorphism comes for free from
+`UnitScale.dimScale` — nothing is re-proved by hand.
+
+The ISQ base quantities are length, mass, time, electric current, thermodynamic
+temperature, amount of substance and luminous intensity. Four of the corresponding typed
+unit types already exist (`LengthUnit`, `MassUnit`, `TimeUnit`, `TemperatureUnit`); the
+remaining three — `CurrentUnit`, `AmountUnit`, `LuminousIntensityUnit` — are introduced
+here. (They follow the `LengthUnit` convention of a positive-real magnitude; the full
+division/scaling API can be filled in later and, following PhysLib's layout, they would
+ultimately live under the relevant physics directories.)
+
+`SIUnitChoices := TypedChoice ISQDimensionBase` is then the typed SI unit choice, and
+`SIUnitChoices.SI` is the coherent SI choice (metre, kilogram, second, ampere, kelvin,
+mole, candela). Contrast `SIUnitChoices` (current-based, seven typed slots) with
+`LTMCTUnitChoices` (charge-based, five typed slots): the machinery supports both, and the
+`Dimension.ltmctToISQ` / `Dimension.isqToLTMCT` bridge relates their bases.
+
+-/
+
+@[expose] public section
+
+open NNReal
+
+/-!
+
+## Typed unit types for the ISQ base quantities not already present
+
+-/
+
+/-- A unit of electric current — a choice of positive-real magnitude. The SI coherent
+  choice is the ampere. -/
+structure CurrentUnit where
+  /-- The underlying scale of the unit. -/
+  val : ℝ
+  property : 0 < val
+
+namespace CurrentUnit
+
+@[simp]
+lemma val_ne_zero (x : CurrentUnit) : x.val ≠ 0 := Ne.symm (ne_of_lt x.property)
+
+lemma val_pos (x : CurrentUnit) : 0 < x.val := x.property
+
+instance : Inhabited CurrentUnit where
+  default := ⟨1, by norm_num⟩
+
+noncomputable instance : HDiv CurrentUnit CurrentUnit ℝ≥0 where
+  hDiv x t := ⟨x.val / t.val, div_nonneg x.val_pos.le t.val_pos.le⟩
+
+lemma div_eq_val (x y : CurrentUnit) :
+    x / y = (⟨x.val / y.val, div_nonneg x.val_pos.le y.val_pos.le⟩ : ℝ≥0) := rfl
+
+/-- The SI coherent unit of electric current, the ampere. -/
+def amperes : CurrentUnit := ⟨1, by norm_num⟩
+
+end CurrentUnit
+
+/-- A unit of amount of substance — a choice of positive-real magnitude. The SI coherent
+  choice is the mole. -/
+structure AmountUnit where
+  /-- The underlying scale of the unit. -/
+  val : ℝ
+  property : 0 < val
+
+namespace AmountUnit
+
+@[simp]
+lemma val_ne_zero (x : AmountUnit) : x.val ≠ 0 := Ne.symm (ne_of_lt x.property)
+
+lemma val_pos (x : AmountUnit) : 0 < x.val := x.property
+
+instance : Inhabited AmountUnit where
+  default := ⟨1, by norm_num⟩
+
+noncomputable instance : HDiv AmountUnit AmountUnit ℝ≥0 where
+  hDiv x t := ⟨x.val / t.val, div_nonneg x.val_pos.le t.val_pos.le⟩
+
+lemma div_eq_val (x y : AmountUnit) :
+    x / y = (⟨x.val / y.val, div_nonneg x.val_pos.le y.val_pos.le⟩ : ℝ≥0) := rfl
+
+/-- The SI coherent unit of amount of substance, the mole. -/
+def moles : AmountUnit := ⟨1, by norm_num⟩
+
+end AmountUnit
+
+/-- A unit of luminous intensity — a choice of positive-real magnitude. The SI coherent
+  choice is the candela. -/
+structure LuminousIntensityUnit where
+  /-- The underlying scale of the unit. -/
+  val : ℝ
+  property : 0 < val
+
+namespace LuminousIntensityUnit
+
+@[simp]
+lemma val_ne_zero (x : LuminousIntensityUnit) : x.val ≠ 0 := Ne.symm (ne_of_lt x.property)
+
+lemma val_pos (x : LuminousIntensityUnit) : 0 < x.val := x.property
+
+instance : Inhabited LuminousIntensityUnit where
+  default := ⟨1, by norm_num⟩
+
+noncomputable instance : HDiv LuminousIntensityUnit LuminousIntensityUnit ℝ≥0 where
+  hDiv x t := ⟨x.val / t.val, div_nonneg x.val_pos.le t.val_pos.le⟩
+
+lemma div_eq_val (x y : LuminousIntensityUnit) :
+    x / y = (⟨x.val / y.val, div_nonneg x.val_pos.le y.val_pos.le⟩ : ℝ≥0) := rfl
+
+/-- The SI coherent unit of luminous intensity, the candela. -/
+def candelas : LuminousIntensityUnit := ⟨1, by norm_num⟩
+
+end LuminousIntensityUnit
+
+/-!
+
+## The ISQ `UnitSystem` instance
+
+Each ISQ base quantity is assigned its typed unit type; the magnitude layer is the
+positive-real `val`, exactly as for the `LTMCTDimensionBase` instance.
+
+-/
+
+noncomputable instance : UnitSystem ISQDimensionBase where
+  Unit
+    | .length => LengthUnit
+    | .mass => MassUnit
+    | .time => TimeUnit
+    | .current => CurrentUnit
+    | .temperature => TemperatureUnit
+    | .amount => AmountUnit
+    | .luminousIntensity => LuminousIntensityUnit
+  mag {b} :=
+    match b with
+    | .length | .mass | .time | .current | .temperature | .amount | .luminousIntensity =>
+        fun u => ⟨u.val, u.val_pos.le⟩
+  mag_pos {b} :=
+    match b with
+    | .length | .mass | .time | .current | .temperature | .amount | .luminousIntensity =>
+        fun u => NNReal.coe_pos.mp u.val_pos
+
+/-!
+
+## `SIUnitChoices`
+
+-/
+
+/-- A **typed SI unit choice**: a typed unit at every ISQ base quantity. This is the
+  seven-slot, current-based sibling of the five-slot, charge-based `LTMCTUnitChoices`,
+  produced by the same basis-generic `TypedChoice` / `UnitSystem` machinery. -/
+abbrev SIUnitChoices := TypedChoice ISQDimensionBase
+
+namespace SIUnitChoices
+
+/-- The coherent SI unit choice: metre, kilogram, second, ampere, kelvin, mole, candela. -/
+noncomputable def SI : SIUnitChoices := fun
+  | .length => LengthUnit.meters
+  | .mass => MassUnit.kilograms
+  | .time => TimeUnit.seconds
+  | .current => CurrentUnit.amperes
+  | .temperature => TemperatureUnit.kelvin
+  | .amount => AmountUnit.moles
+  | .luminousIntensity => LuminousIntensityUnit.candelas
+
+/-- The dimension-scaling homomorphism over the ISQ basis, obtained *for free* from the
+  generic `UnitScale.dimScale` fold — no per-basis hand-rolling. -/
+noncomputable def dimScale (u1 u2 : SIUnitChoices) : Dimension ISQDimensionBase →* ℝ≥0 :=
+  UnitScale.dimScale u1.toScale u2.toScale
+
+/-- Type-safety check: the current slot of a typed SI unit choice is a `CurrentUnit` —
+  a `MassUnit` cannot be placed there. -/
+example (u : SIUnitChoices) : CurrentUnit := u .current
+
+/-- A quantity of ISQ dimension does not rescale between a unit choice and itself. -/
+lemma dimScale_self (u : SIUnitChoices) (d : Dimension ISQDimensionBase) :
+    dimScale u u d = 1 := UnitScale.dimScale_self _ d
+
+end SIUnitChoices

--- a/Physlib/Units/SIUnitChoices.lean
+++ b/Physlib/Units/SIUnitChoices.lean
@@ -14,7 +14,7 @@ public import Physlib.Units.ISQDimensionBase
 `LTMCTUnitChoices` is the typed unit choice over PhysLib's default dimension basis
 `LTMCTDimensionBase`. This module gives the *second* typed unit choice — over the
 seven ISQ base quantities `ISQDimensionBase` — realised through the basis-generic
-`UnitSystem` / `TypedChoice` machinery of `Physlib.Units.UnitSystem`. It is the concrete
+`UnitMagnitudeCatalog` / `UnitSystem` machinery of `Physlib.Units.UnitSystem`. It is the concrete
 payoff of parametrising the unit side: the same generic layer produces a fully *typed*
 unit choice over a different basis, and the scaling homomorphism comes for free from
 `UnitScale.dimScale` — nothing is re-proved by hand.
@@ -27,7 +27,7 @@ here. (They follow the `LengthUnit` convention of a positive-real magnitude; the
 division/scaling API can be filled in later and, following PhysLib's layout, they would
 ultimately live under the relevant physics directories.)
 
-`SIUnitChoices := TypedChoice ISQDimensionBase` is then the typed SI unit choice, and
+`SIUnitChoices := UnitSystem ISQDimensionBase` is then the typed SI unit choice, and
 `SIUnitChoices.SI` is the coherent SI choice (metre, kilogram, second, ampere, kelvin,
 mole, candela). Contrast `SIUnitChoices` (current-based, seven typed slots) with
 `LTMCTUnitChoices` (charge-based, five typed slots): the machinery supports both, and the
@@ -38,6 +38,7 @@ mole, candela). Contrast `SIUnitChoices` (current-based, seven typed slots) with
 @[expose] public section
 
 open NNReal
+open scoped BigOperators
 
 /-!
 
@@ -131,14 +132,14 @@ end LuminousIntensityUnit
 
 /-!
 
-## The ISQ `UnitSystem` instance
+## The ISQ `UnitMagnitudeCatalog` instance
 
 Each ISQ base quantity is assigned its typed unit type; the magnitude layer is the
 positive-real `val`, exactly as for the `LTMCTDimensionBase` instance.
 
 -/
 
-noncomputable instance : UnitSystem ISQDimensionBase where
+noncomputable instance : UnitMagnitudeCatalog ISQDimensionBase where
   Unit
     | .length => LengthUnit
     | .mass => MassUnit
@@ -158,14 +159,34 @@ noncomputable instance : UnitSystem ISQDimensionBase where
 
 /-!
 
+## Folding over the ISQ base quantities
+
+-/
+
+open Finset in
+/-- The product over the seven ISQ base quantities, in canonical enumeration order — the
+  `ISQDimensionBase` companion to `prod_univ_LTMCTDimensionBase`, a reusable fact about the
+  `Fintype` enumeration for folding `Finset.prod` over the ISQ basis. -/
+lemma prod_univ_ISQDimensionBase {M : Type} [CommMonoid M] (f : ISQDimensionBase → M) :
+    ∏ b, f b = f .length * f .mass * f .time * f .current * f .temperature
+      * f .amount * f .luminousIntensity := by
+  rw [show (univ : Finset ISQDimensionBase) =
+        {.length, .mass, .time, .current, .temperature, .amount, .luminousIntensity} from by
+      decide]
+  rw [prod_insert (by decide), prod_insert (by decide), prod_insert (by decide),
+    prod_insert (by decide), prod_insert (by decide), prod_insert (by decide), prod_singleton,
+    ← mul_assoc, ← mul_assoc, ← mul_assoc, ← mul_assoc, ← mul_assoc]
+
+/-!
+
 ## `SIUnitChoices`
 
 -/
 
 /-- A **typed SI unit choice**: a typed unit at every ISQ base quantity. This is the
   seven-slot, current-based sibling of the five-slot, charge-based `LTMCTUnitChoices`,
-  produced by the same basis-generic `TypedChoice` / `UnitSystem` machinery. -/
-abbrev SIUnitChoices := TypedChoice ISQDimensionBase
+  produced by the same basis-generic `UnitSystem` / `UnitMagnitudeCatalog` machinery. -/
+abbrev SIUnitChoices := UnitSystem ISQDimensionBase
 
 namespace SIUnitChoices
 

--- a/Physlib/Units/UnitDependent.lean
+++ b/Physlib/Units/UnitDependent.lean
@@ -197,7 +197,8 @@ lemma LTMCTUnitChoices.scaleUnit_apply_fst (u1 u2 : LTMCTUnitChoices) :
     ChargeUnit.div_eq_val, TemperatureUnit.div_eq_val, toReal]
 
 @[simp]
-lemma LTMCTUnitChoices.dimScale_scaleUnit {u1 u2 u : LTMCTUnitChoices} (d : Dimension LTMCTDimensionBase) :
+lemma LTMCTUnitChoices.dimScale_scaleUnit {u1 u2 u : LTMCTUnitChoices}
+    (d : Dimension LTMCTDimensionBase) :
     u.dimScale (scaleUnit u1 u2 u) d = u1.dimScale u2 d := by
   simp [dimScale, scaleUnit]
   simp [LengthUnit.div_eq_val, TimeUnit.div_eq_val, MassUnit.div_eq_val, ChargeUnit.div_eq_val,

--- a/Physlib/Units/UnitDependent.lean
+++ b/Physlib/Units/UnitDependent.lean
@@ -17,7 +17,7 @@ depend on a choice of a units. For example a function
 carry a dimensions, but is dependent on a choice of units.
 
 We define three versions
-- `UnitDependent M` having a function `scaleUnit : UnitChoices → UnitChoices → M → M`
+- `UnitDependent M` having a function `scaleUnit : LTMCTUnitChoices → LTMCTUnitChoices → M → M`
   subject to two conditions `scaleUnit_trans` and `scaleUnit_id`
 - `LinearUnitDependent M` extends `UnitDependent M` with additional linearity conditions
   on `scaleUnit`.
@@ -43,7 +43,7 @@ class UnitDependent (M : Type) where
     to say that in `scaleUnit u1 u2 m` that `m` should be interpreted as being in the units `u1`,
     although this is often the case.
   -/
-  scaleUnit : UnitChoices → UnitChoices → M → M
+  scaleUnit : LTMCTUnitChoices → LTMCTUnitChoices → M → M
   scaleUnit_trans : ∀ u1 u2 u3 m, scaleUnit u2 u3 (scaleUnit u1 u2 m) = scaleUnit u1 u3 m
   scaleUnit_trans' : ∀ u1 u2 u3 m, scaleUnit u1 u2 (scaleUnit u2 u3 m) = scaleUnit u1 u3 m
   scaleUnit_id : ∀ u m, scaleUnit u u m = m
@@ -83,13 +83,13 @@ class ContinuousLinearUnitDependent (M : Type) [AddCommMonoid M] [Module ℝ M]
 
 @[simp]
 lemma UnitDependent.scaleUnit_symm_apply {M : Type} [UnitDependent M]
-    (u1 u2 : UnitChoices) (m : M) :
+    (u1 u2 : LTMCTUnitChoices) (m : M) :
     scaleUnit u2 u1 (scaleUnit u1 u2 m) = m := by
   rw [scaleUnit_trans, scaleUnit_id]
 
 @[simp]
 lemma UnitDependent.scaleUnit_injective {M : Type} [UnitDependent M]
-    (u1 u2 : UnitChoices) (m1 m2 : M) :
+    (u1 u2 : LTMCTUnitChoices) (m1 m2 : M) :
     scaleUnit u1 u2 m1 = scaleUnit u1 u2 m2 ↔ m1 = m2 :=
   ⟨fun h => by simpa using congrArg (scaleUnit u2 u1) h, congrArg (scaleUnit u1 u2)⟩
 
@@ -102,7 +102,7 @@ lemma UnitDependent.scaleUnit_injective {M : Type} [UnitDependent M]
 open UnitDependent
 /-- For an `M` with an instance of `UnitDependent M`, `scaleUnit u1 u2` as an equivalence. -/
 def UnitDependent.scaleUnitEquiv {M : Type} [UnitDependent M]
-    (u1 u2 : UnitChoices) : M ≃ M where
+    (u1 u2 : LTMCTUnitChoices) : M ≃ M where
   toFun m := scaleUnit u1 u2 m
   invFun m := scaleUnit u2 u1 m
   right_inv m := by simp
@@ -112,7 +112,7 @@ def UnitDependent.scaleUnitEquiv {M : Type} [UnitDependent M]
   linear map. -/
 def LinearUnitDependent.scaleUnitLinear
     {M : Type} [AddCommMonoid M] [Module ℝ M] [LinearUnitDependent M]
-    (u1 u2 : UnitChoices) :
+    (u1 u2 : LTMCTUnitChoices) :
     M →ₗ[ℝ] M where
   toFun m := scaleUnit u1 u2 m
   map_add' m1 m2 := by simp [LinearUnitDependent.scaleUnit_add]
@@ -121,7 +121,7 @@ def LinearUnitDependent.scaleUnitLinear
 /-- For an `M` with an instance of `LinearUnitDependent M`, `scaleUnit u1 u2` as a
   linear equivalence. -/
 def LinearUnitDependent.scaleUnitLinearEquiv {M : Type} [AddCommMonoid M]
-    [Module ℝ M] [LinearUnitDependent M] (u1 u2 : UnitChoices) :
+    [Module ℝ M] [LinearUnitDependent M] (u1 u2 : LTMCTUnitChoices) :
     M ≃ₗ[ℝ] M :=
     LinearEquiv.ofLinear (scaleUnitLinear u1 u2) (scaleUnitLinear u2 u1)
     (by ext u; simp [scaleUnitLinear])
@@ -131,7 +131,7 @@ def LinearUnitDependent.scaleUnitLinearEquiv {M : Type} [AddCommMonoid M]
   continuous linear map. -/
 def ContinuousLinearUnitDependent.scaleUnitContLinear {M : Type} [AddCommMonoid M] [Module ℝ M]
     [TopologicalSpace M] [ContinuousLinearUnitDependent M]
-    (u1 u2 : UnitChoices) : M →L[ℝ] M where
+    (u1 u2 : LTMCTUnitChoices) : M →L[ℝ] M where
   toLinearMap := LinearUnitDependent.scaleUnitLinear u1 u2
   cont := ContinuousLinearUnitDependent.scaleUnit_cont u1 u2
 
@@ -139,7 +139,7 @@ def ContinuousLinearUnitDependent.scaleUnitContLinear {M : Type} [AddCommMonoid 
   continuous linear equivalence. -/
 def ContinuousLinearUnitDependent.scaleUnitContLinearEquiv {M : Type} [AddCommMonoid M] [Module ℝ M]
     [TopologicalSpace M] [ContinuousLinearUnitDependent M]
-    (u1 u2 : UnitChoices) : M ≃L[ℝ] M :=
+    (u1 u2 : LTMCTUnitChoices) : M ≃L[ℝ] M :=
     ContinuousLinearEquiv.mk (LinearUnitDependent.scaleUnitLinearEquiv u1 u2)
     (ContinuousLinearUnitDependent.scaleUnit_cont u1 u2)
     (ContinuousLinearUnitDependent.scaleUnit_cont u2 u1)
@@ -148,7 +148,7 @@ def ContinuousLinearUnitDependent.scaleUnitContLinearEquiv {M : Type} [AddCommMo
 lemma ContinuousLinearUnitDependent.scaleUnitContLinearEquiv_apply
     {M : Type} [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
     [ContinuousLinearUnitDependent M]
-    (u1 u2 : UnitChoices) (m : M) :
+    (u1 u2 : LTMCTUnitChoices) (m : M) :
     (ContinuousLinearUnitDependent.scaleUnitContLinearEquiv u1 u2) m =
       scaleUnit u1 u2 m := rfl
 
@@ -156,7 +156,7 @@ lemma ContinuousLinearUnitDependent.scaleUnitContLinearEquiv_apply
 lemma ContinuousLinearUnitDependent.scaleUnitContLinearEquiv_symm_apply
     {M : Type} [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
     [ContinuousLinearUnitDependent M]
-    (u1 u2 : UnitChoices) (m : M) :
+    (u1 u2 : LTMCTUnitChoices) (m : M) :
     (ContinuousLinearUnitDependent.scaleUnitContLinearEquiv u1 u2).symm m =
       scaleUnit u2 u1 m := rfl
 /-!
@@ -171,7 +171,7 @@ We construct instance of the `UnitDependent`, `LinearUnitDependent` and
 
 open UnitDependent
 
-noncomputable instance : UnitDependent UnitChoices where
+noncomputable instance : UnitDependent LTMCTUnitChoices where
   scaleUnit u1 u2 u := ⟨
       LengthUnit.scale (u2.length/u1.length) u.length (by simp),
       TimeUnit.scale (u2.time/u1.time) u.time (by simp),
@@ -190,40 +190,40 @@ noncomputable instance : UnitDependent UnitChoices where
   scaleUnit_id u1 u := by simp
 
 @[simp]
-lemma UnitChoices.scaleUnit_apply_fst (u1 u2 : UnitChoices) :
+lemma LTMCTUnitChoices.scaleUnit_apply_fst (u1 u2 : LTMCTUnitChoices) :
     (scaleUnit u1 u2 u1) = u2 := by
   ext <;> simp [scaleUnit, LengthUnit.scale, TimeUnit.scale, MassUnit.scale, ChargeUnit.scale,
     TemperatureUnit.scale, LengthUnit.div_eq_val, TimeUnit.div_eq_val, MassUnit.div_eq_val,
     ChargeUnit.div_eq_val, TemperatureUnit.div_eq_val, toReal]
 
 @[simp]
-lemma UnitChoices.dimScale_scaleUnit {u1 u2 u : UnitChoices} (d : Dimension LTMCTDimensionBase) :
+lemma LTMCTUnitChoices.dimScale_scaleUnit {u1 u2 u : LTMCTUnitChoices} (d : Dimension LTMCTDimensionBase) :
     u.dimScale (scaleUnit u1 u2 u) d = u1.dimScale u2 d := by
   simp [dimScale, scaleUnit]
   simp [LengthUnit.div_eq_val, TimeUnit.div_eq_val, MassUnit.div_eq_val, ChargeUnit.div_eq_val,
     TemperatureUnit.div_eq_val, toReal]
 
-lemma Dimensionful.of_scaleUnit {M : Type} [CarriesDimension M] {u1 u2 u : UnitChoices}
+lemma Dimensionful.of_scaleUnit {M : Type} [CarriesDimension M] {u1 u2 u : LTMCTUnitChoices}
     (c : Dimensionful M) :
     c.1 (scaleUnit u1 u2 u) =
     u1.dimScale u2 (dim M) • c.1 (u) := by
-  rw [c.2 u (scaleUnit u1 u2 u), UnitChoices.dimScale_scaleUnit]
+  rw [c.2 u (scaleUnit u1 u2 u), LTMCTUnitChoices.dimScale_scaleUnit]
 
 noncomputable instance {M1 : Type} [CarriesDimension M1] : MulUnitDependent M1 where
   scaleUnit u1 u2 m := (toDimensionful u1 m).1 u2
   scaleUnit_trans u1 u2 u3 m := by
     simp [toDimensionful]
-    rw [smul_smul, mul_comm, UnitChoices.dimScale_transitive]
+    rw [smul_smul, mul_comm, LTMCTUnitChoices.dimScale_transitive]
   scaleUnit_trans' u1 u2 u3 m := by
-    simp [toDimensionful, smul_smul, UnitChoices.dimScale_transitive]
+    simp [toDimensionful, smul_smul, LTMCTUnitChoices.dimScale_transitive]
   scaleUnit_id u m := by
-    simp [toDimensionful, UnitChoices.dimScale_self]
+    simp [toDimensionful, LTMCTUnitChoices.dimScale_self]
   scaleUnit_mul u1 u2 r m := by
     simp [toDimensionful]
     exact smul_comm (u1.dimScale u2 (dim M1)) r m
 
 lemma HasDim.scaleUnit_apply {M : Type} [CarriesDimension M]
-    (u1 u2 : UnitChoices) (m : M) :
+    (u1 u2 : LTMCTUnitChoices) (m : M) :
     scaleUnit u1 u2 m = (u1.dimScale u2 (dim M)) • m :=
   toDimensionful_apply_apply u1 u2 m
 
@@ -258,7 +258,7 @@ noncomputable instance {M1 M2 : Type} [UnitDependent M2] :
 
 @[simp]
 lemma UnitDependent.scaleUnit_apply_fun_right {M1 M2 : Type} [UnitDependent M2]
-    (u1 u2 : UnitChoices) (f : M1 → M2) (m1 : M1) :
+    (u1 u2 : LTMCTUnitChoices) (f : M1 → M2) (m1 : M1) :
     scaleUnit u1 u2 f m1 = scaleUnit u1 u2 (f m1) := rfl
 
 open LinearUnitDependent in
@@ -324,7 +324,7 @@ noncomputable instance {M1 M2 : Type} [UnitDependent M1] :
 
 @[simp]
 lemma UnitDependent.scaleUnit_apply_fun_left {M1 M2 : Type} [UnitDependent M1]
-    (u1 u2 : UnitChoices) (f : M1 → M2) (m1 : M1) :
+    (u1 u2 : LTMCTUnitChoices) (f : M1 → M2) (m1 : M1) :
     scaleUnit u1 u2 f m1 = f (scaleUnit u2 u1 m1) := rfl
 
 noncomputable instance instUnitDependentTwoSided
@@ -343,7 +343,7 @@ noncomputable instance instUnitDependentTwoSided
 
 @[simp]
 lemma UnitDependent.scaleUnit_apply_fun {M1 M2 : Type} [UnitDependent M1]
-    [UnitDependent M2] (u1 u2 : UnitChoices) (f : M1 → M2) (m1 : M1) :
+    [UnitDependent M2] (u1 u2 : LTMCTUnitChoices) (f : M1 → M2) (m1 : M1) :
     scaleUnit u1 u2 f m1 = scaleUnit u1 u2 (f (scaleUnit u2 u1 m1)) := rfl
 
 noncomputable instance instUnitDependentTwoSidedMul
@@ -395,7 +395,7 @@ lemma ContinuousLinearUnitDependent.scaleUnit_apply_fun {M1 M2 : Type}
     [AddCommGroup M2] [Module ℝ M2] [TopologicalSpace M2] [ContinuousConstSMul ℝ M2]
     [IsTopologicalAddGroup M2]
     [ContinuousLinearUnitDependent M2]
-    (u1 u2 : UnitChoices) (f : M1 →L[ℝ] M2) (m1 : M1) :
+    (u1 u2 : LTMCTUnitChoices) (f : M1 →L[ℝ] M2) (m1 : M1) :
     scaleUnit u1 u2 f m1 =
       scaleUnit u1 u2 (f (scaleUnit u2 u1 m1)) := rfl
 
@@ -416,31 +416,31 @@ lemma ContinuousLinearUnitDependent.scaleUnit_apply_fun {M1 M2 : Type}
   or the dimension of `M` is zero.
 -/
 def IsDimensionallyCorrect {M : Type} [UnitDependent M] (m : M) : Prop :=
-  ∀ u1 u2 : UnitChoices, scaleUnit u1 u2 m = m
+  ∀ u1 u2 : LTMCTUnitChoices, scaleUnit u1 u2 m = m
 
 lemma isDimensionallyCorrect_iff {M : Type} [UnitDependent M] (m : M) :
-    IsDimensionallyCorrect m ↔ ∀ u1 u2 : UnitChoices,
+    IsDimensionallyCorrect m ↔ ∀ u1 u2 : LTMCTUnitChoices,
       scaleUnit u1 u2 m = m := by rfl
 
 @[simp]
 lemma isDimensionallyCorrect_fun_iff {M1 M2 : Type} [UnitDependent M1] [UnitDependent M2]
     {f : M1 → M2} :
     IsDimensionallyCorrect f ↔
-    ∀ u1 u2 : UnitChoices, ∀ m, scaleUnit u1 u2 (f (scaleUnit u2 u1 m)) = f m := by
+    ∀ u1 u2 : LTMCTUnitChoices, ∀ m, scaleUnit u1 u2 (f (scaleUnit u2 u1 m)) = f m := by
   simp [IsDimensionallyCorrect, funext_iff]
 
 @[simp]
 lemma isDimensionallyCorrect_fun_left {M1 M2 : Type} [UnitDependent M1]
     {f : M1 → M2} :
     IsDimensionallyCorrect f ↔
-    ∀ u1 u2 : UnitChoices, ∀ m, (f (scaleUnit u2 u1 m)) = f m := by
+    ∀ u1 u2 : LTMCTUnitChoices, ∀ m, (f (scaleUnit u2 u1 m)) = f m := by
   simp [IsDimensionallyCorrect, funext_iff]
 
 @[simp]
 lemma isDimensionallyCorrect_fun_right {M1 M2 : Type} [UnitDependent M2]
     {f : M1 → M2} :
     IsDimensionallyCorrect f ↔
-    ∀ u1 u2 : UnitChoices, ∀ m, scaleUnit u1 u2 (f m) = f m := by
+    ∀ u1 u2 : LTMCTUnitChoices, ∀ m, scaleUnit u1 u2 (f m) = f m := by
   simp [IsDimensionallyCorrect, funext_iff]
 /-!
 
@@ -458,7 +458,7 @@ class DMul (M1 M2 M3 : Type) [CarriesDimension M1] [CarriesDimension M2] [Carrie
 @[simp]
 lemma DMul.hMul_scaleUnit {M1 M2 M3 : Type} [CarriesDimension M1] [CarriesDimension M2]
     [CarriesDimension M3]
-    [DMul M1 M2 M3] (m1 : M1) (m2 : M2) (u1 u2 : UnitChoices) :
+    [DMul M1 M2 M3] (m1 : M1) (m2 : M2) (u1 u2 : LTMCTUnitChoices) :
     (scaleUnit u1 u2 m1) * (scaleUnit u1 u2 m2) =
     scaleUnit u1 u2 (m1 * m2) := by
   simpa [scaleUnit, toDimensionful] using
@@ -474,7 +474,7 @@ lemma DMul.hMul_scaleUnit {M1 M2 M3 : Type} [CarriesDimension M1] [CarriesDimens
   carrying a dimension, the subtype of `M` which scales according to the dimension `d`. -/
 def DimSet (M : Type) [MulAction ℝ≥0 M] [MulUnitDependent M] (d : Dimension LTMCTDimensionBase) :
     Set M :=
-  {m : M | ∀ u1 u2, scaleUnit u1 u2 m = (UnitChoices.dimScale u1 u2 d) • m}
+  {m : M | ∀ u1 u2, scaleUnit u1 u2 m = (LTMCTUnitChoices.dimScale u1 u2 d) • m}
 
 instance (M : Type) [MulAction ℝ≥0 M] [MulUnitDependent M] (d : Dimension LTMCTDimensionBase) :
     MulAction ℝ≥0 (DimSet M d) where
@@ -496,9 +496,9 @@ instance (M : Type) [MulAction ℝ≥0 M] [MulUnitDependent M] (d : Dimension LT
 
 @[simp]
 lemma scaleUnit_dimSet_val {M : Type} [MulAction ℝ≥0 M] [MulUnitDependent M]
-    (d : Dimension LTMCTDimensionBase) (m : DimSet M d) (u1 u2 : UnitChoices) :
+    (d : Dimension LTMCTDimensionBase) (m : DimSet M d) (u1 u2 : LTMCTUnitChoices) :
     (scaleUnit u1 u2 m).1 = scaleUnit u1 u2 m.1 := (m.2 u1 u2).symm
 
 lemma DimSet.mem_iff {M : Type} [MulAction ℝ≥0 M] [MulUnitDependent M]
     (d : Dimension LTMCTDimensionBase) (m : M) :
-    m ∈ DimSet M d ↔ ∀ u1 u2, scaleUnit u1 u2 m = (UnitChoices.dimScale u1 u2 d) • m := by rfl
+    m ∈ DimSet M d ↔ ∀ u1 u2, scaleUnit u1 u2 m = (LTMCTUnitChoices.dimScale u1 u2 d) • m := by rfl

--- a/Physlib/Units/UnitSystem.lean
+++ b/Physlib/Units/UnitSystem.lean
@@ -8,32 +8,48 @@ module
 public import Physlib.Units.ParametricUnits
 /-!
 
-# Typed unit systems, parametrised in a dimension basis
+# Unit systems, parametrised in a dimension basis
 
-`Dimension B` is basis-generic and `ParametricUnits` gives the basis-generic *magnitude*
-layer `UnitScale B` (a positive real per base dimension, with the scaling homomorphism
-`UnitScale.dimScale` proved once via `Finset.prod`). What was still hardwired to the
-default basis is the *typed* unit side: `LTMCTUnitChoices` is a bespoke five-field record with
-one named unit type per base dimension (`LengthUnit`, `TimeUnit`, …).
+A **unit system** is the everyday physics object: a rule fixing one concrete unit for
+each base quantity. SI fixes the metre for length, the second for time, the kilogram for
+mass, …; CGS fixes the centimetre, second and gram. Choosing a system gives every quantity
+a numerical value; changing systems rescales those values.
 
-This module provides the generic typed layer. A `UnitSystem B` attaches to a basis `B` a
-family of *typed* unit types — one per base dimension — each carrying a positive-real
-magnitude:
+This module makes that notion work for *any* dimension basis `B` (matching the
+basis-generic `Dimension B`), while keeping units *typed*: the unit in the length slot has
+type `LengthUnit`, the one in the time slot `TimeUnit`, so the checker rejects a mass unit
+in a length slot.
 
-* `UnitSystem B` — the class: `Unit : B → Type`, `mag`, `mag_pos`.
-* `TypedChoice B` — a typed unit at every base dimension, `(b : B) → UnitSystem.Unit b`.
-* `TypedChoice.toScale : TypedChoice B → UnitScale B` — forget the types down to the
-  magnitude layer already provided by `ParametricUnits`.
+* `UnitMagnitudeCatalog B` — the **menu** for basis `B`. For each base dimension `b : B` it
+  gives a *type* `Unit b` of admissible units — so a dimension may offer many (length: metre,
+  kilometre, micrometre, …) — and a *function* `mag` assigning each unit its one positive-real
+  magnitude. The menu lists the options and picks none; many unit systems share one catalog.
+* `UnitSystem B` — the **pick**: a function choosing *exactly one* unit per base dimension. A
+  single unit system therefore fixes one length unit — metre *or* kilometre, never both — so
+  metre and kilometre are two menu entries selected by two different `UnitSystem`s over the
+  same catalog. SI and CGS are two such picks.
+* `UnitSystem.toScale : UnitSystem B → UnitScale B` — forget the unit *types*, keep only
+  the magnitudes, landing in the bare magnitude layer `UnitScale B` where the scaling
+  homomorphism `UnitScale.dimScale` is proved once.
 
-The `LTMCTDimensionBase` instance recovers exactly today's typed unit names, and
-`LTMCTUnitChoices ≃ TypedChoice LTMCTDimensionBase` exhibits the bespoke five-field record as
-that instance. The scaling laws are **not** re-proved here: they live once on the
-magnitude layer `UnitScale B`, and the typed layer is a thin faithful wrapper projecting
-onto it via `toScale`.
+**Menu vs. pick.** The catalog is a menu, not a choice: it says which units exist and what
+each weighs, but selects none — a `UnitSystem` makes the selection. And in PhysLib a base
+unit *is* a positive real (`{ val : ℝ // 0 < val }`), i.e. its own magnitude, so the
+magnitude comes fixed with the unit; there is no separate "assign a magnitude" step. Hence
+metre, micrometre and kilometre are three *different* units on the one length menu, and
+"SI in metres" versus "the same in micrometres" are two different `UnitSystem`s over the
+**same** catalog — related by `UnitScale.dimScale`, which computes the 10⁶ factor between
+them. (The multiplicity one might expect from "many magnitudes" lives here, among the unit
+systems, not in many catalogs.)
+
+The `LTMCTDimensionBase` catalog recovers PhysLib's five named unit types, and
+`LTMCTUnitChoices ≃ UnitSystem LTMCTDimensionBase` exhibits the bespoke five-field record
+as that instance. Scaling laws are **not** re-proved here — they live once on `UnitScale B`,
+and the typed layer is a thin faithful wrapper projecting onto it via `toScale`.
 
 This is the typed, basis-generic layer discussed as "Option D" in the review of the
-dimension-parametrisation PR; it is the only design that keeps *both* basis-genericity
-and typed-unit safety.
+dimension-parametrisation PR; it is the only design that keeps *both* basis-genericity and
+typed-unit safety.
 
 -/
 
@@ -42,11 +58,12 @@ and typed-unit safety.
 open NNReal
 open scoped BigOperators
 
-/-- A **typed unit system** for a basis `B`: for each base dimension `b : B`, a typed
-  unit type `Unit b`, together with the positive-real magnitude `mag` of each such unit.
-  This is the data that makes a *typed* unit choice over `B` (as opposed to the bare
-  magnitude layer `UnitScale B`) possible for an arbitrary basis. -/
-class UnitSystem (B : Type) where
+/-- A **menu of typed units** for a basis `B`: for each base dimension `b : B`, a *type*
+  `Unit b` of admissible units (a dimension may offer several — metre, kilometre, …) and a
+  *function* `mag` giving each its single positive-real magnitude. It lists the options and
+  picks none — a `UnitSystem` makes the pick. One catalog underlies many unit systems (SI,
+  CGS, …); the magnitude is the data `toScale` reads to drive rescaling. -/
+class UnitMagnitudeCatalog (B : Type) where
   /-- The typed unit type at each base dimension. -/
   Unit : B → Type
   /-- The positive-real magnitude of a typed unit. -/
@@ -54,44 +71,45 @@ class UnitSystem (B : Type) where
   /-- Every typed unit has a positive magnitude. -/
   mag_pos : ∀ {b : B} (u : Unit b), 0 < mag u
 
+/-- A **unit system** over a basis `B` with a `UnitMagnitudeCatalog`: one typed unit chosen
+  per base dimension — the pick off the catalog's menu, and the formal counterpart of SI,
+  CGS, …. Over the default basis, `u .length : LengthUnit`, and a `MassUnit` cannot be
+  placed in the length slot. -/
+def UnitSystem (B : Type) [UnitMagnitudeCatalog B] := (b : B) → UnitMagnitudeCatalog.Unit b
+
 namespace UnitSystem
 
-variable {B : Type}
+variable {B : Type} [UnitMagnitudeCatalog B]
+
+/-- Two unit systems agree once they pick the same unit at every base dimension: `UnitSystem`
+  is extensional, as befits a choice-per-dimension. -/
+@[ext]
+theorem ext {u v : UnitSystem B} (h : ∀ b, u b = v b) : u = v := funext h
+
+/-- Forget a unit system to its magnitude layer `UnitScale B`: keep each chosen unit's
+  magnitude, drop its type — the layer where `UnitScale.dimScale` is already proved. -/
+noncomputable def toScale (u : UnitSystem B) : UnitScale B where
+  scale b := UnitMagnitudeCatalog.mag (u b)
+  scale_pos b := UnitMagnitudeCatalog.mag_pos (u b)
+
+@[simp]
+lemma toScale_scale (u : UnitSystem B) (b : B) :
+    (toScale u).scale b = UnitMagnitudeCatalog.mag (u b) := rfl
 
 end UnitSystem
 
-/-- A **typed unit choice** over a basis `B` equipped with a `UnitSystem`: a typed unit
-  at every base dimension. This is the basis-generic, *typed* form of `LTMCTUnitChoices`. -/
-def TypedChoice (B : Type) [UnitSystem B] := (b : B) → UnitSystem.Unit b
-
-namespace TypedChoice
-
-variable {B : Type} [UnitSystem B]
-
-/-- Forget a typed unit choice down to its magnitude layer `UnitScale B`, the layer on
-  which the scaling homomorphism `UnitScale.dimScale` is already proved. -/
-noncomputable def toScale (u : TypedChoice B) : UnitScale B where
-  scale b := UnitSystem.mag (u b)
-  scale_pos b := UnitSystem.mag_pos (u b)
-
-@[simp]
-lemma toScale_scale (u : TypedChoice B) (b : B) :
-    (toScale u).scale b = UnitSystem.mag (u b) := rfl
-
-end TypedChoice
-
 /-!
 
-## The `LTMCTDimensionBase` instance
+## The `LTMCTDimensionBase` catalog
 
-The default basis's `UnitSystem` recovers exactly PhysLib's five named typed unit types,
-so `TypedChoice LTMCTDimensionBase` is the typed five-slot unit choice and
+The default basis's `UnitMagnitudeCatalog` recovers exactly PhysLib's five named typed unit
+types, so `UnitSystem LTMCTDimensionBase` is the typed five-slot unit system and
 `u .length : LengthUnit`, `LengthUnit.meters`, … all still work — and a `MassUnit` cannot
 be placed in the length slot.
 
 -/
 
-noncomputable instance : UnitSystem LTMCTDimensionBase where
+noncomputable instance : UnitMagnitudeCatalog LTMCTDimensionBase where
   Unit
     | .length => LengthUnit
     | .time => TimeUnit
@@ -105,12 +123,11 @@ noncomputable instance : UnitSystem LTMCTDimensionBase where
     match b with
     | .length | .time | .mass | .charge | .temperature => fun u => NNReal.coe_pos.mp u.val_pos
 
-/-- Type-safety check: a typed unit choice over `LTMCTDimensionBase` projects onto the
-  named typed unit types, so the length slot is a `LengthUnit` (and cannot hold a
-  `MassUnit`). -/
-example (u : TypedChoice LTMCTDimensionBase) : LengthUnit := u .length
+/-- Type-safety check: a unit system over `LTMCTDimensionBase` projects onto the named typed
+  unit types, so the length slot is a `LengthUnit` (and cannot hold a `MassUnit`). -/
+example (u : UnitSystem LTMCTDimensionBase) : LengthUnit := u .length
 
-example : TypedChoice LTMCTDimensionBase := fun
+example : UnitSystem LTMCTDimensionBase := fun
   | .length => LengthUnit.meters
   | .time => TimeUnit.seconds
   | .mass => MassUnit.kilograms
@@ -119,18 +136,18 @@ example : TypedChoice LTMCTDimensionBase := fun
 
 /-!
 
-## `LTMCTUnitChoices` is `TypedChoice LTMCTDimensionBase`
+## `LTMCTUnitChoices` is `UnitSystem LTMCTDimensionBase`
 
-The bespoke five-field record and the generic typed choice over the default basis carry
+The bespoke five-field record and the generic unit system over the default basis carry
 the same data.
 
 -/
 
 namespace LTMCTUnitChoices
 
-/-- The bespoke five-field `LTMCTUnitChoices` and the generic `TypedChoice LTMCTDimensionBase`
+/-- The bespoke five-field `LTMCTUnitChoices` and the generic `UnitSystem LTMCTDimensionBase`
   are the same data. -/
-def equivTypedChoice : LTMCTUnitChoices ≃ TypedChoice LTMCTDimensionBase where
+def equivUnitSystem : LTMCTUnitChoices ≃ UnitSystem LTMCTDimensionBase where
   toFun u := fun
     | .length => u.length
     | .time => u.time
@@ -147,10 +164,10 @@ def equivTypedChoice : LTMCTUnitChoices ≃ TypedChoice LTMCTDimensionBase where
   right_inv f := by funext b; cases b <;> rfl
 
 /-- The typed generic projection agrees with the bespoke `LTMCTUnitChoices.toScale`: reading
-  `LTMCTUnitChoices` as a `TypedChoice` and forgetting to the magnitude layer is the same as
+  `LTMCTUnitChoices` as a `UnitSystem` and forgetting to the magnitude layer is the same as
   the bespoke `toScale`. -/
-lemma toScale_equivTypedChoice (u : LTMCTUnitChoices) :
-    (equivTypedChoice u).toScale = u.toScale := by
+lemma toScale_equivUnitSystem (u : LTMCTUnitChoices) :
+    (equivUnitSystem u).toScale = u.toScale := by
   refine UnitScale.ext ?_
   funext b
   cases b <;> rfl
@@ -170,7 +187,10 @@ scaling law: there is one source of truth, the generic fold on `UnitScale B`.
 -/
 
 open Finset in
-private lemma prod_univ_LTMCTDimensionBase {M : Type} [CommMonoid M]
+/-- The product over the five default base quantities, in canonical enumeration order — a
+  reusable fact about the `Fintype` enumeration of `LTMCTDimensionBase`, for folding
+  `Finset.prod` over the default basis (e.g. in a hand-rolled scaling law). -/
+lemma prod_univ_LTMCTDimensionBase {M : Type} [CommMonoid M]
     (f : LTMCTDimensionBase → M) :
     ∏ b, f b = f .length * f .time * f .mass * f .charge * f .temperature := by
   rw [show (univ : Finset LTMCTDimensionBase)

--- a/Physlib/Units/UnitSystem.lean
+++ b/Physlib/Units/UnitSystem.lean
@@ -13,7 +13,7 @@ public import Physlib.Units.ParametricUnits
 `Dimension B` is basis-generic and `ParametricUnits` gives the basis-generic *magnitude*
 layer `UnitScale B` (a positive real per base dimension, with the scaling homomorphism
 `UnitScale.dimScale` proved once via `Finset.prod`). What was still hardwired to the
-default basis is the *typed* unit side: `UnitChoices` is a bespoke five-field record with
+default basis is the *typed* unit side: `LTMCTUnitChoices` is a bespoke five-field record with
 one named unit type per base dimension (`LengthUnit`, `TimeUnit`, …).
 
 This module provides the generic typed layer. A `UnitSystem B` attaches to a basis `B` a
@@ -26,7 +26,7 @@ magnitude:
   magnitude layer already provided by `ParametricUnits`.
 
 The `LTMCTDimensionBase` instance recovers exactly today's typed unit names, and
-`UnitChoices ≃ TypedChoice LTMCTDimensionBase` exhibits the bespoke five-field record as
+`LTMCTUnitChoices ≃ TypedChoice LTMCTDimensionBase` exhibits the bespoke five-field record as
 that instance. The scaling laws are **not** re-proved here: they live once on the
 magnitude layer `UnitScale B`, and the typed layer is a thin faithful wrapper projecting
 onto it via `toScale`.
@@ -61,7 +61,7 @@ variable {B : Type}
 end UnitSystem
 
 /-- A **typed unit choice** over a basis `B` equipped with a `UnitSystem`: a typed unit
-  at every base dimension. This is the basis-generic, *typed* form of `UnitChoices`. -/
+  at every base dimension. This is the basis-generic, *typed* form of `LTMCTUnitChoices`. -/
 def TypedChoice (B : Type) [UnitSystem B] := (b : B) → UnitSystem.Unit b
 
 namespace TypedChoice
@@ -119,18 +119,18 @@ example : TypedChoice LTMCTDimensionBase := fun
 
 /-!
 
-## `UnitChoices` is `TypedChoice LTMCTDimensionBase`
+## `LTMCTUnitChoices` is `TypedChoice LTMCTDimensionBase`
 
 The bespoke five-field record and the generic typed choice over the default basis carry
 the same data.
 
 -/
 
-namespace UnitChoices
+namespace LTMCTUnitChoices
 
-/-- The bespoke five-field `UnitChoices` and the generic `TypedChoice LTMCTDimensionBase`
+/-- The bespoke five-field `LTMCTUnitChoices` and the generic `TypedChoice LTMCTDimensionBase`
   are the same data. -/
-def equivTypedChoice : UnitChoices ≃ TypedChoice LTMCTDimensionBase where
+def equivTypedChoice : LTMCTUnitChoices ≃ TypedChoice LTMCTDimensionBase where
   toFun u := fun
     | .length => u.length
     | .time => u.time
@@ -146,22 +146,22 @@ def equivTypedChoice : UnitChoices ≃ TypedChoice LTMCTDimensionBase where
   left_inv u := by cases u; rfl
   right_inv f := by funext b; cases b <;> rfl
 
-/-- The typed generic projection agrees with the bespoke `UnitChoices.toScale`: reading
-  `UnitChoices` as a `TypedChoice` and forgetting to the magnitude layer is the same as
+/-- The typed generic projection agrees with the bespoke `LTMCTUnitChoices.toScale`: reading
+  `LTMCTUnitChoices` as a `TypedChoice` and forgetting to the magnitude layer is the same as
   the bespoke `toScale`. -/
-lemma toScale_equivTypedChoice (u : UnitChoices) :
+lemma toScale_equivTypedChoice (u : LTMCTUnitChoices) :
     (equivTypedChoice u).toScale = u.toScale := by
   refine UnitScale.ext ?_
   funext b
   cases b <;> rfl
 
-end UnitChoices
+end LTMCTUnitChoices
 
 /-!
 
 ## The bespoke scaling law is the generic fold
 
-`UnitChoices.dimScale` — the five explicit `rpow` factors written out by hand in
+`LTMCTUnitChoices.dimScale` — the five explicit `rpow` factors written out by hand in
 `Basic.lean` — is exactly the generic `UnitScale.dimScale` fold (a `Finset.prod` over the
 basis) at the `LTMCTDimensionBase` instance, applied to `toScale`. This is what makes the
 typed layer a *faithful* wrapper rather than a second, independent statement of the
@@ -178,37 +178,37 @@ private lemma prod_univ_LTMCTDimensionBase {M : Type} [CommMonoid M]
   rw [prod_insert (by decide), prod_insert (by decide), prod_insert (by decide),
     prod_insert (by decide), prod_singleton, ← mul_assoc, ← mul_assoc, ← mul_assoc]
 
-namespace UnitChoices
+namespace LTMCTUnitChoices
 
-private lemma length_ratio (u1 u2 : UnitChoices) :
+private lemma length_ratio (u1 u2 : LTMCTUnitChoices) :
     u1.length / u2.length = u1.toScale.scale .length / u2.toScale.scale .length := by
   apply NNReal.eq; rw [LengthUnit.div_eq_val, NNReal.coe_div]; rfl
 
-private lemma time_ratio (u1 u2 : UnitChoices) :
+private lemma time_ratio (u1 u2 : LTMCTUnitChoices) :
     u1.time / u2.time = u1.toScale.scale .time / u2.toScale.scale .time := by
   apply NNReal.eq; rw [TimeUnit.div_eq_val, NNReal.coe_div]; rfl
 
-private lemma mass_ratio (u1 u2 : UnitChoices) :
+private lemma mass_ratio (u1 u2 : LTMCTUnitChoices) :
     u1.mass / u2.mass = u1.toScale.scale .mass / u2.toScale.scale .mass := by
   apply NNReal.eq; rw [MassUnit.div_eq_val, NNReal.coe_div]; rfl
 
-private lemma charge_ratio (u1 u2 : UnitChoices) :
+private lemma charge_ratio (u1 u2 : LTMCTUnitChoices) :
     u1.charge / u2.charge = u1.toScale.scale .charge / u2.toScale.scale .charge := by
   apply NNReal.eq; rw [ChargeUnit.div_eq_val, NNReal.coe_div]; rfl
 
-private lemma temperature_ratio (u1 u2 : UnitChoices) :
+private lemma temperature_ratio (u1 u2 : LTMCTUnitChoices) :
     u1.temperature / u2.temperature =
       u1.toScale.scale .temperature / u2.toScale.scale .temperature := by
   apply NNReal.eq; rw [TemperatureUnit.div_eq_val, NNReal.coe_div]; rfl
 
-/-- The hand-rolled five-factor `UnitChoices.dimScale` equals the basis-generic
+/-- The hand-rolled five-factor `LTMCTUnitChoices.dimScale` equals the basis-generic
   `UnitScale.dimScale` fold at `LTMCTDimensionBase`, applied to `toScale`. The scaling law
   therefore has a single source of truth on the magnitude layer `UnitScale B`. -/
-lemma dimScale_eq_toScale_dimScale (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+lemma dimScale_eq_toScale_dimScale (u1 u2 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     u1.dimScale u2 d = UnitScale.dimScale u1.toScale u2.toScale d := by
   rw [dimScale_apply, length_ratio, time_ratio, mass_ratio, charge_ratio, temperature_ratio,
     UnitScale.dimScale, MonoidHom.coe_mk, OneHom.coe_mk, prod_univ_LTMCTDimensionBase]
   simp only [Dimension.length, Dimension.time, Dimension.mass, Dimension.charge,
     Dimension.temperature]
 
-end UnitChoices
+end LTMCTUnitChoices

--- a/Physlib/Units/UnitSystem.lean
+++ b/Physlib/Units/UnitSystem.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 Nicolas Rouquette. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nicolas Rouquette
+-/
+module
+
+public import Physlib.Units.ParametricUnits
+/-!
+
+# Typed unit systems, parametrised in a dimension basis
+
+`Dimension B` is basis-generic and `ParametricUnits` gives the basis-generic *magnitude*
+layer `UnitScale B` (a positive real per base dimension, with the scaling homomorphism
+`UnitScale.dimScale` proved once via `Finset.prod`). What was still hardwired to the
+default basis is the *typed* unit side: `UnitChoices` is a bespoke five-field record with
+one named unit type per base dimension (`LengthUnit`, `TimeUnit`, …).
+
+This module provides the generic typed layer. A `UnitSystem B` attaches to a basis `B` a
+family of *typed* unit types — one per base dimension — each carrying a positive-real
+magnitude:
+
+* `UnitSystem B` — the class: `Unit : B → Type`, `mag`, `mag_pos`.
+* `TypedChoice B` — a typed unit at every base dimension, `(b : B) → UnitSystem.Unit b`.
+* `TypedChoice.toScale : TypedChoice B → UnitScale B` — forget the types down to the
+  magnitude layer already provided by `ParametricUnits`.
+
+The `LTMCTDimensionBase` instance recovers exactly today's typed unit names, and
+`UnitChoices ≃ TypedChoice LTMCTDimensionBase` exhibits the bespoke five-field record as
+that instance. The scaling laws are **not** re-proved here: they live once on the
+magnitude layer `UnitScale B`, and the typed layer is a thin faithful wrapper projecting
+onto it via `toScale`.
+
+This is the typed, basis-generic layer discussed as "Option D" in the review of the
+dimension-parametrisation PR; it is the only design that keeps *both* basis-genericity
+and typed-unit safety.
+
+-/
+
+@[expose] public section
+
+open NNReal
+open scoped BigOperators
+
+/-- A **typed unit system** for a basis `B`: for each base dimension `b : B`, a typed
+  unit type `Unit b`, together with the positive-real magnitude `mag` of each such unit.
+  This is the data that makes a *typed* unit choice over `B` (as opposed to the bare
+  magnitude layer `UnitScale B`) possible for an arbitrary basis. -/
+class UnitSystem (B : Type) where
+  /-- The typed unit type at each base dimension. -/
+  Unit : B → Type
+  /-- The positive-real magnitude of a typed unit. -/
+  mag : {b : B} → Unit b → ℝ≥0
+  /-- Every typed unit has a positive magnitude. -/
+  mag_pos : ∀ {b : B} (u : Unit b), 0 < mag u
+
+namespace UnitSystem
+
+variable {B : Type}
+
+end UnitSystem
+
+/-- A **typed unit choice** over a basis `B` equipped with a `UnitSystem`: a typed unit
+  at every base dimension. This is the basis-generic, *typed* form of `UnitChoices`. -/
+def TypedChoice (B : Type) [UnitSystem B] := (b : B) → UnitSystem.Unit b
+
+namespace TypedChoice
+
+variable {B : Type} [UnitSystem B]
+
+/-- Forget a typed unit choice down to its magnitude layer `UnitScale B`, the layer on
+  which the scaling homomorphism `UnitScale.dimScale` is already proved. -/
+noncomputable def toScale (u : TypedChoice B) : UnitScale B where
+  scale b := UnitSystem.mag (u b)
+  scale_pos b := UnitSystem.mag_pos (u b)
+
+@[simp]
+lemma toScale_scale (u : TypedChoice B) (b : B) :
+    (toScale u).scale b = UnitSystem.mag (u b) := rfl
+
+end TypedChoice
+
+/-!
+
+## The `LTMCTDimensionBase` instance
+
+The default basis's `UnitSystem` recovers exactly PhysLib's five named typed unit types,
+so `TypedChoice LTMCTDimensionBase` is the typed five-slot unit choice and
+`u .length : LengthUnit`, `LengthUnit.meters`, … all still work — and a `MassUnit` cannot
+be placed in the length slot.
+
+-/
+
+noncomputable instance : UnitSystem LTMCTDimensionBase where
+  Unit
+    | .length => LengthUnit
+    | .time => TimeUnit
+    | .mass => MassUnit
+    | .charge => ChargeUnit
+    | .temperature => TemperatureUnit
+  mag {b} :=
+    match b with
+    | .length | .time | .mass | .charge | .temperature => fun u => ⟨u.val, u.val_pos.le⟩
+  mag_pos {b} :=
+    match b with
+    | .length | .time | .mass | .charge | .temperature => fun u => NNReal.coe_pos.mp u.val_pos
+
+/-- Type-safety check: a typed unit choice over `LTMCTDimensionBase` projects onto the
+  named typed unit types, so the length slot is a `LengthUnit` (and cannot hold a
+  `MassUnit`). -/
+example (u : TypedChoice LTMCTDimensionBase) : LengthUnit := u .length
+
+example : TypedChoice LTMCTDimensionBase := fun
+  | .length => LengthUnit.meters
+  | .time => TimeUnit.seconds
+  | .mass => MassUnit.kilograms
+  | .charge => ChargeUnit.coulombs
+  | .temperature => TemperatureUnit.kelvin
+
+/-!
+
+## `UnitChoices` is `TypedChoice LTMCTDimensionBase`
+
+The bespoke five-field record and the generic typed choice over the default basis carry
+the same data.
+
+-/
+
+namespace UnitChoices
+
+/-- The bespoke five-field `UnitChoices` and the generic `TypedChoice LTMCTDimensionBase`
+  are the same data. -/
+def equivTypedChoice : UnitChoices ≃ TypedChoice LTMCTDimensionBase where
+  toFun u := fun
+    | .length => u.length
+    | .time => u.time
+    | .mass => u.mass
+    | .charge => u.charge
+    | .temperature => u.temperature
+  invFun f :=
+    { length := f .length
+      time := f .time
+      mass := f .mass
+      charge := f .charge
+      temperature := f .temperature }
+  left_inv u := by cases u; rfl
+  right_inv f := by funext b; cases b <;> rfl
+
+/-- The typed generic projection agrees with the bespoke `UnitChoices.toScale`: reading
+  `UnitChoices` as a `TypedChoice` and forgetting to the magnitude layer is the same as
+  the bespoke `toScale`. -/
+lemma toScale_equivTypedChoice (u : UnitChoices) :
+    (equivTypedChoice u).toScale = u.toScale := by
+  refine UnitScale.ext ?_
+  funext b
+  cases b <;> rfl
+
+end UnitChoices
+
+/-!
+
+## The bespoke scaling law is the generic fold
+
+`UnitChoices.dimScale` — the five explicit `rpow` factors written out by hand in
+`Basic.lean` — is exactly the generic `UnitScale.dimScale` fold (a `Finset.prod` over the
+basis) at the `LTMCTDimensionBase` instance, applied to `toScale`. This is what makes the
+typed layer a *faithful* wrapper rather than a second, independent statement of the
+scaling law: there is one source of truth, the generic fold on `UnitScale B`.
+
+-/
+
+open Finset in
+private lemma prod_univ_LTMCTDimensionBase {M : Type} [CommMonoid M]
+    (f : LTMCTDimensionBase → M) :
+    ∏ b, f b = f .length * f .time * f .mass * f .charge * f .temperature := by
+  rw [show (univ : Finset LTMCTDimensionBase)
+        = {.length, .time, .mass, .charge, .temperature} from by decide]
+  rw [prod_insert (by decide), prod_insert (by decide), prod_insert (by decide),
+    prod_insert (by decide), prod_singleton, ← mul_assoc, ← mul_assoc, ← mul_assoc]
+
+namespace UnitChoices
+
+private lemma length_ratio (u1 u2 : UnitChoices) :
+    u1.length / u2.length = u1.toScale.scale .length / u2.toScale.scale .length := by
+  apply NNReal.eq; rw [LengthUnit.div_eq_val, NNReal.coe_div]; rfl
+
+private lemma time_ratio (u1 u2 : UnitChoices) :
+    u1.time / u2.time = u1.toScale.scale .time / u2.toScale.scale .time := by
+  apply NNReal.eq; rw [TimeUnit.div_eq_val, NNReal.coe_div]; rfl
+
+private lemma mass_ratio (u1 u2 : UnitChoices) :
+    u1.mass / u2.mass = u1.toScale.scale .mass / u2.toScale.scale .mass := by
+  apply NNReal.eq; rw [MassUnit.div_eq_val, NNReal.coe_div]; rfl
+
+private lemma charge_ratio (u1 u2 : UnitChoices) :
+    u1.charge / u2.charge = u1.toScale.scale .charge / u2.toScale.scale .charge := by
+  apply NNReal.eq; rw [ChargeUnit.div_eq_val, NNReal.coe_div]; rfl
+
+private lemma temperature_ratio (u1 u2 : UnitChoices) :
+    u1.temperature / u2.temperature =
+      u1.toScale.scale .temperature / u2.toScale.scale .temperature := by
+  apply NNReal.eq; rw [TemperatureUnit.div_eq_val, NNReal.coe_div]; rfl
+
+/-- The hand-rolled five-factor `UnitChoices.dimScale` equals the basis-generic
+  `UnitScale.dimScale` fold at `LTMCTDimensionBase`, applied to `toScale`. The scaling law
+  therefore has a single source of truth on the magnitude layer `UnitScale B`. -/
+lemma dimScale_eq_toScale_dimScale (u1 u2 : UnitChoices) (d : Dimension LTMCTDimensionBase) :
+    u1.dimScale u2 d = UnitScale.dimScale u1.toScale u2.toScale d := by
+  rw [dimScale_apply, length_ratio, time_ratio, mass_ratio, charge_ratio, temperature_ratio,
+    UnitScale.dimScale, MonoidHom.coe_mk, OneHom.coe_mk, prod_univ_LTMCTDimensionBase]
+  simp only [Dimension.length, Dimension.time, Dimension.mass, Dimension.charge,
+    Dimension.temperature]
+
+end UnitChoices

--- a/Physlib/Units/WithDim/Area.lean
+++ b/Physlib/Units/WithDim/Area.lean
@@ -25,7 +25,7 @@ abbrev DimArea : Type := Dimensionful (WithDim (L𝓭 * L𝓭) ℝ≥0)
 
 namespace DimArea
 
-open UnitChoices
+open LTMCTUnitChoices
 
 /-!
 
@@ -40,11 +40,11 @@ noncomputable def squareMeter : DimArea := toDimensionful SI ⟨1⟩
 
 /-- The dimensional area corresponding to 1 square foot. -/
 noncomputable def squareFoot : DimArea := toDimensionful ({SI with
-  length := LengthUnit.feet} : UnitChoices) ⟨1⟩
+  length := LengthUnit.feet} : LTMCTUnitChoices) ⟨1⟩
 
 /-- The dimensional area corresponding to 1 square mile. -/
 noncomputable def squareMile : DimArea := toDimensionful ({SI with
-  length := LengthUnit.miles} : UnitChoices) ⟨1⟩
+  length := LengthUnit.miles} : LTMCTUnitChoices) ⟨1⟩
 
 /-- The dimensional area corresponding to 1 are (100 square meters). -/
 noncomputable def are : DimArea := toDimensionful SI ⟨100⟩
@@ -54,7 +54,7 @@ noncomputable def hectare : DimArea := toDimensionful SI ⟨10000⟩
 
 /-- The dimensional area corresponding to 1 acre (1/640 square miles). -/
 noncomputable def acre : DimArea := toDimensionful ({SI with
-  length := LengthUnit.miles} : UnitChoices) ⟨(1/640)⟩
+  length := LengthUnit.miles} : LTMCTUnitChoices) ⟨(1/640)⟩
 
 /-!
 

--- a/Physlib/Units/WithDim/Basic.lean
+++ b/Physlib/Units/WithDim/Basic.lean
@@ -16,7 +16,7 @@ The dimension `d : Dimension B` may be taken over any basis `B` of base dimensio
 The *algebraic* structure of `WithDim d M` (its additive, order, scalar-action,
 multiplication, division and casting instances) is available for every basis `B`.
 The *unit-scaling* structure (`HasDim`, `DMul`, and the `scaleUnit` lemmas), which
-routes through `UnitChoices.dimScale`, is provided for the standard basis
+routes through `LTMCTUnitChoices.dimScale`, is provided for the standard basis
 `LTMCTDimensionBase`.
 
 -/
@@ -205,7 +205,7 @@ lemma val_pow_two_eq_mul {B : Type} {d1 : Dimension B} (m1 : WithDim d1 ℝ) :
 
 @[simp]
 lemma scaleUnit_val_eq_scaleUnit_val {d : Dimension LTMCTDimensionBase} (M : Type) [MulAction ℝ≥0 M]
-    (u1 u2 : UnitChoices) (m1 m2 : WithDim d M) :
+    (u1 u2 : LTMCTUnitChoices) (m1 m2 : WithDim d M) :
     (scaleUnit u1 u2 m1).val = (scaleUnit u1 u2 m2).val ↔ m1.val = m2.val := by
   rw [← WithDim.ext_iff]
   simp only [scaleUnit_injective]
@@ -213,14 +213,14 @@ lemma scaleUnit_val_eq_scaleUnit_val {d : Dimension LTMCTDimensionBase} (M : Typ
 
 lemma scaleUnit_val_eq_scaleUnit_val_of_dim_eq {d1 d2 : Dimension LTMCTDimensionBase} {M : Type}
     [MulAction ℝ≥0 M]
-    {u1 u2 : UnitChoices} {m1 : WithDim d1 M} {m2 : WithDim d2 M}
+    {u1 u2 : LTMCTUnitChoices} {m1 : WithDim d1 M} {m2 : WithDim d2 M}
     (h : d1 = d2 := by ext <;> {simp; try ring}) :
     (scaleUnit u1 u2 m1).val = (scaleUnit u1 u2 m2).val ↔ m1.val = m2.val := by
   subst h
   simp
 
 lemma scaleUnit_val {d : Dimension LTMCTDimensionBase} (M : Type) [MulAction ℝ≥0 M]
-    (u1 u2 : UnitChoices) (m1 : WithDim d M) :
+    (u1 u2 : LTMCTUnitChoices) (m1 : WithDim d M) :
     (scaleUnit u1 u2 m1).val = u1.dimScale u2 d • m1.val := rfl
 
 /-!
@@ -239,7 +239,7 @@ lemma val_div_val {B : Type} {d1 d2 : Dimension B} (m1 : WithDim d1 ℝ) (m2 : W
 
 @[simp]
 lemma div_scaleUnit {d1 d2 : Dimension LTMCTDimensionBase} (m1 : WithDim d1 ℝ) (m2 : WithDim d2 ℝ)
-    (u1 u2 : UnitChoices) :
+    (u1 u2 : LTMCTUnitChoices) :
     (scaleUnit u1 u2 m1) / (scaleUnit u1 u2 m2) = scaleUnit u1 u2 (m1 / m2) := by
   symm
   ext
@@ -253,7 +253,7 @@ lemma div_scaleUnit {d1 d2 : Dimension LTMCTDimensionBase} (m1 : WithDim d1 ℝ)
 
 @[simp]
 lemma scaleUnit_dim_eq_zero {d : Dimension LTMCTDimensionBase} (m : WithDim d ℝ)
-    (u1 u2 : UnitChoices) (h : d = 1 := by ext <;> {simp; try ring}) :
+    (u1 u2 : LTMCTUnitChoices) (h : d = 1 := by ext <;> {simp; try ring}) :
     scaleUnit u1 u2 m = m := by
   subst h
   ext
@@ -277,7 +277,7 @@ lemma cast_refl {B : Type} {d : Dimension B} {M : Type} (m : WithDim d M) :
 @[simp]
 lemma cast_scaleUnit {d d2 : Dimension LTMCTDimensionBase} {M : Type} [MulAction ℝ≥0 M]
     (m : WithDim d M)
-    (h : d = d2) (u1 u2 : UnitChoices) :
+    (h : d = d2) (u1 u2 : LTMCTUnitChoices) :
     cast (scaleUnit u1 u2 m) h = scaleUnit u1 u2 (cast m h) := by
   subst h
   simp

--- a/Physlib/Units/WithDim/Energy.lean
+++ b/Physlib/Units/WithDim/Energy.lean
@@ -24,7 +24,7 @@ open NNReal
 abbrev DimEnergy : Type := Dimensionful (WithDim (M𝓭 * L𝓭 * L𝓭 * T𝓭⁻¹ * T𝓭⁻¹) ℝ)
 
 namespace DimEnergy
-open UnitChoices Dimensionful CarriesDimension
+open LTMCTUnitChoices Dimensionful CarriesDimension
 
 /-- The dimensional energy corresponding to 1 joule, J. -/
 noncomputable def joule : DimEnergy := toDimensionful SI ⟨1⟩

--- a/Physlib/Units/WithDim/Pressure.lean
+++ b/Physlib/Units/WithDim/Pressure.lean
@@ -24,7 +24,7 @@ open NNReal
 abbrev DimPressure : Type := Dimensionful (WithDim (M𝓭 * L𝓭⁻¹ * T𝓭⁻¹ * T𝓭⁻¹) ℝ)
 
 namespace DimPressure
-open UnitChoices Dimensionful CarriesDimension
+open LTMCTUnitChoices Dimensionful CarriesDimension
 
 /-- The dimensional pressure corresponding to 1 pascal, Pa. -/
 noncomputable def pascal : DimPressure := toDimensionful SI ⟨1⟩
@@ -44,6 +44,6 @@ noncomputable def torr : DimPressure := (1/760 : ℝ≥0) • standardAtmosphere
 /-- The dimensional pressure corresponding to 1 pound per square inch. -/
 noncomputable def psi : DimPressure := toDimensionful ({SI with
   mass := MassUnit.pounds,
-  length := LengthUnit.inches} : UnitChoices) ⟨1⟩
+  length := LengthUnit.inches} : LTMCTUnitChoices) ⟨1⟩
 
 end DimPressure

--- a/Physlib/Units/WithDim/Speed.lean
+++ b/Physlib/Units/WithDim/Speed.lean
@@ -25,7 +25,7 @@ abbrev DimSpeed : Type := Dimensionful (WithDim (L𝓭 * T𝓭⁻¹) ℝ≥0)
 
 namespace DimSpeed
 
-open UnitChoices
+open LTMCTUnitChoices
 
 /-!
 
@@ -33,21 +33,21 @@ open UnitChoices
 
 -/
 open Dimensionful
-open UnitChoices CarriesDimension
+open LTMCTUnitChoices CarriesDimension
 /-- The dimensional speed corresponding to 1 meter per second. -/
 noncomputable def oneMeterPerSecond : DimSpeed := toDimensionful SI ⟨1⟩
 
 /-- The dimensional speed corresponding to 1 mile per hour. -/
 noncomputable def oneMilePerHour : DimSpeed := toDimensionful ({SI with
-  length := LengthUnit.miles, time := TimeUnit.hours} : UnitChoices) ⟨1⟩
+  length := LengthUnit.miles, time := TimeUnit.hours} : LTMCTUnitChoices) ⟨1⟩
 
 /-- The dimensional speed corresponding to 1 kilometer per hour. -/
 noncomputable def oneKilometerPerHour : DimSpeed := toDimensionful ({SI with
-  length := LengthUnit.kilometers, time := TimeUnit.hours} : UnitChoices) ⟨1⟩
+  length := LengthUnit.kilometers, time := TimeUnit.hours} : LTMCTUnitChoices) ⟨1⟩
 
 /-- The dimensional speed corresponding to 1 knot, aka, one nautical mile per hour. -/
 noncomputable def oneKnot : DimSpeed := toDimensionful ({SI with
-  length := LengthUnit.nauticalMiles, time := TimeUnit.hours} : UnitChoices) ⟨1⟩
+  length := LengthUnit.nauticalMiles, time := TimeUnit.hours} : LTMCTUnitChoices) ⟨1⟩
 
 /-- The dimensionful speed of light corresponding to 299792458 meters per second. -/
 noncomputable def speedOfLight : Dimensionful (WithDim (L𝓭 * T𝓭⁻¹) ℝ) :=


### PR DESCRIPTION
Closes #1480.

Finishes the unit-side counterpart to #1447 (which parameterized `Dimension` over a basis and added the magnitude twin `UnitScale B`). The *typed* unit choice was still welded to `LTMCTDimensionBase`; this makes it basis-generic while keeping typed-unit safety, following **Option D** from the [#1447 review](https://github.com/leanprover-community/physlib/pull/1447#issuecomment-5026424659). Full rationale, the blast-radius map, and the "why not A/B/C" analysis are in #1480.

## What's here (three reviewable commits)

1. **`feat(Units)`: additive core** — `class UnitSystem B` (`Unit : B → Type`, `mag`, `mag_pos`), `TypedChoice B := (b : B) → UnitSystem.Unit b`, `TypedChoice.toScale : TypedChoice B → UnitScale B`, the `LTMCTDimensionBase` instance, `LTMCTUnitChoices ≃ TypedChoice LTMCTDimensionBase`, and `dimScale_eq_toScale_dimScale` (the hand-rolled five-factor `dimScale` **equals** the generic `Finset.prod` fold — one source of truth). `@[ext]` added to `UnitScale`. No existing call site changes.
2. **`refactor(Units)`: rename `UnitChoices → LTMCTUnitChoices`** — it is inherently the unit choice for `LTMCTDimensionBase` (its fields hardcode the five `…Unit` types), so the name now mirrors the dimension basis. Stays a record: `{ SI with length := … }`, `u.length`, `⟨…⟩`, `@[ext]` all unchanged. Whole-word rename, all ~112 references under `Physlib/Units/`.
3. **`feat(Units)`: `SIUnitChoices`** — `SIUnitChoices := TypedChoice ISQDimensionBase`, the typed SI unit choice over the seven ISQ base quantities, from the *same* machinery. Adds `CurrentUnit` / `AmountUnit` / `LuminousIntensityUnit` (ampere / mole / candela), `instance : UnitSystem ISQDimensionBase`, the coherent `SIUnitChoices.SI` (m, kg, s, A, K, mol, cd), and a `dimScale` reused from the generic fold. Pairs `ISQDimensionBase ↔ SIUnitChoices` beside `LTMCTDimensionBase ↔ LTMCTUnitChoices`, with the existing `ltmctToISQ` / `isqToLTMCT` already bridging the bases.

(A fourth commit wraps two signatures the rename pushed past 100 columns.)

## Acceptance criteria (from #1480)

- [x] `UnitSystem`, `TypedChoice`, `TypedChoice.toScale` added and building, indexed in `Physlib.lean`.
- [x] `instance : UnitSystem LTMCTDimensionBase` recovering the five typed unit names, with a `u .length : LengthUnit` type-safety check.
- [x] `LTMCTUnitChoices ≃ TypedChoice LTMCTDimensionBase`.
- [x] `LTMCTUnitChoices.dimScale = UnitScale.dimScale ∘ toScale` (law-unification), a single source of truth for the scaling law on the magnitude layer.
- [x] `UnitChoices` renamed to `LTMCTUnitChoices` (record kept; ergonomics unchanged).
- [x] `SIUnitChoices := TypedChoice ISQDimensionBase` with `UnitSystem ISQDimensionBase`, the three new ISQ typed unit types, `SIUnitChoices.SI`, and a `u .current : CurrentUnit` type-safety check; its `dimScale` reuses the generic fold.
- [x] Full `Physlib` build green; axioms classical-only on the new results.

## Verification

Ran the `build.yml` gate locally on this branch — all green:

- `lake build -KCI` — 9266 jobs
- `check_file_imports`, `check_dup_tags`, `sorry_lint` — pass
- `runPhyslibLinters` — Physlib + QuantumInfo pass
- `scripts/lint-style.sh`, `api_map_linter.py`, `codespell` — pass
- Axioms of the new results: `propext`, `Classical.choice`, `Quot.sound` only (no `sorryAx`).

Notes for reviewers: the three new unit types (`CurrentUnit` / `AmountUnit` / `LuminousIntensityUnit`) are minimal (positive-real magnitude + division); their full scale/relation API, and relocation to the appropriate physics directories following the `LengthUnit` convention, can be a follow-up. Happy to split this into separate PRs (core / rename / second basis) if that's easier to review.
