### PR TITLE
docs(SU5): name ChargeSpectrum in docstrings left stale by the rename

### DIFF
--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/AllowsTerm.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/AllowsTerm.lean
@@ -96,7 +96,8 @@ potential term via symmetry.
 
 -/
 
-/-- The charges of representations `x : Charges` allow a potential term `T : PotentialTerm`
+/-- The charge spectrum of representations `x : ChargeSpectrum 𝓩` allows a potential term
+`T : PotentialTerm`
 if the zero charge is in the set of charges associated with that potential term. -/
 def AllowsTerm (x : ChargeSpectrum 𝓩) (T : PotentialTerm) : Prop := 0 ∈ ofPotentialTerm x T
 

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/Basic.lean
@@ -291,8 +291,8 @@ lemma _root_.Option.mem_powerset_iff {x : Option 𝓩} (y : Option 𝓩) :
     y ∈ x.powerset ↔ y.toFinset ⊆ x.toFinset := by
   cases x <;> cases y <;> simp [Option.powerset]
 
-/-- The powerset of a charge . Given a charge `x : Charges`
-  it's powerset is the finite set of all `Charges` which are subsets of `x`. -/
+/-- The powerset of a charge spectrum. Given a charge spectrum `x : ChargeSpectrum 𝓩`
+  its powerset is the finite set of all `ChargeSpectrum 𝓩` which are subsets of `x`. -/
 def powerset (x : ChargeSpectrum 𝓩) : Finset (ChargeSpectrum 𝓩) :=
   (x.qHd.powerset.product <| x.qHu.powerset.product <| x.Q5.powerset.product <|
     x.Q10.powerset).map toProd.symm.toEmbedding

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/Map.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/Map.lean
@@ -85,9 +85,9 @@ variable {𝓩 𝓩1 𝓩2 : Type} [AddCommGroup 𝓩] [AddCommGroup 𝓩1] [Dec
 
 -/
 
-/-- Given an additive monoid homomorphisms `f : 𝓩 →+ 𝓩1`, for a charge
-  `x : Charges 𝓩`, `x.map f` is the charge of `Charges 𝓩1` obtained by mapping the elements
-  of `x` by `f`. -/
+/-- Given an additive monoid homomorphisms `f : 𝓩 →+ 𝓩1`, for a charge spectrum
+  `x : ChargeSpectrum 𝓩`, `x.map f` is the charge spectrum in `ChargeSpectrum 𝓩1` obtained by
+  mapping the elements of `x` by `f`. -/
 def map (f : 𝓩 →+ 𝓩1) (x : ChargeSpectrum 𝓩) : ChargeSpectrum 𝓩1 where
   qHd := f <$> x.qHd
   qHu := f <$> x.qHu

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/MinimallyAllowsTerm/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/MinimallyAllowsTerm/Basic.lean
@@ -73,7 +73,7 @@ it allows the term.
 We prove properties of charge spectra which minimally allow potential terms.
 
 -/
-/-- A collection of charges `x : Charges` is said to minimally allow
+/-- A charge spectrum `x : ChargeSpectrum 𝓩` is said to minimally allow
   the potential term `T` if it allows `T` and no strict subset of it allows `T`. -/
 def MinimallyAllowsTerm (x : ChargeSpectrum 𝓩) (T : PotentialTerm) : Prop :=
   ∀ y ∈ x.powerset, y = x ↔ y.AllowsTerm T

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/OfFieldLabel.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/OfFieldLabel.lean
@@ -61,7 +61,7 @@ a `FieldLabel`, returns the finite set of charges associated with representation
 corresponding to that `FieldLabel`.
 
 -/
-/-- Given an `x : Charges`, the charges associated with a given `FieldLabel`. -/
+/-- Given an `x : ChargeSpectrum 𝓩`, the charges associated with a given `FieldLabel`. -/
 def ofFieldLabel (x : ChargeSpectrum 𝓩) : FieldLabel → Finset 𝓩
   | .fiveBarHd => x.qHd.toFinset
   | .fiveBarHu => x.qHu.toFinset

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/OfPotentialTerm.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/OfPotentialTerm.lean
@@ -70,8 +70,8 @@ This is slow to compute in practice.
 
 -/
 
-/-- Given a charges `x : Charges` associated to the representations, and a potential
-  term `T`, the charges associated with instances of that potential term. -/
+/-- Given a charge spectrum `x : ChargeSpectrum 𝓩` associated to the representations, and a
+  potential term `T`, the charges associated with instances of that potential term. -/
 def ofPotentialTerm (x : ChargeSpectrum 𝓩) (T : PotentialTerm) : Multiset 𝓩 :=
   let add : Multiset 𝓩 → Multiset 𝓩 → Multiset 𝓩 := fun a b => (a ×ˢ b).map
       fun (x, y) => x + y

--- a/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/Yukawa.lean
+++ b/Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/Yukawa.lean
@@ -142,7 +142,7 @@ lemma ofYukawaTermsNSum_subset_of_subset [DecidableEq 𝓩] {x y : ChargeSpectru
 
 variable [DecidableEq 𝓩]
 
-/-- For charges `x : Charges`, the proposition which states that the singlets
+/-- For a charge spectrum `x : ChargeSpectrum 𝓩`, the proposition which states that the singlets
   needed to regenerate the Yukawa couplings regenerate a dangerous coupling
   (in the superpotential) with up-to `n` insertions of the scalars.
 


### PR DESCRIPTION
Closes #1494.

`ChargeSpectrum` was called `Charges` until a54f8f0c (#742). Seven docstrings under `Physlib/Particles/SuperSymmetry/SU5/ChargeSpectrum/` still name the old type, including the one in #1494. All seven take `x : ChargeSpectrum 𝓩`.

| file | declaration |
| --- | --- |
| `Basic.lean` | `powerset` |
| `AllowsTerm.lean` | `AllowsTerm` |
| `Map.lean` | `map` |
| `MinimallyAllowsTerm/Basic.lean` | `MinimallyAllowsTerm` |
| `OfFieldLabel.lean` | `ofFieldLabel` |
| `OfPotentialTerm.lean` | `ofPotentialTerm` |
| `Yukawa.lean` | `YukawaGeneratesDangerousAtLevel` |

Where the surrounding prose called the argument a charge rather than a charge spectrum, I fixed that too, since it is the same rename. `Basic.lean` also had `it's` for `its`. Remaining uses of "Charges" in that directory are ordinary English in section headings and are untouched.

Docstrings only, no declarations added or removed