### PR TITLE
docs(units): add units and dimensions API map

### DIFF
--- a/Physlib/Units/API-map.yaml
+++ b/Physlib/Units/API-map.yaml
@@ -5,12 +5,14 @@ Title: Units
 Overview: |
     Every physical quantity has a dimension: a rational power of each base dimension,
     recording how the numerical value of the quantity changes when the unit of each base
-    quantity is changed. The default set of base dimensions is length, time, mass, charge
-    and temperature, written L𝓭, T𝓭, M𝓭, C𝓭 and Θ𝓭. Dimensions multiply by adding
+    quantity is changed. The LTMCT set has five base dimensions: length, time, mass,
+    charge and temperature, written L𝓭, T𝓭, M𝓭, C𝓭 and Θ𝓭. Dimensions multiply by adding
     exponents and invert by negating them, so they form a commutative group with a
-    rational power operation. The International System of Quantities takes seven base
-    quantities instead, in which electric charge is derived as current times time; both
-    sets are available and are related by a faithful inclusion and a reduction.
+    rational power operation. The International System of Quantities uses a different set
+    of seven base quantities, in which electric charge is derived as current times time;
+    both sets are available and are related by a faithful inclusion and a reduction.
+    LTMCT is the set over which the typed unit layer (LTMCTUnitChoices and its SI choice)
+    and the named derived quantities are built; the ISQ set carries SIUnitChoices.
 
     A unit system fixes one concrete unit for each base quantity. Changing from one system
     to another multiplies a quantity of dimension d by a positive factor: the product,
@@ -18,8 +20,8 @@ Overview: |
     assigns to that base quantity. That factor is multiplicative in the dimension, equals
     one when the two systems agree, and composes along a chain, so the value of a quantity
     in one system determines its value in every other. The statement is proved once for a
-    general set of base dimensions and specialises to the default five and to the seven
-    ISQ base quantities without being restated.
+    general set of base dimensions and specialises to the LTMCT set and to the ISQ set
+    without being restated.
 
     A value carrying a dimension inherits the additive, order and scalar structure of its
     underlying type, while products and quotients add and subtract the exponents. Area,
@@ -66,7 +68,7 @@ Requirements:
     done: true
     location: "Physlib/Units/Dimension.lean (Dimension.extend, Dimension.extend_exponent_apply, Dimension.extendHom, Dimension.Embedding, Dimension.Projection, Dimension.Embedding.ofBasis)"
 
-  - description: "The default set of five base dimensions is defined with the exponent projection of each."
+  - description: "The LTMCT set of five base dimensions is defined with the exponent projection of each."
     done: true
     location: "Physlib/Units/LTMCTDimensionBase.lean (LTMCTDimensionBase, Dimension.length, Dimension.time, Dimension.mass, Dimension.charge, Dimension.temperature)"
 
@@ -94,7 +96,7 @@ Requirements:
     done: true
     location: "Physlib/Units/ISQDimensionBase.lean (ISQDimensionBase.single_amount_ne_one, ISQDimensionBase.single_luminousIntensity_ne_one)"
 
-  - description: "A faithful embedding carries the default five base dimensions into the ISQ set, sending the charge generator to the derived ISQ charge."
+  - description: "A faithful embedding carries the LTMCT base dimensions into the ISQ set, sending the charge generator to the derived ISQ charge."
     done: true
     location: "Physlib/Units/ISQBridge.lean (Dimension.toISQFun, Dimension.toISQHom, Dimension.toISQHom_apply, Dimension.toISQHom_injective, Dimension.ltmctToISQ, Dimension.toISQHom_C𝓭)"
 
@@ -106,7 +108,7 @@ Requirements:
     done: true
     location: "Physlib/Units/ISQBridge.lean (Dimension.fromISQHom_comp_toISQHom, Dimension.isqToLTMCT_comp_ltmctToISQ)"
 
-  - description: "A unit choice fixes one unit for each of the five default base quantities, with the SI choice of metre, second, kilogram, coulomb and kelvin."
+  - description: "A unit choice fixes one unit for each of the five LTMCT base quantities, with the SI choice of metre, second, kilogram, coulomb and kelvin."
     done: true
     location: "Physlib/Units/Basic.lean (LTMCTUnitChoices, LTMCTUnitChoices.SI, LTMCTUnitChoices.SI_length, LTMCTUnitChoices.SI_time, LTMCTUnitChoices.SI_mass, LTMCTUnitChoices.SI_charge, LTMCTUnitChoices.SI_temperature)"
 
@@ -162,7 +164,7 @@ Requirements:
     done: true
     location: "Physlib/Units/UnitSystem.lean (UnitSystem.toScale, UnitSystem.toScale_scale)"
 
-  - description: "The bespoke five-field unit choice is equivalent to a unit system over the default base dimensions, and its hand-written scaling law is the generic product specialised to that set."
+  - description: "The bespoke five-field unit choice is equivalent to a unit system over the LTMCT base dimensions, and its hand-written scaling law is the generic product specialised to that set."
     done: true
     location: "Physlib/Units/ParametricUnits.lean (LTMCTUnitChoices.toScale); Physlib/Units/UnitSystem.lean (LTMCTUnitChoices.equivUnitSystem, LTMCTUnitChoices.toScale_equivUnitSystem, prod_univ_LTMCTDimensionBase, LTMCTUnitChoices.dimScale_eq_toScale_dimScale)"
 
@@ -182,7 +184,7 @@ Requirements:
     done: true
     location: "Physlib/Units/SIUnitChoices.lean (prod_univ_ISQDimensionBase, SIUnitChoices.dimScale, SIUnitChoices.dimScale_self)"
 
-  - description: "The SI unit choice over the default five base quantities shall be computable, which a note in the source records as requiring the axioms that define the base units to be replaced."
+  - description: "The SI unit choice over the five LTMCT base quantities shall be computable, which a note in the source records as requiring the axioms that define the base units to be replaced."
     done: false
     location: "N/A"
 
@@ -238,7 +240,7 @@ Requirements:
     done: true
     location: "Physlib/Units/WithDim/Basic.lean (WithDim.withDim_hMul_val, WithDim.val_mul_eq_mul, WithDim.val_pow_two_eq_mul, WithDim.val_div_val, WithDim.div_scaleUnit)"
 
-  - description: "Over the default base dimensions the tagged type carries its dimension and its transformation under a change of unit is scalar multiplication by the scaling factor."
+  - description: "Over the LTMCT base dimensions the tagged type carries its dimension and its transformation under a change of unit is scalar multiplication by the scaling factor."
     done: true
     location: "Physlib/Units/WithDim/Basic.lean (WithDim.scaleUnit_val, WithDim.scaleUnit_val_eq_scaleUnit_val, WithDim.scaleUnit_val_eq_scaleUnit_val_of_dim_eq)"
 

--- a/Physlib/Units/API-map.yaml
+++ b/Physlib/Units/API-map.yaml
@@ -6,10 +6,11 @@ Overview: |
     Every physical quantity has a dimension: a rational power of each base dimension,
     recording how the numerical value of the quantity changes when the unit of each base
     quantity is changed. The LTMCT set has five base dimensions: length, time, mass,
-    charge and temperature, written L𝓭, T𝓭, M𝓭, C𝓭 and Θ𝓭. Dimensions multiply by adding
-    exponents and invert by negating them, so they form a commutative group with a
-    rational power operation. The International System of Quantities uses a different set
-    of seven base quantities, in which electric charge is derived as current times time;
+    charge and temperature, whose initials give the name; they are written L𝓭, T𝓭,
+    M𝓭, C𝓭 and Θ𝓭. Dimensions multiply by adding exponents and invert by negating
+    them, so they form a commutative group with a rational power operation. The
+    International System of Quantities (ISQ) uses a different set of seven base
+    quantities, in which electric charge is derived as current times time;
     both sets are available and are related by a faithful inclusion and a reduction.
     LTMCT is the set over which the typed unit layer (LTMCTUnitChoices and its SI choice)
     and the named derived quantities are built; the ISQ set carries SIUnitChoices.

--- a/Physlib/Units/API-map.yaml
+++ b/Physlib/Units/API-map.yaml
@@ -3,48 +3,32 @@ version: v0.1
 Title: Units
 
 Overview: |
-    Every physical quantity has a dimension: a rational power of each base
-    dimension, recording how the numerical value of the quantity changes when the
-    unit of each base quantity is changed. The default set of base dimensions used
-    here is length, time, mass, charge and temperature, written L𝓭, T𝓭, M𝓭, C𝓭 and
-    Θ𝓭. Dimensions multiply by adding exponents and invert by negating them, so they
-    form a commutative group with a rational power operation. The International
-    System of Quantities takes a different set of seven base quantities, length,
-    mass, time, electric current, thermodynamic temperature, amount of substance and
-    luminous intensity, in which electric charge is derived as current times time.
-    Both sets are available, and the two are related by a faithful inclusion of the
-    default set into the ISQ set and a reduction in the other direction that forgets
-    amount of substance and luminous intensity.
+    Every physical quantity has a dimension: a rational power of each base dimension,
+    recording how the numerical value of the quantity changes when the unit of each base
+    quantity is changed. The default set of base dimensions is length, time, mass, charge
+    and temperature, written L𝓭, T𝓭, M𝓭, C𝓭 and Θ𝓭. Dimensions multiply by adding
+    exponents and invert by negating them, so they form a commutative group with a
+    rational power operation. The International System of Quantities takes seven base
+    quantities instead, in which electric charge is derived as current times time; both
+    sets are available and are related by a faithful inclusion and a reduction.
 
