### PR TITLE
feat(QuantumMechanics): add `positionState` and `momentumState`

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -322,6 +322,7 @@ public import Physlib.QuantumMechanics.HilbertSpaces.OneDimension.SchwartzSubmod
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Basic
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.DirichletSubmodule
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Fourier
+public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.MomentumStates
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.PolyBddSchwartzSubmodule
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.PositionStates
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -323,6 +323,7 @@ public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Basic
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.DirichletSubmodule
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.Fourier
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.PolyBddSchwartzSubmodule
+public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.PositionStates
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SchwartzSubmodule
 public import Physlib.QuantumMechanics.HilbertSpaces.SpaceD.SobolevSubmodule
 public import Physlib.QuantumMechanics.HilbertSpaces.TensorProducts.CompleteTensorProduct

--- a/Physlib/QuantumMechanics/HilbertSpaces/OneDimension/PlaneWaves.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/OneDimension/PlaneWaves.lean
@@ -6,17 +6,16 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Mathlib.Analysis.Distribution.TemperedDistribution
-public import Physlib.Meta.TODO.Basic
 /-!
 
 # Plane waves
 
-We define plane waves as a member of the dual of the
-Schwartz submodule of the Hilbert space.
+We define plane waves as a member of the dual of the Schwartz submodule of the 1d Hilbert space.
+
+This module has been generalized to d-dimensions in
+`QuantumMechanics/HilbertSpaces/SpaceD/MomentumStates.lean` and will be removed in the near future.
 
 -/
-
-TODO "Generalize plane waves to d dimensions and SpaceDHilbertSpace."
 
 @[expose] public section
 

--- a/Physlib/QuantumMechanics/HilbertSpaces/OneDimension/PositionStates.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/OneDimension/PositionStates.lean
@@ -6,17 +6,16 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Mathlib.Analysis.Distribution.TemperedDistribution
-public import Physlib.Meta.TODO.Basic
 /-!
 
 # Position states
 
-We define plane waves as a member of the dual of the
-Schwartz submodule of the Hilbert space.
+We define position state as a member of the dual of the Schwartz submodule of the 1d Hilbert space.
+
+This module has been generalized to d-dimensions in
+`QuantumMechanics/HilbertSpaces/SpaceD/PositionStates.lean` and will be removed in the near future.
 
 -/
-
-TODO "Generalize position states to d dimensions and SpaceDHilbertSpace."
 
 @[expose] public section
 namespace QuantumMechanics

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/MomentumStates.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/MomentumStates.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Distribution.TemperedDistribution
 public import Physlib.SpaceAndTime.Space.Module
+public import Physlib.Meta.TODO.Basic
 /-!
 
 # Momentum states
@@ -29,6 +30,8 @@ of the dual of `𝓢(Space d, ℂ)` defined by evaluation of the Fourier transfo
 -/
 
 @[expose] public section
+
+TODO "Prove that momentum states are generalized eigenvectors of every derivative operator."
 
 namespace QuantumMechanics
 

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/MomentumStates.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/MomentumStates.lean
@@ -11,8 +11,20 @@ public import Physlib.SpaceAndTime.Space.Module
 
 # Momentum states
 
-We define plane waves as a member of the dual of the
-Schwartz submodule of the Hilbert space.
+## i. Overview
+
+Informally, the momentum "state" corresponding to momentum `p` is the non-normalizable
+plane wave `exp (I p ⬝ᵥ x)`. More precisely, the momentum "state" lives in the _rigged_ Hilbert
+space `𝓢(Space d, ℂ) < SpaceDHilbertSpace d μ < StrongDual ℂ 𝓢(Space d, ℂ)` as the element
+of the dual of `𝓢(Space d, ℂ)` defined by evaluation of the Fourier transform at `p`.
+
+## ii. Key results
+
+## iii. Table of contents
+
+## iv. References
+
+- https://en.wikipedia.org/wiki/Rigged_Hilbert_space
 
 -/
 
