### PR TITLE
docs(Electromagnetism): expand the foundational module overview

### DIFF
--- a/Physlib/Electromagnetism/Basic.lean
+++ b/Physlib/Electromagnetism/Basic.lean
@@ -8,11 +8,31 @@ module
 public import Physlib.SpaceAndTime.SpaceTime.Basic
 /-!
 
-# Electromagnetism
+# A. Electromagnetism
 
-In this file we define the electric field, the magnetic field, and the field strength tensor.
+Electromagnetism describes electric and magnetic fields, their potentials and sources, and the
+relations between them on space and spacetime. This module provides a compact foundational API used
+by more specialized electromagnetism modules in Physlib.
 
-This module is old and parts of it will soon be replaced.
+## A.1. Main definitions
+
+The module contains coordinate-level types for electric and magnetic fields, a spacetime vector
+potential, charge and current densities, and the constants describing an electromagnetic system.
+For an `EMSystem`, it also defines the speed of light and Coulomb's constant in terms of the vacuum
+permittivity and permeability.
+
+## A.2. Current status
+
+The definitions here are intentionally lightweight. More developed APIs are organized under the
+`Kinematics`, `Dynamics`, `Distributional`, `ThreeDimension`, and `Vacuum` subdirectories. The
+abbreviations in this file remain useful as shared entry points while those APIs continue to
+converge.
+
+## A.3. Future work
+
+Charge and current densities should be generalized to signed measures while remaining convenient
+for integration and tensor notation. As the specialized APIs stabilize, overlapping legacy
+interfaces should be consolidated without breaking the physical meaning of existing declarations.
 
 -/
 

--- a/Physlib/Electromagnetism/Basic.lean
+++ b/Physlib/Electromagnetism/Basic.lean
@@ -40,17 +40,15 @@ interfaces should be consolidated without breaking the physical meaning of exist
 
 namespace Electromagnetism
 
-/-- The electric field is a map from `d`+1 dimensional spacetime to the vector space
-  `ℝ^d`. -/
+/-- The electric field is a map from `(d + 1)`-dimensional spacetime to `ℝ^d`. -/
 abbrev ElectricField (d : ℕ := 3) := Time → Space d → EuclideanSpace ℝ (Fin d)
 
-/-- The magnetic field is a map from `d+1` dimensional spacetime to the vector space
-  `ℝ^d`. -/
+/-- The magnetic field is a map from `(d + 1)`-dimensional spacetime to `ℝ^d`. -/
 abbrev MagneticField (d : ℕ := 3) := Time → Space d → EuclideanSpace ℝ (Fin d)
 
 open realLorentzTensor
 
-/-- The vector potential of an electromagnetic field-/
+/-- The vector potential of an electromagnetic field. -/
 abbrev VectorPotential (d : ℕ := 3) := SpaceTime d → ℝT[d, .up]
 
 /-- The electric permittivity and the magnetic permeability of free space. -/
@@ -62,14 +60,14 @@ structure EMSystem where
 
 TODO "Charge density and current density should be generalized to signed measures,
   in such a way
-  that they are still easy to work with and can be integrated with with tensor notation.
+  that they are still easy to work with and can be integrated with tensor notation.
   See here:
   https://leanprover.zulipchat.com/#narrow/channel/479953-Physlib/topic/Maxwell's.20Equations"
 
 /-- The charge density. -/
 abbrev ChargeDensity := Time → Space → ℝ
 
-/-- Current density. -/
+/-- The current density. -/
 abbrev CurrentDensity := Time → Space → EuclideanSpace ℝ (Fin 3)
 
 namespace EMSystem


### PR DESCRIPTION
Expands the Electromagnetism foundational module from a two-line stub noting it "is old and parts of it will soon be replaced" into proper module documentation: what the module provides (field/potential/density types, EM constants), current status relative to the more developed `Kinematics`/`Dynamics`/`Distributional`/`ThreeDimension`/`Vacuum` subdirectories, and future-work notes (generalizing charge/current density to signed measures, consolidating legacy interfaces as specialized APIs stabilize). Also tightens a few docstrings (spacing, minor grammar) on the existing declarations without changing them.

Documentation only — no declarations, proofs, or signatures changed.

### AI/LLM disclosure
AI coding tools were used to help draft this documentation. I reviewed the complete change for accuracy before submitting.