-    A unit system fixes one concrete unit for each base quantity. The SI fixes the
-    metre, second, kilogram, ampere, kelvin, mole and candela; the default
-    charge-based system fixes the metre, second, kilogram, coulomb and kelvin.
-    Changing from one unit system to another multiplies a quantity of dimension d by
-    a positive factor: the product, over the base quantities, of the ratio of the two
-    units raised to the exponent that d assigns to that base quantity. That factor is
-    multiplicative in the dimension, equals one when the two systems agree, and
-    composes along a chain of three systems, so the value of a quantity in one system
-    determines its value in every other. The same statement is proved once for a
-    general set of base dimensions and specialises to the default five and to the
-    seven ISQ base quantities without being restated.
+    A unit system fixes one concrete unit for each base quantity. Changing from one system
+    to another multiplies a quantity of dimension d by a positive factor: the product,
+    over the base quantities, of the ratio of the two units raised to the exponent that d
+    assigns to that base quantity. That factor is multiplicative in the dimension, equals
+    one when the two systems agree, and composes along a chain, so the value of a quantity
+    in one system determines its value in every other. The statement is proved once for a
+    general set of base dimensions and specialises to the default five and to the seven
+    ISQ base quantities without being restated.
 
-    A value carrying a dimension inherits the additive, order and scalar structure of
-    its underlying type, while products and quotients add and subtract the exponents.
-    Area, speed, energy, pressure and momentum appear as named dimensions with
-    concrete units: the square metre, square foot, square mile, are, hectare and
-    acre; the metre
-    per second, mile per hour, kilometre per hour, knot and the speed of light; the
-    joule, electronvolt, calorie and kilowatt hour; the pascal, millimetre of
-    mercury, bar, standard atmosphere, torr and pound per square inch; and the
-    three-momentum of a particle in d spatial dimensions. Mass and velocity are named
-    in the source but carry no declarations yet.
-
-    A statement is dimensionally correct when its truth does not depend on the unit
-    system in which it is written, and this is the formal content of dimensional
-    analysis. The API expresses that condition for values, for functions and for
-    propositions, and proves that the derivative and the integral of a dimensionally
-    correct quantity are again dimensionally correct. Worked examples check E = m c^2
-    and F = m a against it, and exhibit E = m c as a statement that fails it.
+    A value carrying a dimension inherits the additive, order and scalar structure of its
+    underlying type, while products and quotients add and subtract the exponents. Area,
+    speed, energy, pressure and momentum appear as named dimensions with concrete units.
+    A statement is dimensionally correct when its truth does not depend on the unit system
+    in which it is written, which is the formal content of dimensional analysis; the API
+    expresses that condition for values, functions and propositions, and proves that the
+    derivative and the integral of a dimensionally correct quantity are again
+    dimensionally correct.
 
 ParentAPIs:
   - "Time (Physlib/SpaceAndTime/Time)"
@@ -62,213 +46,270 @@ References:
 
 Requirements:
 
-  - description: >
-      The API contains the dimensional algebra over an arbitrary set of base
-      dimensions. A dimension assigns a rational exponent to each base dimension;
-      dimensions multiply by adding exponents, invert by negating them, and form a
-      commutative group with a rational power operation and, over a finite set of
-      base dimensions, decidable equality. The base vector at each base dimension is
-      defined. A change of base-dimension set is recorded as a monoid homomorphism of
-      dimensions, either an injective embedding of one set into another or a
-      surjective reduction of a richer set onto a coarser one, so that a relabelling
-      which does not preserve products, inverses and rational powers is not
-      expressible.
+  - description: "A dimension assigns a rational exponent to each base dimension, with extensionality."
     done: true
-    location: "Physlib/Units/Dimension.lean (Dimension, Dimension.ext, Dimension.mul_exponent, Dimension.one_exponent, Dimension.inv_exponent, Dimension.div_exponent, Dimension.npow_exponent, Dimension.qpow_exponent, Dimension.single, Dimension.single_exponent, Dimension.extend, Dimension.extend_exponent_apply, Dimension.extendHom, Dimension.Embedding, Dimension.Projection, Dimension.Embedding.ofBasis, CommGroup (Dimension B))"
+    location: "Physlib/Units/Dimension.lean (Dimension, Dimension.ext)"
 
-  - description: >
-      The API contains the default set of five base dimensions, length, time, mass,
-      charge and temperature, with the exponent projection of each, the constructor
-      of a dimension from its five exponents, the computation of each exponent under
-      products, inverses, quotients and natural powers, and the named generators L𝓭,
-      T𝓭, M𝓭, C𝓭 and Θ𝓭, each identified with the corresponding base vector of the
-      generic algebra.
+  - description: "Dimensions form a commutative group with a rational power operation."
     done: true
-    location: "Physlib/Units/LTMCTDimensionBase.lean (LTMCTDimensionBase, Dimension.length, Dimension.time, Dimension.mass, Dimension.charge, Dimension.temperature, Dimension.ofLTMCTDimensionBase, Dimension.length_mul, Dimension.one_time, Dimension.inv_mass, Dimension.div_charge, Dimension.npow_temperature, Dimension.L𝓭, Dimension.T𝓭, Dimension.M𝓭, Dimension.C𝓭, Dimension.Θ𝓭, Dimension.L𝓭_eq_single, Dimension.T𝓭_eq_single, Dimension.M𝓭_eq_single, Dimension.C𝓭_eq_single, Dimension.Θ𝓭_eq_single)"
+    location: "Physlib/Units/Dimension.lean (CommGroup (Dimension B), Dimension.qpow_exponent)"
 
-  - description: >
-      The API contains the seven base quantities of the International System of
-      Quantities, length, mass, time, electric current, thermodynamic temperature,
-      amount of substance and luminous intensity, with electric charge as the derived
-      dimension current times time, and with amount of substance and luminous
-      intensity shown to be independent of the other base quantities. It relates that
-      set to the default five by a faithful embedding sending the charge generator to
-      the derived ISQ charge, and by a reduction reading electric current as charge
-      per time and forgetting amount of substance and luminous intensity; the
-      reduction is a retraction of the embedding, and the composite in the other order
-      is not the identity.
+  - description: "The exponents of a product, of the unit, of an inverse, of a quotient and of a natural power are computed."
     done: true
-    location: |
-      Physlib/Units/ISQDimensionBase.lean (ISQDimensionBase, ISQDimensionBase.card_eq_seven, ISQDimensionBase.charge, ISQDimensionBase.charge_exponent_current, ISQDimensionBase.charge_exponent_time, ISQDimensionBase.charge_exponent_mass, ISQDimensionBase.single_amount_ne_one, ISQDimensionBase.single_luminousIntensity_ne_one); Physlib/Units/ISQBridge.lean (Dimension.toISQFun, Dimension.toISQHom, Dimension.toISQHom_apply, Dimension.fromISQFun, Dimension.fromISQHom, Dimension.fromISQHom_apply, Dimension.fromISQHom_comp_toISQHom, Dimension.toISQHom_injective, Dimension.fromISQHom_surjective, Dimension.ltmctToISQ, Dimension.isqToLTMCT, Dimension.isqToLTMCT_comp_ltmctToISQ, Dimension.toISQHom_C𝓭)
+    location: "Physlib/Units/Dimension.lean (Dimension.mul_exponent, Dimension.one_exponent, Dimension.inv_exponent, Dimension.div_exponent, Dimension.npow_exponent)"
 
-  - description: >
-      The API contains a choice of unit for each of the five default base quantities,
-      the SI choice of metre, second, kilogram, coulomb and kelvin, and a second
-      choice obtained from the SI one by rescaling each base unit by a distinct prime,
-      which serves to refute dimensional correctness. It contains the factor by which
-      a quantity of a given dimension rescales under a change of unit choice, as a
-      monoid homomorphism from dimensions to the positive reals, with the facts that
-      it is one on the trivial dimension and on a system paired with itself, that it
-      is strictly positive and nonzero, that it composes along a chain of three unit
-      choices, that swapping the two choices inverts it, and that scaling by it is
-      injective.
+  - description: "The base vector at each base dimension is defined, with its exponents."
     done: true
-    location: "Physlib/Units/Basic.lean (LTMCTUnitChoices, LTMCTUnitChoices.dimScale, LTMCTUnitChoices.dimScale_apply, LTMCTUnitChoices.dimScale_self, LTMCTUnitChoices.dimScale_one, LTMCTUnitChoices.dimScale_transitive, LTMCTUnitChoices.dimScale_mul_symm, LTMCTUnitChoices.dimScale_coe_mul_symm, LTMCTUnitChoices.dimScale_ne_zero, LTMCTUnitChoices.dimScale_pos, LTMCTUnitChoices.dimScale_symm, LTMCTUnitChoices.dimScale_of_inv_eq_swap, LTMCTUnitChoices.smul_dimScale_injective, LTMCTUnitChoices.SI, LTMCTUnitChoices.SI_length, LTMCTUnitChoices.SI_time, LTMCTUnitChoices.SI_mass, LTMCTUnitChoices.SI_charge, LTMCTUnitChoices.SI_temperature, LTMCTUnitChoices.SIPrimed, LTMCTUnitChoices.dimScale_SI_SIPrimed, LTMCTUnitChoices.dimScale_SIPrimed_SI)"
+    location: "Physlib/Units/Dimension.lean (Dimension.single, Dimension.single_exponent)"
 
-  - description: >
-      The API contains the assignment of a dimension to a type, the strengthening of
-      that assignment to a type on which the positive reals act, the condition on a
-      function from unit choices to such a type that it rescale by the correct factor
-      under every change of unit, the subtype of functions satisfying that condition
-      with its scalar action, and the equivalence, for each fixed unit choice, between
-      a value of the type and a quantity given in every unit system.
+  - description: "A change of base-dimension set is a monoid homomorphism of dimensions, either an injective embedding of one set into another or a surjective reduction of a richer set onto a coarser one, so a relabelling that does not preserve products, inverses and rational powers is not expressible."
     done: true
