### PR TITLE
docs(Relativity): correct the CoVector rep docstring to say covectors

### DIFF
--- a/Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean
@@ -30,7 +30,7 @@ namespace Lorentz
 namespace CoVector
 attribute [-simp] Fintype.sum_sum_type
 
-/-- The representation of the Lorentz group on Lorentz vectors. -/
+/-- The representation of the Lorentz group on Lorentz covectors. -/
 def rep {d : ℕ} : Representation ℝ (LorentzGroup d) (CoVector d) where
   toFun Λ := Matrix.toLinAlgEquiv basis (LorentzGroup.transpose Λ⁻¹)
   map_one' := by


### PR DESCRIPTION
Closes #1495.

The docstring on `Lorentz.CoVector.rep` says the representation acts on Lorentz vectors. It acts on `CoVector d`. The same line sits above `Lorentz.Vector.rep` in `Physlib/Relativity/Tensors/RealTensor/Vector/Representation.lean`, where it is correct, so this looks like a copy where the type changed and the docstring did not.

Docstring only, no declarations added or removed