### PR TITLE
docs(tensors): add Tensors API map

### DIFF
--- a/Physlib/Relativity/Tensors/API-map.yaml
+++ b/Physlib/Relativity/Tensors/API-map.yaml
@@ -1,0 +1,134 @@
+version: v0.1
+
+Title: Tensors
+
+Overview: |
+    The key data structure is `TensorSpecies`, which packages everything needed to
+    define a type of tensor with index notation: a symmetry group `G`, a type `C` of
+    index colors, a representation and a basis for each color, an involution `τ`
+    naming the dual color that an index may contract with, and the contraction, unit
+    and metric data for each dual pair. For `S : TensorSpecies` and a list of colors
+    `c : Fin n → C`, `S.Tensor c` is the type of tensors with those indices, realized
+    as a `PiTensorProduct`; `Pure S c` is the type of pure tensors; and
+    `ComponentIdx c` is the type of component labels. On this base the API builds the
+    operations of ordinary index notation: permutation and reindexing of indices,
+    tensor products, contraction of a dual pair (both within one tensor and across
+    two), evaluation of an index at a fixed component, raising and lowering against
+    the metric, and conjugation. A `{ ... }ᵀ` elaborator turns pen-and-paper index
+    expressions into these operations, and the `Tensorial` class carries them to any
+    type linearly equivalent to a tensor.
+    Two species are constructed. `realLorentzTensor d` has colors `up` and `down`
+    over the Lorentz group, and supports Lorentz vectors and covectors, the Minkowski
+    product, causal character, velocities, and the rank-four Levi-Civita tensor.
+    `complexLorentzTensor` has the two Weyl colors and their duals alongside the
+    Lorentz vector colors, over SL(2, ℂ). A canonical equivariant semilinear map
+    takes the first into the second and commutes with permutation, tensor
+    products, contraction of a dual pair and evaluation of an index.
+
+ParentAPIs:
+  - "Lorentz Group (Physlib/Relativity/LorentzGroup)"
+  - "Weyl Fermions (Physlib/Relativity/Fermions/Weyl)"
+
+References:
+  - "Formalization of physics index notation in Lean 4, Tooby-Smith. arXiv:2411.07667, https://arxiv.org/abs/2411.07667"
+
+Requirements:
+
+  - description: "The key data structure `TensorSpecies` (a group, a type of index colors, a representation and a basis for each color, the dual-color involution `τ`, and the contraction, unit and metric data satisfying the coherence conditions) is defined."
+    done: true
+    location: "Physlib/Relativity/Tensors/TensorSpecies/Basic.lean (TensorSpecies, basisIdxCongr, τ_τ_apply, basis_congr, numIndices)"
+
+  - description: "The API contains the type `Tensor` of tensors with a given list of index colors, the type `Pure` of pure tensors, the type `ComponentIdx` of component labels, the passage between a tensor and its components, the component basis, and the identification of rank-zero tensors with the base field."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/Basic.lean (Tensor, Pure, Pure.toTensor, Pure.component, Pure.basisVector, Tensor.componentMap, ofComponents, basis, basis_repr_pure, toField); Physlib/Relativity/Tensors/ComponentIdx/Basic.lean (ComponentIdx, ComponentIdx.congr_right, ComponentIdx.cast); Physlib/Relativity/Tensors/ComponentIdx/Single.lean (ComponentIdx.single); Physlib/Relativity/Tensors/ComponentIdx/Product.lean (ComponentIdx.prod); Physlib/Relativity/Tensors/ComponentIdx/Contraction.lean (ComponentIdx.dropPair, ComponentIdx.DropPairSection, ComponentIdx.DropPairSection.ofFinEquiv)
+
+  - description: "The API contains the action of the symmetry group on pure tensors and on tensors, the permutation of indices along a color-preserving map, and the notion `IsReindexing` of such a map together with its closure under inverse, composition and the index maps used by products, evaluation and contraction."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/Basic.lean (actionP, actionT, Pure.permP, permT, permT_equivariant, permT_permT, permT_injective); Physlib/Relativity/Tensors/Reindexing.lean (IsReindexing, IsReindexing.toEquiv, IsReindexing.inv, IsReindexing.comp, IsReindexing.symm, IsReindexing.append_congr_left, IsReindexing.append_congr_right, IsReindexing.append_swap, IsReindexing.succAbove, IsReindexing.succSuccAbove)
+
+  - description: "The API contains the tensor product of pure tensors and of tensors, with its components in the basis, its equivariance, and its behaviour under swapping the factors, permuting either factor, and rebracketing."
+    done: true
+    location: "Physlib/Relativity/Tensors/Product.lean (Pure.prodP, prodT, prodT_basis, prodT_basis_repr_apply, tensorEquivProd, prodT_equivariant, prodT_swap, prodT_permT_left, prodT_permT_right, prodT_assoc, prodT_assoc')"
+
+  - description: "The API contains the contraction of a pair of indices of dual color, on pure tensors and on tensors, with its equivariance, its components in the basis, its interaction with permutations and products, and the slot-addressed contraction of one tensor against another in both the result-to-end and result-to-slot conventions."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean (Fin.succSuccAbove, Fin.predPredAbove, Fin.funPredPredAbove); Physlib/Relativity/Tensors/Contraction/Pure.lean (Pure.dropPair, Pure.contrPCoeff, Pure.contrP, Pure.contrPMultilinear); Physlib/Relativity/Tensors/Contraction/Basic.lean (contrT, contrT_pure, contrT_equivariant, contrT_permT, contrT_symm, contrT_comm); Physlib/Relativity/Tensors/Contraction/Basis.lean (contrT_basis_repr_apply, contrT_basis_repr_apply_eq_sum_fin, contrT_basis); Physlib/Relativity/Tensors/Contraction/Products.lean (prodT_contrT_snd, contrT_prodT_snd, prodT_contrT_fst); Physlib/Relativity/Tensors/Contraction/CrossToEnd.lean (crossToEnd, crossToEnd_two, crossToEnd_equivariant, crossToEnd_assoc_rankTwo, crossToEnd_permT_left, crossToEnd_permT_right); Physlib/Relativity/Tensors/Contraction/CrossToSlot.lean (crossToSlot, crossToSlot_eq_crossToEnd, crossToSlotInv, crossToSlot_equivariant)
+
+  - description: "The API contains the unit tensor and the metric tensor of a color, their invariance under the group action, the collapse of a metric contracted against the metric at the dual color, the unit tensor as an identity for slot contraction, and the raising and lowering of a named index as a linear equivalence."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/UnitTensor.lean (unitTensor, unitTensor_eq_permT_dual, contrT_single_unitTensor, unitTensor_invariant); Physlib/Relativity/Tensors/MetricTensor.lean (metricTensor, metricTensor_invariant, contrT_metricTensor_metricTensor, contrT_metricTensor_metricTensor_eq_dual_unit); Physlib/Relativity/Tensors/Contraction/UnitTensorContraction.lean (crossToEnd_unitTensor, crossToEnd_round_trip_of_unit_slot, crossToSlot_raise_lower_round_trip, crossToSlotEquiv); Physlib/Relativity/Tensors/Dual.lean (toDualMapAtIndex, fromDualMapAtIndex, toDualMapAtIndex_toDualMapAtIndex, toDualMapAtIndex_equivariant, toDualAtIndex)
+
+  - description: "The API contains the evaluation of one index of a tensor at a fixed basis label, its components in the basis, its commutation with permutations, contractions and products, and the reconstruction of a tensor as the sum over basis labels of the evaluations of its last index, each tensored with the matching rank-one basis tensor and permuted back into the last slot."
+    done: true
+    location: "Physlib/Relativity/Tensors/Evaluation.lean (Pure.evalPCoeff, Pure.evalP, Pure.evalPMultilinear, evalT, evalT_basis, evalT_permT, contrT_evalT, evalT_prodT_right, eq_sum_evalT, ext_of_evalT)"
+
+  - description: "The API contains explicit constructors of tensors from vectors, from elements of a tensor product of two or three carriers, and from invariant maps, together with tensors specified by integer or rational components in the standard basis."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/Constructors.lean (Pure.fromSingleP, fromSingleT, fromPairT, fromPairTContr, fromSingleTContrFromPairT, fromConstPair, fromTripleT, fromConstTriple); Physlib/Relativity/Tensors/OfInt.lean (TensorInt, TensorInt.toTensor, basis_eq_tensorInt); Physlib/Relativity/Tensors/ComplexTensor/OfRat.lean (ofRat, basis_eq_ofRat, prodT_ofRat_ofRat, contrT_ofRat, permT_ofRat)
+
+  - description: "The API contains an elaborator turning pen-and-paper index expressions into tensor operations, and the class `Tensorial` carrying index notation to any type linearly equivalent to a tensor, with the induced group action, basis and products."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/Elab.lean (tensorExprSyntax, elaborateTensorNode, syntaxFull, TensorExpressionOperator); Physlib/Relativity/Tensors/Tensorial.lean (Tensorial, Tensorial.self, Tensorial.numIndices, Tensorial.mulAction, Tensorial.smulLinearMap, Tensorial.prod, Tensorial.toTensorCLM, Tensorial.actionCLM, Tensorial.basis_toTensor_apply, Tensorial.basis_map_prod)
+
+  - description: "The API contains the conjugation structure on a tensor species (a second involution on colors, the conjugation of a tensor, its involutivity and its commutation with contraction), together with the componentwise criterion used to state reality and the Hermitian condition on a metric slot."
+    done: true
+    location: "Physlib/Relativity/Tensors/Conjugation/Basic.lean (ConjTensorSpecies, conjEquiv, componentReindex, conjT, conjT_basis, conjT_conjT, conjT_contrT, conjT_eq_permT_iff, IsHermitian)"
+
+  - description: "The API contains the tensor species `realLorentzTensor d` of real Lorentz tensors, with colors `up` and `down`, built from the contravariant and covariant modules, their representations of the Lorentz group, their bases, and the contraction, metric and unit maps; the metric tensors of the species are computed in the standard basis, and the pairwise tensor products of the contravariant and covariant modules are identified with square matrices."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/RealTensor/Basic.lean (realLorentzTensor, realLorentzTensor.Color, τ_up_eq_down, τ_down_eq_up, contrPCoeff_basis, contrT_eq_sum_evalT, contrT_toField); Physlib/Relativity/Tensors/RealTensor/Vector/Pre/Modules.lean (ContrMod, CoMod, AddCommGroup (ContrMod d), Module ℝ (ContrMod d), AddCommGroup (CoMod d), Module ℝ (CoMod d), ContrMod.rep, CoMod.rep, ContrMod.stdBasis, CoMod.stdBasis); Physlib/Relativity/Tensors/RealTensor/Vector/Pre/Basic.lean (contrBasis, coBasis, contrIsoCo); Physlib/Relativity/Tensors/RealTensor/Vector/Pre/Contraction.lean (contrCoContract, coContrContract, contrContrContractField); Physlib/Relativity/Tensors/RealTensor/Metrics/Pre.lean (preContrMetric, preCoMetric); Physlib/Relativity/Tensors/RealTensor/Units/Pre.lean (preContrCoUnit, preCoContrUnit); Physlib/Relativity/Tensors/RealTensor/Metrics/Basic.lean (coMetric, contrMetric, actionT_coMetric, actionT_contrMetric, coMetric_repr_apply_eq_minkowskiMatrix, contrMetric_repr_apply_eq_minkowskiMatrix); Physlib/Relativity/Tensors/RealTensor/Matrix/Pre.lean (contrContrToMatrixRe, coCoToMatrixRe, contrCoToMatrixRe, coContrToMatrixRe)
+
+  - description: "The API contains Lorentz vectors and covectors as functions on `Fin 1 ⊕ Fin d`, with their module, norm and inner-product structures, their charted-space structures, their standard bases, their representations of the Lorentz group, their tensorial instances and the invariant contraction between them, together with the coordinate maps and the time and spatial parts of a vector, and the model with corners under which vectors are treated as a manifold."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/RealTensor/Vector/Basic.lean (Lorentz.Vector, AddCommGroup (Vector d), Module ℝ (Vector d), Norm (Vector d), NormedAddCommGroup (Vector d), NormedSpace ℝ (Vector d), InnerProductSpace ℝ (Vector d), ChartedSpace (Vector d) (Vector d), Vector.equivEuclid, Vector.basis, Vector.basis_repr_apply, Vector.coordCLM, Vector.euclidCLE, Vector.timeComponent, Vector.spatialPart, Vector.spatialCLM, Vector.temporalCLM, Vector.asSmoothManifold); Physlib/Relativity/Tensors/RealTensor/Vector/Representation.lean (Vector.rep, Vector.rep_apply_eq_mulVec, Vector.rep_bijective); Physlib/Relativity/Tensors/RealTensor/Vector/Tensorial.lean (Vector.tensorial, Vector.smul_eq_mulVec, Vector.smul_basis, Vector.actionCLM); Physlib/Relativity/Tensors/RealTensor/CoVector/Basic.lean (Lorentz.CoVector, AddCommGroup (CoVector d), Module ℝ (CoVector d), Norm (CoVector d), NormedAddCommGroup (CoVector d), NormedSpace ℝ (CoVector d), InnerProductSpace ℝ (CoVector d), ChartedSpace (CoVector d) (CoVector d), CoVector.equivEuclid, CoVector.basis, CoVector.basis_repr_apply); Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean (CoVector.rep, CoVector.rep_apply_eq_mulVec, CoVector.rep_bijective); Physlib/Relativity/Tensors/RealTensor/CoVector/Tensorial.lean (CoVector.tensorial, CoVector.actionCLM); Physlib/Relativity/Tensors/RealTensor/Representation/Contraction.lean (Vector.contract, CoVector.contract, Vector.contract_rep, CoVector.contract_rep)
+
+  - description: "The API contains the Minkowski product of two Lorentz vectors, with its symmetry, invariance and nondegeneracy, the adjoint of a linear map and the characterization of the maps preserving the product, and the causal structure it determines: causal character and its invariance, the light cones and causal relations, the norm characterizations of timelike and lightlike vectors, and the type of Lorentz velocities."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/RealTensor/Vector/MinkowskiProduct.lean (minkowskiProductMap, minkowskiProduct, minkowskiProduct_symm, minkowskiProduct_invariant, minkowskiProduct_basis_left, minkowskiProduct_eq_zero_forall_iff, adjoint, IsLorentz, isLorentz_iff_toMatrix_mem_lorentzGroup); Physlib/Relativity/Tensors/RealTensor/Vector/Causality/Basic.lean (CausalCharacter, causalCharacter, causalCharacter_invariant, spaceLike_iff_norm_sq_neg, interiorFutureLightCone, interiorPastLightCone, causallyPrecedes, causalDiamond, isFutureDirected); Physlib/Relativity/Tensors/RealTensor/Vector/Causality/TimeLike.lean (timeLike_iff_norm_sq_pos, timelike_time_dominates_space); Physlib/Relativity/Tensors/RealTensor/Vector/Causality/LightLike.lean (lightLike_iff_norm_sq_zero, causallyPrecedes_refl); Physlib/Relativity/Tensors/RealTensor/Velocity/Basic.lean (Velocity, Velocity.timeComponent_pos, Velocity.norm_spatialPart_le_timeComponent, Velocity.isPathConnected)
+
+  - description: "The API contains the rank-four Levi-Civita tensor as a real Lorentz tensor in three spatial dimensions, its components in the standard basis as a Levi-Civita symbol, its antisymmetry under each adjacent transposition of indices, and the epsilon-epsilon contraction identities at the level of the Euclidean Levi-Civita symbol, summed over all four index slots, over the last three, and over the last two."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/LeviCivita/Basic.lean (leviCivita, notation ε4, euclidLeviCivita, leviCivita_basis_repr_apply, leviCivita_basis_repr_eq_leviCivitaSymbol, leviCivita_antisymm, leviCivita_antisymm_mid, leviCivita_antisymm_last); Physlib/Relativity/Tensors/LeviCivita/Contractions.lean (euclidLeviCivita_symbol_contract_zero, euclidLeviCivita_symbol_contract_one, euclidLeviCivita_symbol_contract_two)
+
+  - description: "The API contains the tensor species `complexLorentzTensor` of complex Lorentz tensors, with the left- and right-handed Weyl colors, their duals and the two Lorentz vector colors over SL(2, ℂ), together with the metric and unit tensors of each color in several equivalent forms and the identification of pairwise products of complex Lorentz vectors with matrices."
+    done: true
+    location: |
+      Physlib/Relativity/Tensors/ComplexTensor/Basic.lean (complexLorentzTensor, complexLorentzTensor.Color, repDim, basis, rep, contrPCoeff_basis); Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Modules.lean (ContrℂModule, CoℂModule, ContrℂModule.SL2CRep, CoℂModule.SL2CRep); Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Contraction.lean (contrCoContraction, coContrContraction); Physlib/Relativity/Tensors/ComplexTensor/Metrics/Basic.lean (coMetric, contrMetric, leftMetric, rightMetric, dualLeftMetric, dualRightMetric, coMetric_eq_ofRat, leftMetric_eq_ofRat); Physlib/Relativity/Tensors/ComplexTensor/Units/Basic.lean (coContrUnit, contrCoUnit, dualLeftLeftUnit, leftDualLeftUnit, dualRightRightUnit, rightDualRightUnit); Physlib/Relativity/Tensors/ComplexTensor/Units/Symm.lean (coContrUnit_symm, dualLeftLeftUnit_symm); Physlib/Relativity/Tensors/ComplexTensor/Matrix/Pre.lean (contrContrToMatrix, coCoToMatrix, contrCoToMatrix, coContrToMatrix); Physlib/Relativity/Tensors/ComplexTensor/Lemmas.lean (antiSymm_contr_symm)
+
+  - description: "The API contains a canonical injective semilinear map from real Lorentz tensors to complex Lorentz tensors, equivariant for the complexified Lorentz group and commuting with permutations, products, contractions and evaluations of indices."
+    done: true
+    location: "Physlib/Relativity/Tensors/RealTensor/ToComplex.lean (colorToComplex, ComponentIdx.complexify, toComplex, toComplex_basis, toComplex_pure_basisVector, toComplex_injective, toComplex_equivariant, permT_toComplex, prodT_toComplex, contrT_toComplex, evalT_toComplex)"
+
+  - description: "The API shall extend `realLorentzTensor` and `complexLorentzTensor` to conjugation tensor species, so that reality and Hermiticity conditions can be stated for real and complex Lorentz tensors."
+    done: false
+    location: N/A
+
+  - description: "The API shall define the metrics and units of the real Lorentz species as intertwining maps of the `Vector` and `CoVector` representations, replacing the preliminary constructions and the use of `ContrMod` and `CoMod` in the definition of `realLorentzTensor`."
+    done: false
+    location: N/A
+
+  - description: "The API shall contain the commutation of evaluation with a product in its left factor, the commutation of evaluation with contraction in the order opposite to `contrT_evalT`, and the commutation of two evaluations of a tensor."
+    done: false
+    location: N/A
+
+  - description: "The tensor-level epsilon-epsilon identities for the Levi-Civita tensor: contracting it with itself over all four index pairs gives the field element `-24`, and contracting it with itself over the first three gives `-6` times the unit tensor of color `down`. Stated as `leviCivita_contract_self` and `leviCivita_contract_three`, both carrying the repository's marker for a result that is not yet proved."
+    done: false
+    location: N/A
+
+  - description: "The API shall contain a Euclidean Levi-Civita tensor to carry the epsilon-epsilon contraction identities, which at present are stated for the Euclidean Levi-Civita symbol `euclidLeviCivita` alone."
+    done: false
+    location: N/A
+
+  - description: "The API shall include in the conditions defining `TensorSpecies` a relationship between the metrics and the basis vectors."
+    done: false
+    location: N/A