-    location: "Physlib/Units/Basic.lean (HasDim, HasDim.d, dim, CarriesDimension, HasDimension, hasDimension_iff, Dimensionful, Dimensionful.ext, Dimensionful.smul_apply, CarriesDimension.toDimensionful, CarriesDimension.toDimensionful_apply_apply)"
+    location: "Physlib/Units/Dimension.lean (Dimension.extend, Dimension.extend_exponent_apply, Dimension.extendHom, Dimension.Embedding, Dimension.Projection, Dimension.Embedding.ofBasis)"
 
-  - description: >
-      The API contains the unit side of the theory for an arbitrary set of base
-      dimensions. A magnitude layer assigns a positive real to each base dimension,
-      and the scaling homomorphism on that layer is the product over the base
-      dimensions of the unit ratio raised to the corresponding exponent, proved once
-      and shown to be transitive. Above it sits a typed layer: a catalogue naming, for
-      each base dimension, a type of admissible units and the magnitude of each, and a
-      unit system choosing exactly one unit per base dimension, which projects onto
-      the magnitude layer. The catalogue for the default five base dimensions recovers
-      the five named unit types, the bespoke five-field unit choice is equivalent to a
-      unit system over that set, and its hand-written scaling law is the generic
-      product specialised to that set.
+  - description: "The default set of five base dimensions is defined with the exponent projection of each."
     done: true
-    location: |
-      Physlib/Units/ParametricUnits.lean (UnitScale, UnitScale.ratio_ne_zero, UnitScale.dimScale, UnitScale.dimScale_self, UnitScale.dimScale_one, UnitScale.dimScale_transitive, LTMCTUnitChoices.toScale); Physlib/Units/UnitSystem.lean (UnitMagnitudeCatalog, UnitSystem, UnitSystem.ext, UnitSystem.toScale, UnitSystem.toScale_scale, LTMCTUnitChoices.equivUnitSystem, LTMCTUnitChoices.toScale_equivUnitSystem, prod_univ_LTMCTDimensionBase, LTMCTUnitChoices.dimScale_eq_toScale_dimScale)
+    location: "Physlib/Units/LTMCTDimensionBase.lean (LTMCTDimensionBase, Dimension.length, Dimension.time, Dimension.mass, Dimension.charge, Dimension.temperature)"
 
-  - description: >
-      The API contains a typed unit choice over the seven ISQ base quantities,
-      together with the three unit types that the default five-quantity setting does
-      not provide, namely units of electric current, of amount of substance and of
-      luminous intensity, each a positive magnitude with its quotient by another unit
-      of the same kind. The coherent SI choice of metre, kilogram, second, ampere,
-      kelvin, mole and candela is defined, and the scaling factor over the ISQ base
-      quantities is obtained from the generic product rather than restated.
+  - description: "A dimension is constructed from its five exponents."
     done: true
-    location: "Physlib/Units/SIUnitChoices.lean (CurrentUnit, CurrentUnit.val_pos, CurrentUnit.div_eq_val, CurrentUnit.amperes, AmountUnit, AmountUnit.div_eq_val, AmountUnit.moles, LuminousIntensityUnit, LuminousIntensityUnit.div_eq_val, LuminousIntensityUnit.candelas, prod_univ_ISQDimensionBase, SIUnitChoices, SIUnitChoices.SI, SIUnitChoices.dimScale, SIUnitChoices.dimScale_self)"
+    location: "Physlib/Units/LTMCTDimensionBase.lean (Dimension.ofLTMCTDimensionBase)"
 
-  - description: >
-      The concrete unit layer shall be completed. The SI unit choice over the default
-      five base quantities shall be computable, which a note in the source records as
-      requiring the axioms that define the base units to be replaced. The three unit
-      types introduced for electric current, amount of substance and luminous
-      intensity shall carry the same rescaling operation as the length, time, mass,
-      charge and temperature unit types, so that a decimal multiple such as the
-      milliampere can be named; at present they carry only a quotient and the coherent
-      SI unit.
+  - description: "Each of the five exponents is computed under products, units, inverses, quotients and natural powers."
+    done: true
+    location: "Physlib/Units/LTMCTDimensionBase.lean (Dimension.length_mul, Dimension.one_time, Dimension.inv_mass, Dimension.div_charge, Dimension.npow_temperature)"
+
+  - description: "The named generators L𝓭, T𝓭, M𝓭, C𝓭 and Θ𝓭 are defined and identified with the corresponding base vectors of the generic algebra."
+    done: true
+    location: "Physlib/Units/LTMCTDimensionBase.lean (Dimension.L𝓭, Dimension.T𝓭, Dimension.M𝓭, Dimension.C𝓭, Dimension.Θ𝓭, Dimension.L𝓭_eq_single, Dimension.T𝓭_eq_single, Dimension.M𝓭_eq_single, Dimension.C𝓭_eq_single, Dimension.Θ𝓭_eq_single)"
+
+  - description: "The seven base quantities of the International System of Quantities are defined."
+    done: true
+    location: "Physlib/Units/ISQDimensionBase.lean (ISQDimensionBase, ISQDimensionBase.card_eq_seven)"
+
+  - description: "Electric charge is derived as current times time, with its exponents in current, time and mass."
+    done: true
+    location: "Physlib/Units/ISQDimensionBase.lean (ISQDimensionBase.charge, ISQDimensionBase.charge_exponent_current, ISQDimensionBase.charge_exponent_time, ISQDimensionBase.charge_exponent_mass)"
+
+  - description: "Amount of substance and luminous intensity are independent of the other base quantities."
+    done: true
+    location: "Physlib/Units/ISQDimensionBase.lean (ISQDimensionBase.single_amount_ne_one, ISQDimensionBase.single_luminousIntensity_ne_one)"
+
+  - description: "A faithful embedding carries the default five base dimensions into the ISQ set, sending the charge generator to the derived ISQ charge."
+    done: true
+    location: "Physlib/Units/ISQBridge.lean (Dimension.toISQFun, Dimension.toISQHom, Dimension.toISQHom_apply, Dimension.toISQHom_injective, Dimension.ltmctToISQ, Dimension.toISQHom_C𝓭)"
+
+  - description: "A reduction reads electric current as charge per time and forgets amount of substance and luminous intensity."
+    done: true
+    location: "Physlib/Units/ISQBridge.lean (Dimension.fromISQFun, Dimension.fromISQHom, Dimension.fromISQHom_apply, Dimension.fromISQHom_surjective, Dimension.isqToLTMCT)"
+
+  - description: "The reduction is a retraction of the embedding, and the composite in the other order is not the identity."
+    done: true
+    location: "Physlib/Units/ISQBridge.lean (Dimension.fromISQHom_comp_toISQHom, Dimension.isqToLTMCT_comp_ltmctToISQ)"
+
+  - description: "A unit choice fixes one unit for each of the five default base quantities, with the SI choice of metre, second, kilogram, coulomb and kelvin."
+    done: true
+    location: "Physlib/Units/Basic.lean (LTMCTUnitChoices, LTMCTUnitChoices.SI, LTMCTUnitChoices.SI_length, LTMCTUnitChoices.SI_time, LTMCTUnitChoices.SI_mass, LTMCTUnitChoices.SI_charge, LTMCTUnitChoices.SI_temperature)"
+
+  - description: "A second unit choice rescales each SI base unit by a distinct prime, which serves to refute dimensional correctness."
+    done: true
+    location: "Physlib/Units/Basic.lean (LTMCTUnitChoices.SIPrimed, LTMCTUnitChoices.dimScale_SI_SIPrimed, LTMCTUnitChoices.dimScale_SIPrimed_SI)"
+
+  - description: "The factor by which a quantity of a given dimension rescales under a change of unit choice is a monoid homomorphism from dimensions to the positive reals."
+    done: true
+    location: "Physlib/Units/Basic.lean (LTMCTUnitChoices.dimScale, LTMCTUnitChoices.dimScale_apply)"
+
+  - description: "The rescaling factor is one on the trivial dimension and on a unit system paired with itself."
+    done: true
+    location: "Physlib/Units/Basic.lean (LTMCTUnitChoices.dimScale_self, LTMCTUnitChoices.dimScale_one)"
+
+  - description: "The rescaling factor is strictly positive and nonzero, composes along a chain of three unit choices, and inverts when the two choices are swapped."
+    done: true
+    location: "Physlib/Units/Basic.lean (LTMCTUnitChoices.dimScale_ne_zero, LTMCTUnitChoices.dimScale_pos, LTMCTUnitChoices.dimScale_transitive, LTMCTUnitChoices.dimScale_symm, LTMCTUnitChoices.dimScale_mul_symm, LTMCTUnitChoices.dimScale_coe_mul_symm, LTMCTUnitChoices.dimScale_of_inv_eq_swap)"
+
+  - description: "Scaling by the rescaling factor is injective."
+    done: true
+    location: "Physlib/Units/Basic.lean (LTMCTUnitChoices.smul_dimScale_injective)"
+
+  - description: "A type may be assigned a dimension, strengthened to a type on which the positive reals act."
+    done: true
+    location: "Physlib/Units/Basic.lean (HasDim, HasDim.d, dim, CarriesDimension)"
+
+  - description: "A function from unit choices to a dimension-carrying type is required to rescale by the correct factor under every change of unit."
+    done: true
+    location: "Physlib/Units/Basic.lean (HasDimension, hasDimension_iff)"
+
+  - description: "The subtype of functions satisfying that condition carries a scalar action."
+    done: true
+    location: "Physlib/Units/Basic.lean (Dimensionful, Dimensionful.ext, Dimensionful.smul_apply)"
+
+  - description: "For each fixed unit choice, a value of a dimension-carrying type is equivalent to a quantity given in every unit system."
+    done: true
+    location: "Physlib/Units/Basic.lean (CarriesDimension.toDimensionful, CarriesDimension.toDimensionful_apply_apply)"
+
+  - description: "A magnitude layer assigns a positive real to each base dimension, with nonzero ratios."
+    done: true
+    location: "Physlib/Units/ParametricUnits.lean (UnitScale, UnitScale.ratio_ne_zero)"
+
+  - description: "The scaling homomorphism on the magnitude layer is the product over the base dimensions of the unit ratio raised to the corresponding exponent, and is transitive."
+    done: true
+    location: "Physlib/Units/ParametricUnits.lean (UnitScale.dimScale, UnitScale.dimScale_self, UnitScale.dimScale_one, UnitScale.dimScale_transitive)"
+
+  - description: "A catalogue names a type of admissible units and a magnitude for each base dimension, and a unit system chooses exactly one unit per base dimension."
+    done: true
+    location: "Physlib/Units/UnitSystem.lean (UnitMagnitudeCatalog, UnitSystem, UnitSystem.ext)"
+
+  - description: "A unit system projects onto the magnitude layer."
+    done: true
+    location: "Physlib/Units/UnitSystem.lean (UnitSystem.toScale, UnitSystem.toScale_scale)"
+
+  - description: "The bespoke five-field unit choice is equivalent to a unit system over the default base dimensions, and its hand-written scaling law is the generic product specialised to that set."
+    done: true
+    location: "Physlib/Units/ParametricUnits.lean (LTMCTUnitChoices.toScale); Physlib/Units/UnitSystem.lean (LTMCTUnitChoices.equivUnitSystem, LTMCTUnitChoices.toScale_equivUnitSystem, prod_univ_LTMCTDimensionBase, LTMCTUnitChoices.dimScale_eq_toScale_dimScale)"
+
+  - description: "Units of electric current, of amount of substance and of luminous intensity are defined, each a positive magnitude with its quotient by another unit of the same kind."
+    done: true
+    location: "Physlib/Units/SIUnitChoices.lean (CurrentUnit, CurrentUnit.val_pos, CurrentUnit.div_eq_val, AmountUnit, AmountUnit.div_eq_val, LuminousIntensityUnit, LuminousIntensityUnit.div_eq_val)"
+
+  - description: "The coherent SI units ampere, mole and candela are named."
+    done: true
+    location: "Physlib/Units/SIUnitChoices.lean (CurrentUnit.amperes, AmountUnit.moles, LuminousIntensityUnit.candelas)"
+
+  - description: "A typed unit choice over the seven ISQ base quantities is defined, with the coherent SI choice of metre, kilogram, second, ampere, kelvin, mole and candela."
+    done: true
+    location: "Physlib/Units/SIUnitChoices.lean (SIUnitChoices, SIUnitChoices.SI)"
+
+  - description: "The scaling factor over the ISQ base quantities is obtained from the generic product rather than restated."
+    done: true
+    location: "Physlib/Units/SIUnitChoices.lean (prod_univ_ISQDimensionBase, SIUnitChoices.dimScale, SIUnitChoices.dimScale_self)"
+
+  - description: "The SI unit choice over the default five base quantities shall be computable, which a note in the source records as requiring the axioms that define the base units to be replaced."
     done: false
     location: "N/A"
 
