### PR TITLE
docs(Electromagnetism): document the three-dimensional Maxwell equations module

### DIFF
--- a/Physlib/Electromagnetism/ThreeDimension/MaxwellEquations.lean
+++ b/Physlib/Electromagnetism/ThreeDimension/MaxwellEquations.lean
@@ -27,10 +27,11 @@ This module proves the four differential equations:
 
 ## A.2. Relation to the covariant formulation
 
-The electric and magnetic fields are obtained from an electromagnetic potential. Gauss's law for the
-electric field and Ampère's law are derived from the covariant extremality condition `IsExtrema`, while the two
-homogeneous equations follow from the potential definitions and smoothness assumptions. The results
-therefore connect the tensorial backend to the standard three-dimensional presentation.
+The electric and magnetic fields are obtained from an electromagnetic potential. Gauss's law for
+the electric field and Ampère's law are derived from the covariant extremality condition
+`IsExtrema`, while the two homogeneous equations follow from the potential definitions and
+smoothness assumptions. The results therefore connect the tensorial backend to the standard
+three-dimensional presentation.
 
 ## A.3. Current scope
 

--- a/Physlib/Electromagnetism/ThreeDimension/MaxwellEquations.lean
+++ b/Physlib/Electromagnetism/ThreeDimension/MaxwellEquations.lean
@@ -27,8 +27,8 @@ This module proves the four differential equations:
 
 ## A.2. Relation to the covariant formulation
 
-The electric and magnetic fields are obtained from an electromagnetic potential. Gauss's electric
-law and Ampère's law are derived from the covariant extremality condition `IsExtrema`, while the two
+The electric and magnetic fields are obtained from an electromagnetic potential. Gauss's law for the
+electric field and Ampère's law are derived from the covariant extremality condition `IsExtrema`, while the two
 homogeneous equations follow from the potential definitions and smoothness assumptions. The results
 therefore connect the tensorial backend to the standard three-dimensional presentation.
 

--- a/Physlib/Electromagnetism/ThreeDimension/MaxwellEquations.lean
+++ b/Physlib/Electromagnetism/ThreeDimension/MaxwellEquations.lean
@@ -9,10 +9,34 @@ public import Physlib.Electromagnetism.ThreeDimension.Basic
 public import Physlib.Electromagnetism.Dynamics.IsExtrema
 /-!
 
-# Maxwell equations in three dimensions
+# A. Maxwell's equations in three dimensions
 
-This file states Maxwell's equations in the familiar vector-calculus language
-and connects them to the tensorial backend formulation.
+Maxwell's equations relate electric and magnetic fields to electric charge and current. In three
+spatial dimensions they can be written using the familiar divergence, curl, and time-derivative
+operators of vector calculus.
+
+## A.1. Main results
+
+This module proves the four differential equations:
+
+- `gaussLawElectric`, relating the divergence of the electric field to charge density;
+- `gaussLawMagnetic`, stating that the magnetic field is divergence-free;
+- `ampereLaw`, including both the electric current and displacement-current terms;
+- `faradayLaw`, relating the curl of the electric field to the time derivative of the magnetic
+  field.
+
+## A.2. Relation to the covariant formulation
+
+The electric and magnetic fields are obtained from an electromagnetic potential. Gauss's electric
+law and Ampère's law are derived from the covariant extremality condition `IsExtrema`, while the two
+homogeneous equations follow from the potential definitions and smoothness assumptions. The results
+therefore connect the tensorial backend to the standard three-dimensional presentation.
+
+## A.3. Current scope
+
+The statements here are pointwise differential equations in free space. Integral formulations,
+boundary conditions, and constitutive laws for material media are outside the current scope of this
+module.
 
 -/
 namespace Electromagnetism


### PR DESCRIPTION
Documents the three-dimensional Maxwell equations module: lists the four results it proves (`gaussLawElectric`, `gaussLawMagnetic`, `ampereLaw`, `faradayLaw`), explains how they relate to the covariant `IsExtrema` formulation (the two inhomogeneous equations come from the extremality condition, the two homogeneous ones follow directly from the potential definitions), and notes the current scope (pointwise differential form in free space; integral formulations, boundary conditions, and material media are out of scope).

Documentation only — no declarations, proofs, or signatures changed.

### AI/LLM disclosure
AI coding tools were used to help draft this documentation. I reviewed the complete change for accuracy before submitting.