### PR DESCRIPTION
## Motivation

Related to #1414, the tracking maps for the tensor API in #908 and the Lorentz tensor API in #886. Both issues are still unfilled templates, so the map supplies the requirement list they ask for. An API map records the implemented status and source location of each requirement, so the gap between a planned API and the current library stays visible in-tree.

## Changes

Adds `Physlib/Relativity/Tensors/API-map.yaml`, with 22 requirements, 16 of them done. The completed entries cover `TensorSpecies` and the types `Tensor`, `Pure` and `ComponentIdx`; the group action, index permutation, products, contraction of a dual pair, evaluation, and the unit and metric tensors with raising and lowering; the index-notation elaborator and `Tensorial`; conjugation; and the species `realLorentzTensor` and `complexLorentzTensor` with the semilinear map between them.

Six are recorded as not done: neither Lorentz species is extended to a `ConjTensorSpecies`, so reality and Hermiticity cannot yet be stated for them; the metrics and units of the real species are still built from `ContrMod` and `CoMod` rather than as intertwiners of `Vector` and `CoVector`; three commutation lemmas for `evalT` are absent; there is a Euclidean Levi-Civita symbol but no Euclidean tensor; `TensorSpecies` carries no condition relating the metrics to the basis vectors; and the tensor-level epsilon-epsilon identities `leviCivita_contract_self` and `leviCivita_contract_three` are stated but carry `sorry`, so they are recorded the way `solidSphere_inertiaTensor` is in the rigid body map. The componentwise identities `euclidLeviCivita_symbol_contract_zero`, `_one` and `_two` are proved and stay under the done entry. Nothing outside the new file changes, and no Lean source is touched.

## Checks

`python3 scripts/api_map_linter.py --repo .` passes with no missing files and no missing names, resolving 289 declarations against the Lean sources.