-  - description: >
-      The API contains the treatment of quantities that depend on a choice of unit
-      without themselves carrying a dimension, such as a function between two types
-      that carry dimensions, or a proposition about such quantities. A unit-dependent
-      type comes with the transformation of its elements induced by a change of unit,
-      subject to composition along a chain of unit choices and triviality on an
-      unchanged choice, with strengthenings requiring that transformation to commute
-      with a scalar action, to be linear, or to be linear and continuous, and with the
-      transformation packaged as an equivalence, a linear map, a linear equivalence, a
-      continuous linear map and a continuous linear equivalence. Instances are given
-      for the unit choices themselves, for every type carrying a dimension, and for
-      function types, acting on the argument, on the value, or on both.
-    done: true
-    location: "Physlib/Units/UnitDependent.lean (UnitDependent, MulUnitDependent, LinearUnitDependent, ContinuousLinearUnitDependent, UnitDependent.scaleUnit_symm_apply, UnitDependent.scaleUnit_injective, UnitDependent.scaleUnitEquiv, LinearUnitDependent.scaleUnitLinear, LinearUnitDependent.scaleUnitLinearEquiv, ContinuousLinearUnitDependent.scaleUnitContLinear, ContinuousLinearUnitDependent.scaleUnitContLinearEquiv, LTMCTUnitChoices.scaleUnit_apply_fst, LTMCTUnitChoices.dimScale_scaleUnit, Dimensionful.of_scaleUnit, HasDim.scaleUnit_apply, UnitDependent.scaleUnit_apply_fun_right, UnitDependent.scaleUnit_apply_fun_left, UnitDependent.scaleUnit_apply_fun, instUnitDependentTwoSided, instUnitDependentTwoSidedMul, instContinuousLinearUnitDependentMap)"
-
-  - description: >
-      The API contains dimensional correctness, the condition that a quantity or a
-      statement be unchanged by a change of unit system, with its unfolding for
-      functions acting on the argument, on the value, and on both. It contains the
-      dimension-preserving product of two dimension-carrying types, under which the
-      product of two quantities scales as the product of their dimensions, and the
-      subset of a unit-dependent type consisting of the elements that scale according
-      to a prescribed dimension, which itself carries that dimension.
-    done: true
-    location: "Physlib/Units/UnitDependent.lean (IsDimensionallyCorrect, isDimensionallyCorrect_iff, isDimensionallyCorrect_fun_iff, isDimensionallyCorrect_fun_left, isDimensionallyCorrect_fun_right, DMul, DMul.hMul_scaleUnit, DimSet, DimSet.mem_iff, scaleUnit_dimSet_val)"
-
-  - description: >
-      The API contains the type of values of an underlying type tagged with a
-      dimension, over any set of base dimensions. It inherits zero, addition,
-      negation, subtraction, the additive group and commutative group structures, the
-      order relations with their preorder and partial order, and the action of the
-      positive reals, each computed on the underlying value. Multiplication and
-      division of real-valued quantities multiply the underlying values and multiply
-      the dimensions, and the product is dimension-preserving. Over the default base
-      dimensions the tagged type carries its dimension, its transformation under a
-      change of unit is scalar multiplication by the scaling factor, a quantity of
-      trivial dimension is unchanged by a change of unit, and a cast moves a quantity
-      between two tags whose dimensions are equal, with the equality discharged
-      automatically.
-    done: true
-    location: "Physlib/Units/WithDim/Basic.lean (WithDim, WithDim.ext, WithDim.dim_apply, WithDim.val_zero, WithDim.val_add, WithDim.val_neg, WithDim.val_sub, WithDim.le_def, WithDim.lt_def, WithDim.smul_val, WithDim.withDim_hMul_val, WithDim.val_mul_eq_mul, WithDim.val_pow_two_eq_mul, WithDim.val_div_val, WithDim.div_scaleUnit, WithDim.scaleUnit_val, WithDim.scaleUnit_val_eq_scaleUnit_val, WithDim.scaleUnit_val_eq_scaleUnit_val_of_dim_eq, WithDim.scaleUnit_dim_eq_zero, WithDim.cast, WithDim.cast_refl, WithDim.cast_scaleUnit)"
-
-  - description: >
-      The dimension-tagged type shall inherit further structure from its underlying
-      type: multiplicative and other non-additive algebraic structure, the remaining
-      order structure beyond the preorder and partial order, and topological
-      structure. A note in the source records this; only the additive, order and
-      scalar-action instances listed above exist.
+  - description: "The unit types for electric current, amount of substance and luminous intensity shall carry the same rescaling operation as the other five, so that a decimal multiple such as the milliampere can be named."
     done: false
     location: "N/A"
 
-  - description: >
-      The API contains named quantities of derived dimension with their concrete
-      units. Area has dimension length squared, with the square metre, square foot,
-      square mile, are, hectare and acre, their values in SI units, and the identity
-      of one acre with 43560 square feet. Speed has dimension length over time, with
-      the metre per second, mile per hour, kilometre per hour, knot and the speed of
-      light, their values in SI units, and the conversions between them. Energy has
-      dimension mass times length squared over time squared, with the joule,
-      electronvolt, calorie and kilowatt hour. Pressure has dimension mass over length
-      over time squared, with the pascal, millimetre of mercury, bar, standard
-      atmosphere, torr and pound per square inch. Momentum has dimension mass times
-      length over time and takes values in d spatial components, the three-momentum
-      rather than the four-momentum.
+  - description: "A unit-dependent type comes with the transformation of its elements induced by a change of unit, subject to composition along a chain of unit choices and triviality on an unchanged choice."
     done: true
-    location: |
-      Physlib/Units/WithDim/Area.lean (DimArea, DimArea.squareMeter, DimArea.squareFoot, DimArea.squareMile, DimArea.are, DimArea.hectare, DimArea.acre, DimArea.squareFoot_in_SI, DimArea.squareMile_in_SI, DimArea.acre_in_SI, DimArea.acre_eq_mul_squareFeet); Physlib/Units/WithDim/Speed.lean (DimSpeed, DimSpeed.oneMeterPerSecond, DimSpeed.oneMilePerHour, DimSpeed.oneKilometerPerHour, DimSpeed.oneKnot, DimSpeed.speedOfLight, DimSpeed.oneMilePerHour_in_SI, DimSpeed.speedOfLight_in_SI, DimSpeed.oneKnot_eq_mul_oneKilometerPerHour, DimSpeed.oneKilometerPerHour_eq_mul_oneKnot, DimSpeed.oneMeterPerSecond_eq_mul_oneMilePerHour); Physlib/Units/WithDim/Energy.lean (DimEnergy, DimEnergy.joule, DimEnergy.electronVolt, DimEnergy.calorie, DimEnergy.kilowattHour); Physlib/Units/WithDim/Pressure.lean (DimPressure, DimPressure.pascal, DimPressure.millimeterOfMercury, DimPressure.bar, DimPressure.standardAtmosphere, DimPressure.torr, DimPressure.psi); Physlib/Units/WithDim/Momentum.lean (Momentum)
+    location: "Physlib/Units/UnitDependent.lean (UnitDependent)"
 
