### PR TITLE
docs(standardmodel): add Standard Model gauge group API map

### DIFF
--- a/Physlib/Particles/StandardModel/API-map.yaml
+++ b/Physlib/Particles/StandardModel/API-map.yaml
@@ -1,0 +1,113 @@
+version: v0.1
+
+Title: Standard Model gauge group
+
+Overview: |
+  The key data structures are `GaugeGroupI`, the full gauge group
+  SU(3) x SU(2) x U(1), and `GaugeGroup q` for `q : GaugeGroupQuot`, the gauge
+  group corresponding to a choice of quotient by a finite central subgroup
+  (ℤ₆, ℤ₂, ℤ₃, or none). The API provides the projections onto the three
+  factors, the star structure, the embeddings of the roots of unity as central
+  subgroups, the quotient groups with their common quotient map, and the kernel
+  characterisation of that map. The representation file provides the U(1) and
+  fundamental SU(2) actions on the two-dimensional space used by the Higgs
+  sector. The Higgs Field API
+  (Physlib/Particles/StandardModel/HiggsBoson) builds on this group.
+
+ParentAPIs: []
+
+References:
+  - "D. Tong, Line Operators in the Standard Model, JHEP 07 (2017) 104. https://arxiv.org/abs/1705.01853"
+
+Requirements:
+
+  - description: >
+      The full gauge group `GaugeGroupI` is defined, with its projections onto
+      the SU(3), SU(2) and U(1) factors and extensionality in them.
+    done: true
+    location: Physlib/Particles/StandardModel/Basic.lean (GaugeGroupI, toSU3, toSU2, toU1, ext)
+
+  - description: >
+      The star operation on the gauge group is defined and commutes with the
+      three projections.
+    done: true
+    location: Physlib/Particles/StandardModel/Basic.lean (star_eq, star_toSU3, star_toSU2, star_toU1)
+
+  - description: >
+      The embedding of a unitary scalar as a gauge-group element acting on all
+      three factors is defined, with its projections identified.
+    done: true
+    location: Physlib/Particles/StandardModel/Basic.lean (ofU1Subgroup, ofU1Subgroup_toSU3, ofU1Subgroup_toSU2, ofU1Subgroup_toU1)
+
+  - description: >
+      The sixth roots of unity embed as a central subgroup, constructed on each
+      factor, with membership characterised and normality recorded.
+    done: true
+    location: Physlib/Particles/StandardModel/Basic.lean (gaugeGroupℤ₆UnitaryOfRoot, gaugeGroupℤ₆SU3OfRoot, gaugeGroupℤ₆SU2OfRoot, gaugeGroupℤ₆OfRoot, gaugeGroupℤ₆OfRoot_mem_center, gaugeGroupℤ₆Hom, gaugeGroupℤ₆SubGroup, mem_gaugeGroupℤ₆SubGroup_iff, gaugeGroupℤ₆SubGroup_le_center, gaugeGroupℤ₆SubGroup_normal)
+
+  - description: >
+      The quotient of the gauge group by the ℤ₆ subgroup is defined as a group
+      with its projection.
+    done: true
+    location: Physlib/Particles/StandardModel/Basic.lean (GaugeGroupℤ₆, mk, mk_gaugeGroupℤ₆OfRoot)
+
+  - description: >
+      The ℤ₂ central subgroup and its quotient are defined, with the inclusion
+      into the ℤ₆ subgroup.
+    done: true
+    location: Physlib/Particles/StandardModel/Basic.lean (gaugeGroupℤ₂RootToℤ₆Root, gaugeGroupℤ₂OfRoot, gaugeGroupℤ₂OfRoot_mem_center, gaugeGroupℤ₂Hom, gaugeGroupℤ₂SubGroup, mem_gaugeGroupℤ₂SubGroup_iff, gaugeGroupℤ₂SubGroup_le_gaugeGroupℤ₆SubGroup, gaugeGroupℤ₂SubGroup_le_center, gaugeGroupℤ₂SubGroup_normal, GaugeGroupℤ₂)
+
+  - description: >
+      The ℤ₃ central subgroup and its quotient are defined, with the inclusion
+      into the ℤ₆ subgroup.
+    done: true
+    location: Physlib/Particles/StandardModel/Basic.lean (gaugeGroupℤ₃RootToℤ₆Root, gaugeGroupℤ₃OfRoot, gaugeGroupℤ₃OfRoot_mem_center, gaugeGroupℤ₃Hom, gaugeGroupℤ₃SubGroup, mem_gaugeGroupℤ₃SubGroup_iff, gaugeGroupℤ₃SubGroup_le_gaugeGroupℤ₆SubGroup, gaugeGroupℤ₃SubGroup_le_center, GaugeGroupℤ₃)
+
+  - description: >
+      The key data structure takes a specification of the quotient: the type of
+      quotient choices is defined, and the gauge group, its central subgroup,
+      normality, and inclusion into the ℤ₆ subgroup are given uniformly in the
+      choice.
+    done: true
+    location: Physlib/Particles/StandardModel/Basic.lean (GaugeGroupQuot, GaugeGroup, subgroup, subgroup_le_center, subgroup_normal, subgroup_le_subgroup_ℤ₆)
+
+  - description: >
+      The quotient map from the full gauge group is defined uniformly in the
+      quotient choice, computed on each central embedding, with its kernel
+      characterised.
+    done: true
+    location: Physlib/Particles/StandardModel/Basic.lean (quotientMap, quotientMap_I_apply, quotientMap_ℤ₆_gaugeGroupℤ₆OfRoot, quotientMap_ℤ₂_gaugeGroupℤ₂OfRoot, quotientMap_ℤ₃_gaugeGroupℤ₃OfRoot, mem_subgroup_iff_quotientMap_eq_one, quotientMap_eq_iff)
+
+  - description: >
+      The U(1) representation and the fundamental SU(2) action on the
+      two-dimensional complex space of the Higgs sector are defined and commute.
+    done: true
+    location: Physlib/Particles/StandardModel/Representations.lean (repU1Map, repU1, fundamentalSU2, repU1_fundamentalSU2_commute)
+
+  - description: >
+      The gauge groups carry a Lie group (smooth manifold) structure.
+    done: false
+    location: Physlib/Particles/StandardModel/Basic.lean (gaugeGroupI_lie, gaugeGroup_lie); both are informal lemmas awaiting formalisation.
+
+  - description: >
+      The center of the full gauge group is characterised exactly; at present
+      the central subgroups are only shown to lie in the center.
+    done: false
+    location: N/A
+
+  - description: >
+      The gauge bundle and gauge transformations over spacetime are defined.
+    done: false
+    location: Physlib/Particles/StandardModel/Basic.lean (gaugeBundleI, gaugeTransformI); both are informal definitions awaiting formalisation.
+
+  - description: >
+      The unbroken gauge group after electroweak symmetry breaking is defined
+      using the Higgs field.
+    done: false
+    location: N/A
+
+  - description: >
+      A structure capturing the fermionic content of the Standard Model and its
+      representations is defined.
+    done: false
+    location: N/A


