### PR TITLE
feat(QuantumMechanics/Hydrogen): prove angularMomentum_commutation_lrl

### DIFF
--- a/Physlib/QuantumMechanics/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/Hydrogen/LaplaceRungeLenzVector.lean
@@ -95,7 +95,7 @@ lemma lrlOperator_eq'' (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i =
 
 /-- A supporting piece of `angularMomentum_commutation_lrl`: how `𝐋ᵢⱼ` commutes with the
 dot-product term `𝐋ₖ⬝ᵥ𝐩` appearing in `H.lrlOperator`'s expanded form (`lrlOperator_eq'`). -/
-private lemma angularMomentum_commutation_Ldot_p (i j k : Fin H.d) :
+lemma angularMomentum_commutation_Ldot_p (i j k : Fin H.d) :
     ⁅𝐋[H.d] i j, 𝐋 k ⬝ᵥ 𝐩⁆ =
       (I * ℏ) • (δ[i,k] • (𝐋 j ⬝ᵥ 𝐩) - δ[j,k] • (𝐋 i ⬝ᵥ 𝐩)) := by
   simp only [dotProduct, mul_def, lie_sum, lie_leibniz,

--- a/Physlib/QuantumMechanics/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/Hydrogen/LaplaceRungeLenzVector.lean
@@ -7,7 +7,6 @@ module
 
 public import Physlib.QuantumMechanics.Hydrogen.Basic
 public import Physlib.QuantumMechanics.Operators.Commutation
-public import Physlib.Meta.Linters.Sorry
 /-!
 
 # Laplace-Runge-Lenz vector
@@ -94,14 +93,32 @@ lemma lrlOperator_eq'' (ε : ℝˣ) (i : Fin H.d) : H.lrlOperator ε i =
 ## Angular momentum / LRL vector commutators
 -/
 
+/-- A supporting piece of `angularMomentum_commutation_lrl`: how `𝐋ᵢⱼ` commutes with the
+dot-product term `𝐋ₖ⬝ᵥ𝐩` appearing in `H.lrlOperator`'s expanded form (`lrlOperator_eq'`). -/
+private lemma angularMomentum_commutation_Ldot_p (i j k : Fin H.d) :
+    ⁅𝐋[H.d] i j, 𝐋 k ⬝ᵥ 𝐩⁆ =
+      (I * ℏ) • (δ[i,k] • (𝐋 j ⬝ᵥ 𝐩) - δ[j,k] • (𝐋 i ⬝ᵥ 𝐩)) := by
+  simp only [dotProduct, mul_def, lie_sum, lie_leibniz,
+    angularMomentum_commutation_angularMomentum, angularMomentum_commutation_momentum,
+    comp_smul, smul_comp, comp_sub, sub_comp, add_comp]
+  simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib, ← Finset.smul_sum,
+    KroneckerDelta.sum_smul]
+  rw [angularMomentumOperator_antisymm k i, angularMomentumOperator_antisymm k j]
+  simp only [neg_comp]
+  module
+
 /-- `⁅𝐋ᵢⱼ, 𝐀(ε)ₖ⁆ = iℏ(δᵢₖ𝐀(ε)ⱼ - δⱼₖ𝐀(ε)ᵢ)` -/
-@[sorryful]
 lemma angularMomentum_commutation_lrl (ε : ℝˣ) (i j k : Fin H.d) : ⁅𝐋 i j, H.lrlOperator ε k⁆ =
     (I * ℏ) • (δ[i,k] • H.lrlOperator ε j - δ[j,k] • H.lrlOperator ε i) := by
-  sorry
+  simp_rw [H.lrlOperator_eq']
+  rw [lie_sub, lie_add, angularMomentum_commutation_Ldot_p H i j k, lie_smul,
+    angularMomentum_commutation_momentum, lie_smul, lie_leibniz,
+    angularMomentum_commutation_radiusRegPow, angularMomentum_commutation_position]
+  simp only [zero_comp, comp_sub, comp_smul, smul_sub]
+  module
 
 /-- `⁅𝐋ᵢⱼ, 𝐀(ε)²⁆ = 0` -/
-@[sorryful, simp]
+@[simp]
 lemma angularMomentum_commutation_lrlSqr (ε : ℝˣ) (i j : Fin H.d) :
     ⁅𝐋 i j, H.lrlOperator ε ⬝ᵥ H.lrlOperator ε⁆ = 0 := by
   simp only [dotProduct, mul_def, lie_sum, lie_leibniz, H.angularMomentum_commutation_lrl,
@@ -109,7 +126,7 @@ lemma angularMomentum_commutation_lrlSqr (ε : ℝˣ) (i j : Fin H.d) :
     Finset.sum_sub_distrib, sum_smul, sub_add_sub_cancel, sub_self, smul_zero]
 
 /-- `⁅𝐋², 𝐀(ε)²⁆ = 0` -/
-@[sorryful, simp]
+@[simp]
 lemma angularMomentumSqr_commutation_lrlSqr (ε : ℝˣ) :
     ⁅𝐋²[H.d], H.lrlOperator ε ⬝ᵥ H.lrlOperator ε⁆ = 0 := by
   simp [angularMomentumOperatorSqr, sum_lie, leibniz_lie]


### PR DESCRIPTION
Closes the \`@[sorryful]\` gap on \`HydrogenAtom.angularMomentum_commutation_lrl\`
(\`⁅𝐋ᵢⱼ, 𝐀(ε)ₖ⁆ = iℏ(δᵢₖ𝐀(ε)ⱼ - δⱼₖ𝐀(ε)ᵢ)\`, the regularized Laplace–Runge–Lenz vector
transforming as a vector under rotations), using only already-proved companion
commutators from `Operators/Commutation.lean` (`angularMomentum_commutation_angularMomentum`,
`_momentum`, `_radiusRegPow`, `_position`) and `lrlOperator_eq'`'s expanded form of `𝐀(ε)ᵢ`.

Adds one private helper, `angularMomentum_commutation_Ldot_p`, for how `𝐋ᵢⱼ` commutes
with the `𝐋ₖ⬝ᵥ𝐩` term in that expansion.

`angularMomentum_commutation_lrlSqr` and `angularMomentumSqr_commutation_lrlSqr` were
already fully proved modulo this one dependency, so their `@[sorryful]` tags come off
too — `#print axioms` on all three now shows only `propext`/`Classical.choice`/
`Quot.sound`, matching `sorryfulPseudoTest`'s "tagged sorryful iff it actually contains
sorryAx" invariant. Whole-library `lake build Physlib` is clean.

One file changed, 27 lines.

---

Related: #991 attempted the same fix, but predates the package's rename/reorg (it's
against the old `PhysLean/QuantumMechanics/DDimensions/...` path, before the current
flat `Physlib/QuantumMechanics/...` layout) and hasn't had activity since April, so it
no longer applies against current `master`. If this one looks good to you, might be
worth closing #991 in favor of it — entirely your call, just flagging the overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)