@@ -24,24 +36,27 @@ namespace SpaceDHilbertSpace
 
 noncomputable section
 
-open FourierTransform MeasureTheory SchwartzMap
+open scoped Real SchwartzMap
+open FourierTransform
 
 variable {d : ℕ}
 
-/-- Plane wave as a member of the strong dual of the Schwartz space.
+/-- Momentum state as a member of the strong dual of the Schwartz space.
 
-  For a given `k` this corresponds to the non-normalizable plane wave `exp (2π I k ⬝ᵥ x)`. -/
-def momentumState (k : Space d) : StrongDual ℂ 𝓢(Space d, ℂ) :=
-  TemperedDistribution.delta k ∘L fourierTransformCLM ℂ
+  For a given `p` this corresponds to the non-normalizable plane wave `exp (I p ⬝ᵥ x)`. -/
+def momentumState (p : Space d) : StrongDual ℂ 𝓢(Space d, ℂ) :=
+  TemperedDistribution.delta ((2 * π)⁻¹ • p) ∘L fourierCLM ℂ 𝓢(Space d, ℂ)
 
+/-- The defining property of momentum states. -/
 @[simp]
-lemma momentumState_apply (k : Space d) (ψ : 𝓢(Space d, ℂ)) :
-    momentumState k ψ = 𝓕 ψ k := rfl
+lemma momentumState_apply (p : Space d) (ψ : 𝓢(Space d, ℂ)) :
+    momentumState p ψ = 𝓕 ψ ((2 * π)⁻¹ • p) := rfl
 
 /-- Two Schwartz maps are equal if they are equal on all momentum states. -/
 lemma eq_of_eq_momentumState {ψ φ : 𝓢(Space d, ℂ)}
-    (h : ∀ k, momentumState k ψ = momentumState k φ) : ψ = φ :=
-  fourierCLE ℂ 𝓢(Space d, ℂ) |>.injective <| ext h
+    (h : ∀ p, momentumState p ψ = momentumState p φ) : ψ = φ :=
+  fourierCLE ℂ 𝓢(Space d, ℂ) |>.injective <| SchwartzMap.ext
+    fun k ↦ by simpa [smul_smul, ← mul_rotate] using h ((2 * π) • k)
 
 end
 end SpaceDHilbertSpace

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/MomentumStates.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/MomentumStates.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Analysis.Distribution.TemperedDistribution
 public import Physlib.SpaceAndTime.Space.Module
-public import Physlib.Meta.TODO.Basic
 /-!
 
 # Momentum states

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/MomentumStates.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/MomentumStates.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+module
+
+public import Mathlib.Analysis.Distribution.TemperedDistribution
+public import Physlib.SpaceAndTime.Space.Module
+/-!
+
+# Momentum states
+
+We define plane waves as a member of the dual of the
+Schwartz submodule of the Hilbert space.
+
+-/
+
+@[expose] public section
+
+namespace QuantumMechanics
+
+namespace SpaceDHilbertSpace
+
+noncomputable section
+
+open FourierTransform MeasureTheory SchwartzMap
+
+variable {d : ℕ}
+
+/-- Plane wave as a member of the strong dual of the Schwartz space.
+
+  For a given `k` this corresponds to the non-normalizable plane wave `exp (2π I k ⬝ᵥ x)`. -/
+def momentumState (k : Space d) : StrongDual ℂ 𝓢(Space d, ℂ) :=
+  TemperedDistribution.delta k ∘L fourierTransformCLM ℂ
+
+@[simp]
+lemma momentumState_apply (k : Space d) (ψ : 𝓢(Space d, ℂ)) :
+    momentumState k ψ = 𝓕 ψ k := rfl
+
+/-- Two Schwartz maps are equal if they are equal on all momentum states. -/
+lemma eq_of_eq_momentumState {ψ φ : 𝓢(Space d, ℂ)}
+    (h : ∀ k, momentumState k ψ = momentumState k φ) : ψ = φ :=
+  fourierCLE ℂ 𝓢(Space d, ℂ) |>.injective <| ext h
+
+end
+end SpaceDHilbertSpace
+end QuantumMechanics

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PositionStates.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PositionStates.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Distribution.TemperedDistribution
 public import Physlib.SpaceAndTime.Space.Module