-  - description: >
-      The API shall contain the mass of a particle and the velocity of a particle in d
-      spatial dimensions as named dimension-carrying quantities, in the manner of
-      momentum. Physlib/Units/WithDim/Mass.lean and Physlib/Units/WithDim/Velocity.lean
-      announce those two types in their module documentation but contain no
-      declarations.
+  - description: "Strengthenings require that transformation to commute with a scalar action, to be linear, or to be linear and continuous."
+    done: true
+    location: "Physlib/Units/UnitDependent.lean (MulUnitDependent, LinearUnitDependent, ContinuousLinearUnitDependent)"
+
+  - description: "The transformation is packaged as an equivalence, a linear map, a linear equivalence, a continuous linear map and a continuous linear equivalence."
+    done: true
+    location: "Physlib/Units/UnitDependent.lean (UnitDependent.scaleUnit_symm_apply, UnitDependent.scaleUnit_injective, UnitDependent.scaleUnitEquiv, LinearUnitDependent.scaleUnitLinear, LinearUnitDependent.scaleUnitLinearEquiv, ContinuousLinearUnitDependent.scaleUnitContLinear, ContinuousLinearUnitDependent.scaleUnitContLinearEquiv)"
+
+  - description: "Instances are given for the unit choices themselves and for every type carrying a dimension."
+    done: true
+    location: "Physlib/Units/UnitDependent.lean (LTMCTUnitChoices.scaleUnit_apply_fst, LTMCTUnitChoices.dimScale_scaleUnit, Dimensionful.of_scaleUnit, HasDim.scaleUnit_apply)"
+
+  - description: "Instances for function types act on the argument, on the value, or on both."
+    done: true
+    location: "Physlib/Units/UnitDependent.lean (UnitDependent.scaleUnit_apply_fun_right, UnitDependent.scaleUnit_apply_fun_left, UnitDependent.scaleUnit_apply_fun, instUnitDependentTwoSided, instUnitDependentTwoSidedMul, instContinuousLinearUnitDependentMap)"
+
+  - description: "Dimensional correctness is the condition that a quantity or a statement be unchanged by a change of unit system, with its unfolding for functions acting on the argument, on the value and on both."
+    done: true
+    location: "Physlib/Units/UnitDependent.lean (IsDimensionallyCorrect, isDimensionallyCorrect_iff, isDimensionallyCorrect_fun_iff, isDimensionallyCorrect_fun_left, isDimensionallyCorrect_fun_right)"
+
+  - description: "The dimension-preserving product of two dimension-carrying types scales as the product of their dimensions."
+    done: true
+    location: "Physlib/Units/UnitDependent.lean (DMul, DMul.hMul_scaleUnit)"
+
+  - description: "The subset of a unit-dependent type consisting of the elements that scale according to a prescribed dimension itself carries that dimension."
+    done: true
+    location: "Physlib/Units/UnitDependent.lean (DimSet, DimSet.mem_iff, scaleUnit_dimSet_val)"
+
+  - description: "Values of an underlying type may be tagged with a dimension over any set of base dimensions."
+    done: true
+    location: "Physlib/Units/WithDim/Basic.lean (WithDim, WithDim.ext, WithDim.dim_apply)"
+
+  - description: "The tagged type inherits zero, addition, negation and subtraction, each computed on the underlying value."
+    done: true
+    location: "Physlib/Units/WithDim/Basic.lean (WithDim.val_zero, WithDim.val_add, WithDim.val_neg, WithDim.val_sub)"
+
+  - description: "The tagged type inherits the order relations and the action of the positive reals."
+    done: true
+    location: "Physlib/Units/WithDim/Basic.lean (WithDim.le_def, WithDim.lt_def, WithDim.smul_val)"
+
+  - description: "Multiplication and division of real-valued tagged quantities multiply the underlying values and multiply the dimensions."
+    done: true
+    location: "Physlib/Units/WithDim/Basic.lean (WithDim.withDim_hMul_val, WithDim.val_mul_eq_mul, WithDim.val_pow_two_eq_mul, WithDim.val_div_val, WithDim.div_scaleUnit)"
+
+  - description: "Over the default base dimensions the tagged type carries its dimension and its transformation under a change of unit is scalar multiplication by the scaling factor."
+    done: true
+    location: "Physlib/Units/WithDim/Basic.lean (WithDim.scaleUnit_val, WithDim.scaleUnit_val_eq_scaleUnit_val, WithDim.scaleUnit_val_eq_scaleUnit_val_of_dim_eq)"
+
+  - description: "A tagged quantity of trivial dimension is unchanged by a change of unit."
+    done: true
+    location: "Physlib/Units/WithDim/Basic.lean (WithDim.scaleUnit_dim_eq_zero)"
+
+  - description: "A cast moves a tagged quantity between two tags whose dimensions are equal, with the equality discharged automatically."
+    done: true
+    location: "Physlib/Units/WithDim/Basic.lean (WithDim.cast, WithDim.cast_refl, WithDim.cast_scaleUnit)"
+
+  - description: "The dimension-tagged type shall inherit further structure from its underlying type: multiplicative and other non-additive algebraic structure, the remaining order structure, and topological structure."
     done: false
     location: "N/A"
 
-  - description: >
-      The API contains the dimensional behaviour of the calculus. The derivative of a
-      dimensionally correct differentiable function is dimensionally correct, with the
-      explicit rescaling of the derivative at a rescaled point, and the equation
-      giving the derivative in a fixed direction as a quantity of the dimension of the
-      target divided by the dimension of the source is dimensionally correct. A
-      measure on a type carrying a dimension is unit-dependent, and the integral of a
-      function whose dimension is that of its values divided by the dimension of the
-      measure has the dimension of the values.
+  - description: "Area has dimension length squared, with the square metre, square foot, square mile, are, hectare and acre, their values in SI units, and the identity of one acre with 43560 square feet."
     done: true
-    location: |
-      Physlib/Units/FDeriv.lean (fderiv_apply_scaleUnit, fderiv_isDimensionallyCorrect, fderiv_dimension_const_direction); Physlib/Units/Integral.lean (scaleUnit_measure, integral_isDimensionallyCorrect)
+    location: "Physlib/Units/WithDim/Area.lean (DimArea, DimArea.squareMeter, DimArea.squareFoot, DimArea.squareMile, DimArea.are, DimArea.hectare, DimArea.acre, DimArea.squareFoot_in_SI, DimArea.squareMile_in_SI, DimArea.acre_in_SI, DimArea.acre_eq_mul_squareFeet)"
 
-  - description: >
-      The API contains worked examples, in modules that no other module imports. A
-      length of 400 metres is converted to miles. The relations E = m c^2 and F = m a
-      are stated over dimension-tagged reals, both through the tagged product and
-      through the underlying values, and shown to be dimensionally correct, as are a
-      speed as distance over time, an expression of mixed dimension in mass,
-      temperature, current, length and time, and the cosine of an angular frequency
-      times a time. The relation E = m c is shown not to be dimensionally correct by
-      exhibiting a change of unit that breaks it. The version of E = m c^2 written with
-      the speed of light in an explicit unit system is proved in SI units and then
-      transported to every unit system. A separate module shows that the equality of a
-      length with a speed times a time holds propositionally and not definitionally,
-      so that the two tagged types are bridged by a cast, and repeats the same
-      comparison over a set of base dimensions with no physical unit system, namely
-      bits and symbols.
+  - description: "Speed has dimension length over time, with the metre per second, mile per hour, kilometre per hour, knot and the speed of light, their values in SI units, and the conversions between them."
     done: true
