### PR TITLE
docs(ClassicalMechanics): expand the module overview

### DIFF
--- a/Physlib/ClassicalMechanics/Basic.lean
+++ b/Physlib/ClassicalMechanics/Basic.lean
@@ -7,9 +7,30 @@ module
 
 /-!
 
-# Classical mechanics
+# A. Classical mechanics
 
-This file is currently a stub.
-Please feel free to contribute!
+Classical mechanics describes the motion of physical systems using trajectories, forces,
+energies, and variational principles. Physlib develops both general formulations of the subject
+and formally verified examples of mechanical systems.
 
--/@[expose] public section
+## A.1. Scope
+
+The general infrastructure includes the Euler–Lagrange equations, Hamilton's equations, and
+relations between equivalent Lagrangian descriptions. Concrete models cover free particles,
+harmonic and damped oscillators, pendula, rigid bodies, orbital mechanics, scattering, vibrations,
+and wave equations.
+
+## A.2. Current status
+
+This module is an overview and currently introduces no declarations. The definitions and results
+for each topic live in the corresponding submodules under `Physlib.ClassicalMechanics`.
+
+## A.3. Future work
+
+Shared declarations should be added here only when they apply across several areas of classical
+mechanics. Definitions and results specific to one physical system should remain in its dedicated
+module so that the library stays navigable.
+
+-/
+
+@[expose] public section


### PR DESCRIPTION
Expands the Classical Mechanics module overview from a stub ("This file is currently a stub. Please feel free to contribute!") into a proper module documentation section following the library's `# A`, `## A.1`/`A.2`/`A.3` heading convention: scope of the module, current status (introduces no declarations itself), and future-work guidance for where shared vs. system-specific declarations belong.

Documentation only — no declarations, proofs, or signatures changed.

### AI/LLM disclosure
AI coding tools were used to help draft this documentation. I reviewed the complete change for accuracy before submitting.