+public import Physlib.Meta.TODO.Basic
 /-!
 
 # Position states
@@ -29,6 +30,8 @@ of the dual of `𝓢(Space d, ℂ)` defined by evaluation at `x`.
 -/
 
 @[expose] public section
+
+TODO "Prove that position states are generalized eigenvectors of every multiplication operator."
 
 namespace QuantumMechanics
 namespace SpaceDHilbertSpace

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PositionStates.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PositionStates.lean
@@ -11,6 +11,21 @@ public import Physlib.SpaceAndTime.Space.Module
 
 # Position states
 
+## i. Overview
+
+Informally, the position "state" at `x : Space d` has a non-normalizable wavefunction which is
+a Dirac-delta function centered at `x`. More precisely, the position "state" lives in the _rigged_
+Hilbert space `𝓢(Space d, ℂ) < SpaceDHilbertSpace d μ < StrongDual ℂ 𝓢(Space d, ℂ)` as the element
+of the dual of `𝓢(Space d, ℂ)` defined by evaluation at `x`.
+
+## ii. Key results
+
+## iii. Table of contents
+
+## iv. References
+
+- https://en.wikipedia.org/wiki/Rigged_Hilbert_space
+
 -/
 
 @[expose] public section
@@ -24,10 +39,13 @@ open scoped SchwartzMap
 
 variable {d : ℕ}
 
-/-- Position state as a member of the strong dual of the Schwartz space. -/
+/-- Position state as a member of the strong dual of the Schwartz space.
+
+  For a given `x` this corresponds to the non-normalizable wavefunction `ψ(y) = δᵈ(y - x) -/
 def positionState (x : Space d) : StrongDual ℂ 𝓢(Space d, ℂ) := TemperedDistribution.delta x
 
 /-- The defining property of position states. -/
+@[simp]
 lemma positionState_apply (x : Space d) (f : 𝓢(Space d, ℂ)) : positionState x f = f x := rfl
 
 /-- Two Schwartz maps are equal if they are equal on all position states. -/

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PositionStates.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PositionStates.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+module
+
+public import Mathlib.Analysis.Distribution.TemperedDistribution
+public import Physlib.SpaceAndTime.Space.Module
+/-!
+
+# Position states
+
+-/
+
+@[expose] public section
+
+namespace QuantumMechanics
+namespace SpaceDHilbertSpace
+
+noncomputable section
+
+open scoped SchwartzMap
+
+variable {d : ℕ}
+
+/-- Position state as a member of the strong dual of the Schwartz space. -/
+def positionState (x : Space d) : StrongDual ℂ 𝓢(Space d, ℂ) := TemperedDistribution.delta x
+
+/-- The defining property of position states. -/
+lemma positionState_apply (x : Space d) (f : 𝓢(Space d, ℂ)) : positionState x f = f x := rfl
+
+/-- Two Schwartz maps are equal if they are equal on all position states. -/
+lemma eq_of_eq_positionState {f g : 𝓢(Space d, ℂ)}
+    (h : ∀ x, positionState x f = positionState x g) : f = g := by
+  ext x
+  exact h x
+
+end
+end SpaceDHilbertSpace
+end QuantumMechanics

--- a/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PositionStates.lean
+++ b/Physlib/QuantumMechanics/HilbertSpaces/SpaceD/PositionStates.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Analysis.Distribution.TemperedDistribution
 public import Physlib.SpaceAndTime.Space.Module
-public import Physlib.Meta.TODO.Basic
 /-!
 
 # Position states


### PR DESCRIPTION
Defines `positionState` and `momentumState` in d dimensions as elements of the rigged Hilbert space, generalizing the 1d `positionState` and `planeWave`.