-    location: |
-      Physlib/Units/Examples.lean (UnitExamples.meters400, UnitExamples.EnergyMassWithDim, UnitExamples.energyMassWithDim_isDimensionallyCorrect, UnitExamples.NewtonsSecondWithDim, UnitExamples.newtonsSecondWithDim_isDimensionallyCorrect, UnitExamples.SpeedEq, UnitExamples.speedEq_isDimensionallyCorrect, UnitExamples.OddDimensions, UnitExamples.oddDimensions_isDimensionallyCorrect, UnitExamples.CosDim, UnitExamples.cosDim_isDimensionallyCorrect, UnitExamples.EnergyMassWithDimNot, UnitExamples.energyMassWithDimNot_not_isDimensionallyCorrect, UnitExamples.EnergyMass, UnitExamples.energyMass_isDimensionallyCorrect, UnitExamples.example1_energyMass, UnitExamples.example2_energyMass); Physlib/Units/ParametricDimensionExamples.lean (ParametricDimensionExamples.Info, ParametricDimensionExamples.bitDim, ParametricDimensionExamples.symbolDim)
+    location: "Physlib/Units/WithDim/Speed.lean (DimSpeed, DimSpeed.oneMeterPerSecond, DimSpeed.oneMilePerHour, DimSpeed.oneKilometerPerHour, DimSpeed.oneKnot, DimSpeed.speedOfLight, DimSpeed.oneMilePerHour_in_SI, DimSpeed.speedOfLight_in_SI, DimSpeed.oneKnot_eq_mul_oneKilometerPerHour, DimSpeed.oneKilometerPerHour_eq_mul_oneKnot, DimSpeed.oneMeterPerSecond_eq_mul_oneMilePerHour)"
+
+  - description: "Energy has dimension mass times length squared over time squared, with the joule, electronvolt, calorie and kilowatt hour."
+    done: true
+    location: "Physlib/Units/WithDim/Energy.lean (DimEnergy, DimEnergy.joule, DimEnergy.electronVolt, DimEnergy.calorie, DimEnergy.kilowattHour)"
+
+  - description: "Pressure has dimension mass over length over time squared, with the pascal, millimetre of mercury, bar, standard atmosphere, torr and pound per square inch."
+    done: true
+    location: "Physlib/Units/WithDim/Pressure.lean (DimPressure, DimPressure.pascal, DimPressure.millimeterOfMercury, DimPressure.bar, DimPressure.standardAtmosphere, DimPressure.torr, DimPressure.psi)"
+
+  - description: "Momentum has dimension mass times length over time and takes values in d spatial components, the three-momentum rather than the four-momentum."
+    done: true
+    location: "Physlib/Units/WithDim/Momentum.lean (Momentum)"
+
+  - description: "The API shall contain the mass of a particle and the velocity of a particle in d spatial dimensions as named dimension-carrying quantities, in the manner of momentum, which Mass.lean and Velocity.lean announce in their module documentation but do not yet declare."
+    done: false
+    location: "N/A"
+
+  - description: "The derivative of a dimensionally correct differentiable function is dimensionally correct, with the explicit rescaling of the derivative at a rescaled point."
+    done: true
+    location: "Physlib/Units/FDeriv.lean (fderiv_apply_scaleUnit, fderiv_isDimensionallyCorrect)"
+
+  - description: "The equation giving the derivative in a fixed direction as a quantity of the dimension of the target divided by the dimension of the source is dimensionally correct."
+    done: true
+    location: "Physlib/Units/FDeriv.lean (fderiv_dimension_const_direction)"
+
+  - description: "A measure on a type carrying a dimension is unit-dependent, and the integral of a function whose dimension is that of its values divided by the dimension of the measure has the dimension of the values."
+    done: true
+    location: "Physlib/Units/Integral.lean (scaleUnit_measure, integral_isDimensionallyCorrect)"
+
+  - description: "A worked example converts a length of 400 metres to miles."
+    done: true
+    location: "Physlib/Units/Examples.lean (UnitExamples.meters400)"
+
+  - description: "The relations E = m c^2 and F = m a are stated over dimension-tagged reals and shown to be dimensionally correct."
+    done: true
+    location: "Physlib/Units/Examples.lean (UnitExamples.EnergyMassWithDim, UnitExamples.energyMassWithDim_isDimensionallyCorrect, UnitExamples.NewtonsSecondWithDim, UnitExamples.newtonsSecondWithDim_isDimensionallyCorrect)"
+
+  - description: "A speed as distance over time, an expression of mixed dimension in mass, temperature, current, length and time, and the cosine of an angular frequency times a time are each shown to be dimensionally correct."
+    done: true
+    location: "Physlib/Units/Examples.lean (UnitExamples.SpeedEq, UnitExamples.speedEq_isDimensionallyCorrect, UnitExamples.OddDimensions, UnitExamples.oddDimensions_isDimensionallyCorrect, UnitExamples.CosDim, UnitExamples.cosDim_isDimensionallyCorrect)"
+
+  - description: "The relation E = m c is shown not to be dimensionally correct by exhibiting a change of unit that breaks it."
+    done: true
+    location: "Physlib/Units/Examples.lean (UnitExamples.EnergyMassWithDimNot, UnitExamples.energyMassWithDimNot_not_isDimensionallyCorrect)"
+
+  - description: "The version of E = m c^2 written with the speed of light in an explicit unit system is proved in SI units and then transported to every unit system."
+    done: true
+    location: "Physlib/Units/Examples.lean (UnitExamples.EnergyMass, UnitExamples.energyMass_isDimensionallyCorrect, UnitExamples.example1_energyMass, UnitExamples.example2_energyMass)"
+
+  - description: "The equality of a length with a speed times a time holds propositionally rather than definitionally, so the two tagged types are bridged by a cast, and the same comparison is repeated over a set of base dimensions with no physical unit system, namely bits and symbols."
+    done: true
+    location: "Physlib/Units/ParametricDimensionExamples.lean (ParametricDimensionExamples.Info, ParametricDimensionExamples.bitDim, ParametricDimensionExamples.symbolDim)"