### PR DESCRIPTION
## Motivation

Related to #1414 and the tracking issue #858, which asks for a gauge group parameterised by a choice of finite quotient. That structure now exists in the tree (`GaugeGroupQuot` and `GaugeGroup`, from the gauge-group quotient API), so the map records the requirement list against it. The Higgs Field map lists the Standard Model gauge group (`Physlib/Particles/StandardModel`) as a parent API, so this also fills a referenced node.

## Changes

Adds `Physlib/Particles/StandardModel/API-map.yaml`, with 15 requirements, 10 of them done. The completed entries cover `GaugeGroupI` with its factor projections and star structure; the embeddings of the sixth, second and third roots of unity as central subgroups with membership, centrality and normality; the three quotient groups; the quotient-choice type `GaugeGroupQuot` with `GaugeGroup`, `subgroup` and `quotientMap` given uniformly in the choice, including the kernel characterisation of the quotient map; and the U(1) and fundamental SU(2) representations on the two-dimensional space of the Higgs sector.

Five are recorded as not done: the Lie group structure and the gauge bundle with gauge transformations exist only as informal declarations, and the map cites them as such; the center of the full group is bounded below by the central subgroups but not characterised exactly; and the unbroken gauge group from the Higgs field and the fermionic-content structure are both open tasks already marked in the source. Nothing outside the new file changes, and no Lean source is touched.

## Checks

`python3 scripts/api_map_linter.py --repo .` passes with no missing files and no missing names, resolving 62 declarations in the new map against the Lean sources.
