### PR TITLE
feat(QuantumMechanics) : Prove potentialOperator_isSelfAdjoint

### DIFF
--- a/Physlib/QuantumMechanics/RectangularBarrier/Basic.lean
+++ b/Physlib/QuantumMechanics/RectangularBarrier/Basic.lean
@@ -87,10 +87,15 @@ lemma potentialFunction_eq :
     Q.potentialFunction = fun x ↦ (Icc Q.lower Q.upper).indicator (fun _ ↦ Q.V₀) (x 0) := rfl
 
 /-- The piecewise-constant potential of the rectangular barrier is a.e. strongly measurable. -/
-informal_lemma potentialFunction_aestronglyMeasurable where
-  deps := [``RectangularBarrier]
-  tag := "QM-RB-aesm"
-  -- This relies on `Space.val` being measure-preserving.
+-- This relies on `Space.val` being measure-preserving.
+lemma potentialFunction_aestronglyMeasurable: AEStronglyMeasurable Q.potentialFunction volume := by
+  unfold potentialFunction
+  apply AEStronglyMeasurable.indicator
+  · fun_prop
+  · change (MeasurableSet ((Icc Q.lower Q.upper) ∘ (fun (x: Space 1) => x.val 0)))
+    have hi : MeasurableSet (Icc Q.lower Q.upper) := by measurability
+    have hf : Measurable ((fun x => x.val 0) : Space 1 → ℝ) := by measurability
+    exact MeasurableSet.preimage hi hf
 
 /-!
 ## C. Hilbert space
@@ -119,9 +124,12 @@ def kineticOperator : Q.HS →ₗ.[ℂ] Q.HS := (2 * Q.m)⁻¹ • momentumSqOpe
 def potentialOperator : Q.HS →ₗ.[ℂ] Q.HS := 𝓜 volume (Complex.ofReal ∘ Q.potentialFunction)
 
 /-- The potential operator for the rectangular barrier is self-adjoint. -/
-informal_lemma potentialOperator_isSelfAdjoint where
-  deps := [``RectangularBarrier]
-  tag := "QM-RB-sa"
+lemma potentialOperator_isSelfAdjoint (Q : RectangularBarrier): IsSelfAdjoint Q.potentialOperator := by
+  unfold IsSelfAdjoint; unfold potentialOperator
+  rw [mulOperator_isSelfAdjoint_ofReal]
+  swap; ext x; simp
+  have hQ := potentialFunction_aestronglyMeasurable
+  fun_prop
 
 /-!
 ### D.3. Hamiltonian

--- a/Physlib/QuantumMechanics/RectangularBarrier/Basic.lean
+++ b/Physlib/QuantumMechanics/RectangularBarrier/Basic.lean
@@ -126,9 +126,12 @@ def potentialOperator : Q.HS →ₗ.[ℂ] Q.HS := 𝓜 volume (Complex.ofReal �
 /-- The potential operator for the rectangular barrier is self-adjoint. -/
 lemma potentialOperator_isSelfAdjoint (Q : RectangularBarrier) :
     IsSelfAdjoint Q.potentialOperator := by
-  unfold IsSelfAdjoint; unfold potentialOperator
+  unfold IsSelfAdjoint
+  unfold potentialOperator
   rw [mulOperator_isSelfAdjoint_ofReal]
-  swap; ext x; simp only [Function.comp_apply, Complex.conj_ofReal]
+  swap
+  ext x
+  simp only [Function.comp_apply, Complex.conj_ofReal]
   have hQ := potentialFunction_aestronglyMeasurable
   fun_prop
 

--- a/Physlib/QuantumMechanics/RectangularBarrier/Basic.lean
+++ b/Physlib/QuantumMechanics/RectangularBarrier/Basic.lean
@@ -124,10 +124,11 @@ def kineticOperator : Q.HS →ₗ.[ℂ] Q.HS := (2 * Q.m)⁻¹ • momentumSqOpe
 def potentialOperator : Q.HS →ₗ.[ℂ] Q.HS := 𝓜 volume (Complex.ofReal ∘ Q.potentialFunction)
 
 /-- The potential operator for the rectangular barrier is self-adjoint. -/
-lemma potentialOperator_isSelfAdjoint (Q : RectangularBarrier): IsSelfAdjoint Q.potentialOperator := by
+lemma potentialOperator_isSelfAdjoint (Q : RectangularBarrier) :
+    IsSelfAdjoint Q.potentialOperator := by
   unfold IsSelfAdjoint; unfold potentialOperator
   rw [mulOperator_isSelfAdjoint_ofReal]
-  swap; ext x; simp
+  swap; ext x; simp only [Function.comp_apply, Complex.conj_ofReal]
   have hQ := potentialFunction_aestronglyMeasurable
   fun_prop
 


### PR DESCRIPTION
This pull request provides a proof for the lemma `potentialOperator_isSelfAdjoint` in `Physlib/QuantumMechanics/RectangularBarrier/Basic.lean`, which was previously an informal_lemma. Also, it proves `potentialFunction_aestronglyMeasurable` because `potentialOperator_isSelfAdjoint` uses it. 


## Specific Changes

Two informal lemmas were formalized and proved:

- `RectangularBarrier.potentialFunction_aestronglyMeasurable` : formalize and prove that the potential function of a rectangular barrier is almost everywhere strongly measurable 
- `RectangularBarrier.potentialOperator_isSelfAdjoint` : prove that the potential function of a rectangular barrier is self adjoint using the above lemma 


## Reviewer Guide

I fixed any linting issues found in `Physlib/QuantumMechanics/RectangularBarrier/Basic.lean` after I ran `lake exe lint_all` and `./scripts/lint-style.sh` locally. 

The lemma `potentialFunction_aestronglyMeasurable` was only proved for the canonical `volume` measure. Is this an issue? 


## Additional Comments
I wrote the code, but used ChatGPT and Google Search to suggest approaches and next steps. 

Thank you!