--- a/Physlib/Units/API-map.yaml
+++ b/Physlib/Units/API-map.yaml
@@ -1,0 +1,274 @@
+version: v0.1
+
+Title: Units
+
+Overview: |
+    Every physical quantity has a dimension: a rational power of each base
+    dimension, recording how the numerical value of the quantity changes when the
+    unit of each base quantity is changed. The default set of base dimensions used
+    here is length, time, mass, charge and temperature, written L𝓭, T𝓭, M𝓭, C𝓭 and
+    Θ𝓭. Dimensions multiply by adding exponents and invert by negating them, so they
+    form a commutative group with a rational power operation. The International
+    System of Quantities takes a different set of seven base quantities, length,
+    mass, time, electric current, thermodynamic temperature, amount of substance and
+    luminous intensity, in which electric charge is derived as current times time.
+    Both sets are available, and the two are related by a faithful inclusion of the
+    default set into the ISQ set and a reduction in the other direction that forgets
+    amount of substance and luminous intensity.
+
+    A unit system fixes one concrete unit for each base quantity. The SI fixes the
+    metre, second, kilogram, ampere, kelvin, mole and candela; the default
+    charge-based system fixes the metre, second, kilogram, coulomb and kelvin.
+    Changing from one unit system to another multiplies a quantity of dimension d by
+    a positive factor: the product, over the base quantities, of the ratio of the two
+    units raised to the exponent that d assigns to that base quantity. That factor is
+    multiplicative in the dimension, equals one when the two systems agree, and
+    composes along a chain of three systems, so the value of a quantity in one system
+    determines its value in every other. The same statement is proved once for a
+    general set of base dimensions and specialises to the default five and to the
+    seven ISQ base quantities without being restated.
+
+    A value carrying a dimension inherits the additive, order and scalar structure of
+    its underlying type, while products and quotients add and subtract the exponents.
+    Area, speed, energy, pressure and momentum appear as named dimensions with
+    concrete units: the square metre, square foot, square mile, are, hectare and
+    acre; the metre
+    per second, mile per hour, kilometre per hour, knot and the speed of light; the
+    joule, electronvolt, calorie and kilowatt hour; the pascal, millimetre of
+    mercury, bar, standard atmosphere, torr and pound per square inch; and the
+    three-momentum of a particle in d spatial dimensions. Mass and velocity are named
+    in the source but carry no declarations yet.
+
+    A statement is dimensionally correct when its truth does not depend on the unit
+    system in which it is written, and this is the formal content of dimensional
+    analysis. The API expresses that condition for values, for functions and for
+    propositions, and proves that the derivative and the integral of a dimensionally
+    correct quantity are again dimensionally correct. Worked examples check E = m c^2
+    and F = m a against it, and exhibit E = m c as a statement that fails it.
+
+ParentAPIs:
+  - "Time (Physlib/SpaceAndTime/Time)"
+  - "Space (Physlib/SpaceAndTime/Space)"
+  - "Mass (Physlib/ClassicalMechanics/Mass)"
+  - "Charge (Physlib/Electromagnetism/Charge)"
+  - "Temperature (Physlib/Thermodynamics/Temperature)"
+
+References:
+  - "International Bureau of Weights and Measures (BIPM), The International System of Units (SI Brochure), 9th edition (2019), Chapter 1 (quantities and units) and Chapter 2 (the defining constants and the seven base units)"
+  - "ISO/IEC 80000-1:2009, Quantities and units, Part 1: General, Clauses 3 to 6 (quantities, systems of quantities, dimensions, and systems of units)"
+  - "JCGM 200:2012, International vocabulary of metrology (VIM, 3rd edition), Clause 1 (base quantity, derived quantity, quantity dimension, base unit, coherent system of units)"
+  - "G. I. Barenblatt, Scaling, Self-similarity, and Intermediate Asymptotics, Cambridge University Press (1996), Chapter 1, Sections 1.1 and 1.2 (dimensions, systems of units, and the change of a quantity under a change of unit)"
+  - "Lean Zulip, #Physlib > physical units: https://leanprover.zulipchat.com/#narrow/channel/479953-Physlib/topic/physical.20units"
+
+Requirements:
+
+  - description: >
+      The API contains the dimensional algebra over an arbitrary set of base
+      dimensions. A dimension assigns a rational exponent to each base dimension;
+      dimensions multiply by adding exponents, invert by negating them, and form a
+      commutative group with a rational power operation and, over a finite set of
+      base dimensions, decidable equality. The base vector at each base dimension is
+      defined. A change of base-dimension set is recorded as a monoid homomorphism of
+      dimensions, either an injective embedding of one set into another or a
+      surjective reduction of a richer set onto a coarser one, so that a relabelling
+      which does not preserve products, inverses and rational powers is not
+      expressible.
+    done: true
+    location: "Physlib/Units/Dimension.lean (Dimension, Dimension.ext, Dimension.mul_exponent, Dimension.one_exponent, Dimension.inv_exponent, Dimension.div_exponent, Dimension.npow_exponent, Dimension.qpow_exponent, Dimension.single, Dimension.single_exponent, Dimension.extend, Dimension.extend_exponent_apply, Dimension.extendHom, Dimension.Embedding, Dimension.Projection, Dimension.Embedding.ofBasis, CommGroup (Dimension B))"
+
+  - description: >
+      The API contains the default set of five base dimensions, length, time, mass,
+      charge and temperature, with the exponent projection of each, the constructor
+      of a dimension from its five exponents, the computation of each exponent under
+      products, inverses, quotients and natural powers, and the named generators L𝓭,
+      T𝓭, M𝓭, C𝓭 and Θ𝓭, each identified with the corresponding base vector of the
+      generic algebra.
+    done: true
+    location: "Physlib/Units/LTMCTDimensionBase.lean (LTMCTDimensionBase, Dimension.length, Dimension.time, Dimension.mass, Dimension.charge, Dimension.temperature, Dimension.ofLTMCTDimensionBase, Dimension.length_mul, Dimension.one_time, Dimension.inv_mass, Dimension.div_charge, Dimension.npow_temperature, Dimension.L𝓭, Dimension.T𝓭, Dimension.M𝓭, Dimension.C𝓭, Dimension.Θ𝓭, Dimension.L𝓭_eq_single, Dimension.T𝓭_eq_single, Dimension.M𝓭_eq_single, Dimension.C𝓭_eq_single, Dimension.Θ𝓭_eq_single)"
+
+  - description: >
+      The API contains the seven base quantities of the International System of
+      Quantities, length, mass, time, electric current, thermodynamic temperature,
+      amount of substance and luminous intensity, with electric charge as the derived
+      dimension current times time, and with amount of substance and luminous
+      intensity shown to be independent of the other base quantities. It relates that
+      set to the default five by a faithful embedding sending the charge generator to
+      the derived ISQ charge, and by a reduction reading electric current as charge
+      per time and forgetting amount of substance and luminous intensity; the
+      reduction is a retraction of the embedding, and the composite in the other order
+      is not the identity.
+    done: true
+    location: |
+      Physlib/Units/ISQDimensionBase.lean (ISQDimensionBase, ISQDimensionBase.card_eq_seven, ISQDimensionBase.charge, ISQDimensionBase.charge_exponent_current, ISQDimensionBase.charge_exponent_time, ISQDimensionBase.charge_exponent_mass, ISQDimensionBase.single_amount_ne_one, ISQDimensionBase.single_luminousIntensity_ne_one); Physlib/Units/ISQBridge.lean (Dimension.toISQFun, Dimension.toISQHom, Dimension.toISQHom_apply, Dimension.fromISQFun, Dimension.fromISQHom, Dimension.fromISQHom_apply, Dimension.fromISQHom_comp_toISQHom, Dimension.toISQHom_injective, Dimension.fromISQHom_surjective, Dimension.ltmctToISQ, Dimension.isqToLTMCT, Dimension.isqToLTMCT_comp_ltmctToISQ, Dimension.toISQHom_C𝓭)
+
+  - description: >
+      The API contains a choice of unit for each of the five default base quantities,
+      the SI choice of metre, second, kilogram, coulomb and kelvin, and a second
+      choice obtained from the SI one by rescaling each base unit by a distinct prime,
+      which serves to refute dimensional correctness. It contains the factor by which
+      a quantity of a given dimension rescales under a change of unit choice, as a
+      monoid homomorphism from dimensions to the positive reals, with the facts that
+      it is one on the trivial dimension and on a system paired with itself, that it
+      is strictly positive and nonzero, that it composes along a chain of three unit
+      choices, that swapping the two choices inverts it, and that scaling by it is
+      injective.
+    done: true
+    location: "Physlib/Units/Basic.lean (LTMCTUnitChoices, LTMCTUnitChoices.dimScale, LTMCTUnitChoices.dimScale_apply, LTMCTUnitChoices.dimScale_self, LTMCTUnitChoices.dimScale_one, LTMCTUnitChoices.dimScale_transitive, LTMCTUnitChoices.dimScale_mul_symm, LTMCTUnitChoices.dimScale_coe_mul_symm, LTMCTUnitChoices.dimScale_ne_zero, LTMCTUnitChoices.dimScale_pos, LTMCTUnitChoices.dimScale_symm, LTMCTUnitChoices.dimScale_of_inv_eq_swap, LTMCTUnitChoices.smul_dimScale_injective, LTMCTUnitChoices.SI, LTMCTUnitChoices.SI_length, LTMCTUnitChoices.SI_time, LTMCTUnitChoices.SI_mass, LTMCTUnitChoices.SI_charge, LTMCTUnitChoices.SI_temperature, LTMCTUnitChoices.SIPrimed, LTMCTUnitChoices.dimScale_SI_SIPrimed, LTMCTUnitChoices.dimScale_SIPrimed_SI)"
+
+  - description: >
+      The API contains the assignment of a dimension to a type, the strengthening of
+      that assignment to a type on which the positive reals act, the condition on a
+      function from unit choices to such a type that it rescale by the correct factor
+      under every change of unit, the subtype of functions satisfying that condition
+      with its scalar action, and the equivalence, for each fixed unit choice, between
+      a value of the type and a quantity given in every unit system.
+    done: true
+    location: "Physlib/Units/Basic.lean (HasDim, HasDim.d, dim, CarriesDimension, HasDimension, hasDimension_iff, Dimensionful, Dimensionful.ext, Dimensionful.smul_apply, CarriesDimension.toDimensionful, CarriesDimension.toDimensionful_apply_apply)"
+
+  - description: >
+      The API contains the unit side of the theory for an arbitrary set of base
+      dimensions. A magnitude layer assigns a positive real to each base dimension,
+      and the scaling homomorphism on that layer is the product over the base
+      dimensions of the unit ratio raised to the corresponding exponent, proved once
+      and shown to be transitive. Above it sits a typed layer: a catalogue naming, for
+      each base dimension, a type of admissible units and the magnitude of each, and a
+      unit system choosing exactly one unit per base dimension, which projects onto
+      the magnitude layer. The catalogue for the default five base dimensions recovers
+      the five named unit types, the bespoke five-field unit choice is equivalent to a
+      unit system over that set, and its hand-written scaling law is the generic
+      product specialised to that set.
+    done: true
+    location: |
+      Physlib/Units/ParametricUnits.lean (UnitScale, UnitScale.ratio_ne_zero, UnitScale.dimScale, UnitScale.dimScale_self, UnitScale.dimScale_one, UnitScale.dimScale_transitive, LTMCTUnitChoices.toScale); Physlib/Units/UnitSystem.lean (UnitMagnitudeCatalog, UnitSystem, UnitSystem.ext, UnitSystem.toScale, UnitSystem.toScale_scale, LTMCTUnitChoices.equivUnitSystem, LTMCTUnitChoices.toScale_equivUnitSystem, prod_univ_LTMCTDimensionBase, LTMCTUnitChoices.dimScale_eq_toScale_dimScale)
+
+  - description: >
+      The API contains a typed unit choice over the seven ISQ base quantities,
+      together with the three unit types that the default five-quantity setting does
+      not provide, namely units of electric current, of amount of substance and of
+      luminous intensity, each a positive magnitude with its quotient by another unit
+      of the same kind. The coherent SI choice of metre, kilogram, second, ampere,
+      kelvin, mole and candela is defined, and the scaling factor over the ISQ base
+      quantities is obtained from the generic product rather than restated.
+    done: true
+    location: "Physlib/Units/SIUnitChoices.lean (CurrentUnit, CurrentUnit.val_pos, CurrentUnit.div_eq_val, CurrentUnit.amperes, AmountUnit, AmountUnit.div_eq_val, AmountUnit.moles, LuminousIntensityUnit, LuminousIntensityUnit.div_eq_val, LuminousIntensityUnit.candelas, prod_univ_ISQDimensionBase, SIUnitChoices, SIUnitChoices.SI, SIUnitChoices.dimScale, SIUnitChoices.dimScale_self)"
+
+  - description: >
+      The concrete unit layer shall be completed. The SI unit choice over the default
+      five base quantities shall be computable, which a note in the source records as
+      requiring the axioms that define the base units to be replaced. The three unit
+      types introduced for electric current, amount of substance and luminous
+      intensity shall carry the same rescaling operation as the length, time, mass,
+      charge and temperature unit types, so that a decimal multiple such as the
+      milliampere can be named; at present they carry only a quotient and the coherent
+      SI unit.
+    done: false
+    location: "N/A"
+
+  - description: >
+      The API contains the treatment of quantities that depend on a choice of unit
+      without themselves carrying a dimension, such as a function between two types
+      that carry dimensions, or a proposition about such quantities. A unit-dependent
+      type comes with the transformation of its elements induced by a change of unit,
+      subject to composition along a chain of unit choices and triviality on an
+      unchanged choice, with strengthenings requiring that transformation to commute
+      with a scalar action, to be linear, or to be linear and continuous, and with the
+      transformation packaged as an equivalence, a linear map, a linear equivalence, a
+      continuous linear map and a continuous linear equivalence. Instances are given
+      for the unit choices themselves, for every type carrying a dimension, and for
+      function types, acting on the argument, on the value, or on both.
+    done: true
+    location: "Physlib/Units/UnitDependent.lean (UnitDependent, MulUnitDependent, LinearUnitDependent, ContinuousLinearUnitDependent, UnitDependent.scaleUnit_symm_apply, UnitDependent.scaleUnit_injective, UnitDependent.scaleUnitEquiv, LinearUnitDependent.scaleUnitLinear, LinearUnitDependent.scaleUnitLinearEquiv, ContinuousLinearUnitDependent.scaleUnitContLinear, ContinuousLinearUnitDependent.scaleUnitContLinearEquiv, LTMCTUnitChoices.scaleUnit_apply_fst, LTMCTUnitChoices.dimScale_scaleUnit, Dimensionful.of_scaleUnit, HasDim.scaleUnit_apply, UnitDependent.scaleUnit_apply_fun_right, UnitDependent.scaleUnit_apply_fun_left, UnitDependent.scaleUnit_apply_fun, instUnitDependentTwoSided, instUnitDependentTwoSidedMul, instContinuousLinearUnitDependentMap)"
+
+  - description: >
+      The API contains dimensional correctness, the condition that a quantity or a
+      statement be unchanged by a change of unit system, with its unfolding for
+      functions acting on the argument, on the value, and on both. It contains the
+      dimension-preserving product of two dimension-carrying types, under which the
+      product of two quantities scales as the product of their dimensions, and the
+      subset of a unit-dependent type consisting of the elements that scale according
+      to a prescribed dimension, which itself carries that dimension.
+    done: true
+    location: "Physlib/Units/UnitDependent.lean (IsDimensionallyCorrect, isDimensionallyCorrect_iff, isDimensionallyCorrect_fun_iff, isDimensionallyCorrect_fun_left, isDimensionallyCorrect_fun_right, DMul, DMul.hMul_scaleUnit, DimSet, DimSet.mem_iff, scaleUnit_dimSet_val)"
+
+  - description: >
+      The API contains the type of values of an underlying type tagged with a
+      dimension, over any set of base dimensions. It inherits zero, addition,
+      negation, subtraction, the additive group and commutative group structures, the
+      order relations with their preorder and partial order, and the action of the
+      positive reals, each computed on the underlying value. Multiplication and
+      division of real-valued quantities multiply the underlying values and multiply
+      the dimensions, and the product is dimension-preserving. Over the default base
+      dimensions the tagged type carries its dimension, its transformation under a
+      change of unit is scalar multiplication by the scaling factor, a quantity of
+      trivial dimension is unchanged by a change of unit, and a cast moves a quantity
+      between two tags whose dimensions are equal, with the equality discharged
+      automatically.
+    done: true
+    location: "Physlib/Units/WithDim/Basic.lean (WithDim, WithDim.ext, WithDim.dim_apply, WithDim.val_zero, WithDim.val_add, WithDim.val_neg, WithDim.val_sub, WithDim.le_def, WithDim.lt_def, WithDim.smul_val, WithDim.withDim_hMul_val, WithDim.val_mul_eq_mul, WithDim.val_pow_two_eq_mul, WithDim.val_div_val, WithDim.div_scaleUnit, WithDim.scaleUnit_val, WithDim.scaleUnit_val_eq_scaleUnit_val, WithDim.scaleUnit_val_eq_scaleUnit_val_of_dim_eq, WithDim.scaleUnit_dim_eq_zero, WithDim.cast, WithDim.cast_refl, WithDim.cast_scaleUnit)"
+
+  - description: >
+      The dimension-tagged type shall inherit further structure from its underlying
+      type: multiplicative and other non-additive algebraic structure, the remaining
+      order structure beyond the preorder and partial order, and topological
+      structure. A note in the source records this; only the additive, order and
+      scalar-action instances listed above exist.
+    done: false
+    location: "N/A"
+
+  - description: >
+      The API contains named quantities of derived dimension with their concrete
+      units. Area has dimension length squared, with the square metre, square foot,
+      square mile, are, hectare and acre, their values in SI units, and the identity
+      of one acre with 43560 square feet. Speed has dimension length over time, with
+      the metre per second, mile per hour, kilometre per hour, knot and the speed of
+      light, their values in SI units, and the conversions between them. Energy has
+      dimension mass times length squared over time squared, with the joule,
+      electronvolt, calorie and kilowatt hour. Pressure has dimension mass over length
+      over time squared, with the pascal, millimetre of mercury, bar, standard
+      atmosphere, torr and pound per square inch. Momentum has dimension mass times
+      length over time and takes values in d spatial components, the three-momentum
+      rather than the four-momentum.
+    done: true
+    location: |
+      Physlib/Units/WithDim/Area.lean (DimArea, DimArea.squareMeter, DimArea.squareFoot, DimArea.squareMile, DimArea.are, DimArea.hectare, DimArea.acre, DimArea.squareFoot_in_SI, DimArea.squareMile_in_SI, DimArea.acre_in_SI, DimArea.acre_eq_mul_squareFeet); Physlib/Units/WithDim/Speed.lean (DimSpeed, DimSpeed.oneMeterPerSecond, DimSpeed.oneMilePerHour, DimSpeed.oneKilometerPerHour, DimSpeed.oneKnot, DimSpeed.speedOfLight, DimSpeed.oneMilePerHour_in_SI, DimSpeed.speedOfLight_in_SI, DimSpeed.oneKnot_eq_mul_oneKilometerPerHour, DimSpeed.oneKilometerPerHour_eq_mul_oneKnot, DimSpeed.oneMeterPerSecond_eq_mul_oneMilePerHour); Physlib/Units/WithDim/Energy.lean (DimEnergy, DimEnergy.joule, DimEnergy.electronVolt, DimEnergy.calorie, DimEnergy.kilowattHour); Physlib/Units/WithDim/Pressure.lean (DimPressure, DimPressure.pascal, DimPressure.millimeterOfMercury, DimPressure.bar, DimPressure.standardAtmosphere, DimPressure.torr, DimPressure.psi); Physlib/Units/WithDim/Momentum.lean (Momentum)
+
+  - description: >
+      The API shall contain the mass of a particle and the velocity of a particle in d
+      spatial dimensions as named dimension-carrying quantities, in the manner of
+      momentum. Physlib/Units/WithDim/Mass.lean and Physlib/Units/WithDim/Velocity.lean
+      announce those two types in their module documentation but contain no
+      declarations.
+    done: false
+    location: "N/A"
+
+  - description: >
+      The API contains the dimensional behaviour of the calculus. The derivative of a
+      dimensionally correct differentiable function is dimensionally correct, with the
+      explicit rescaling of the derivative at a rescaled point, and the equation
+      giving the derivative in a fixed direction as a quantity of the dimension of the
+      target divided by the dimension of the source is dimensionally correct. A
+      measure on a type carrying a dimension is unit-dependent, and the integral of a
+      function whose dimension is that of its values divided by the dimension of the
+      measure has the dimension of the values.
+    done: true
+    location: |
+      Physlib/Units/FDeriv.lean (fderiv_apply_scaleUnit, fderiv_isDimensionallyCorrect, fderiv_dimension_const_direction); Physlib/Units/Integral.lean (scaleUnit_measure, integral_isDimensionallyCorrect)
+
+  - description: >
+      The API contains worked examples, in modules that no other module imports. A
+      length of 400 metres is converted to miles. The relations E = m c^2 and F = m a
+      are stated over dimension-tagged reals, both through the tagged product and
+      through the underlying values, and shown to be dimensionally correct, as are a
+      speed as distance over time, an expression of mixed dimension in mass,
+      temperature, current, length and time, and the cosine of an angular frequency
+      times a time. The relation E = m c is shown not to be dimensionally correct by
+      exhibiting a change of unit that breaks it. The version of E = m c^2 written with
+      the speed of light in an explicit unit system is proved in SI units and then
+      transported to every unit system. A separate module shows that the equality of a
+      length with a speed times a time holds propositionally and not definitionally,
+      so that the two tagged types are bridged by a cast, and repeats the same
+      comparison over a set of base dimensions with no physical unit system, namely
+      bits and symbols.
+    done: true
+    location: |
+      Physlib/Units/Examples.lean (UnitExamples.meters400, UnitExamples.EnergyMassWithDim, UnitExamples.energyMassWithDim_isDimensionallyCorrect, UnitExamples.NewtonsSecondWithDim, UnitExamples.newtonsSecondWithDim_isDimensionallyCorrect, UnitExamples.SpeedEq, UnitExamples.speedEq_isDimensionallyCorrect, UnitExamples.OddDimensions, UnitExamples.oddDimensions_isDimensionallyCorrect, UnitExamples.CosDim, UnitExamples.cosDim_isDimensionallyCorrect, UnitExamples.EnergyMassWithDimNot, UnitExamples.energyMassWithDimNot_not_isDimensionallyCorrect, UnitExamples.EnergyMass, UnitExamples.energyMass_isDimensionallyCorrect, UnitExamples.example1_energyMass, UnitExamples.example2_energyMass); Physlib/Units/ParametricDimensionExamples.lean (ParametricDimensionExamples.Info, ParametricDimensionExamples.bitDim, ParametricDimensionExamples.symbolDim)


### PR DESCRIPTION
## Motivation

Related to #1414. An API map records the implemented status and source location of each requirement for an API, so the gap between a planned API and the current library stays visible in-tree. Units has no map yet, and it is a dependency of most of the library.

## Changes

Adds `Physlib/Units/API-map.yaml`, 16 requirements of which 13 are done, covering the 21 modules in the directory.

The done entries cover the dimensional algebra over an arbitrary base-dimension set, the default five base dimensions and the seven ISQ base quantities with the embedding and reduction between them, unit choices with the rescaling factor and its transitivity, dimension-carrying types, the parametric unit-system layer with the SI choice over the ISQ quantities, unit-dependent types, dimensional correctness, the dimension-tagged value type, the named derived quantities (area, speed, energy, pressure, momentum) with their concrete units, the dimensional behaviour of the derivative and the integral, and the worked examples.

The three open entries are the concrete unit layer (a computable SI choice, and a rescaling operation on the current, amount and luminous-intensity unit types so that decimal multiples can be named), the remaining algebraic, order and topological instances on the tagged type, and mass and velocity, which the source announces in module documentation but which carry no declarations. The first two are recorded as open items in the source; no module under `Physlib/Units` carries a proof gap.

Checked with `scripts/api_map_linter.py`: 13 checked, 236 names ok, no missing files or names.
