### PR TITLE
Migrating NoAlphaImport Python Script to Lean

### DIFF
--- a/.github/workflows/alphaBuild.yml
+++ b/.github/workflows/alphaBuild.yml
@@ -50,6 +50,9 @@ jobs:
           linters: gcc
           run: env LEAN_ABORT_ON_PANIC=1 lake exe runPhyslibAlphaLinters
 
+      - name: Check no PhyslibAlpha in Physlib and QuantumInfo
+        run: env LEAN_ABORT_ON_PANIC=1 lake exe noAlphaImports
+
   style_lint:
     name: Python based linters
     runs-on: ubuntu-latest
@@ -78,10 +81,6 @@ jobs:
           chmod u+x scripts/PhyslibAlpha/alphaFileImports.py
           ./scripts/PhyslibAlpha/alphaFileImports.py
 
-      - name: Check no PhyslibAlpha in Physlib and QuantumInfo
-        run: |
-          chmod u+x scripts/PhyslibAlpha/noAlphaImports.py
-          ./scripts/PhyslibAlpha/noAlphaImports.py
 
       - name: Python linters for PhyslibAlpha
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,8 @@ When a long proof cannot be split, make sure it contains comments.
 - Check `./scripts/lint-style.sh`, but **commit your changes first**; this linter reads committed state.
 - If edited a `PhyslibAlpha` file, check the following:
   - `lake exe runPhyslibAlphaLinters`
+  - `lake exe noAlphaImports`
   - `./scripts/PhyslibAlpha/alphaFileImports.py`
-  - `./scripts/PhyslibAlpha/noAlphaImports.py`
   - `./scripts/PhyslibAlpha/alphaPythonLinters.sh`
 
 ## PR scope

--- a/Physlib/Meta/AllFilePaths.lean
+++ b/Physlib/Meta/AllFilePaths.lean
@@ -27,6 +27,10 @@ partial def allFilePaths.go (prev : Array FilePath)
       pure (acc.push (root ++ "/" ++ entry.fileName))
   pure result
 
+/-- Gets an array of all file paths in the supplied directory. -/
+partial def getFilePaths (moduleName : String) : IO (Array FilePath) := do
+   allFilePaths.go (#[] : Array FilePath) moduleName moduleName
+
 /-- Gets an array of all file paths in `Physlib`. -/
 partial def allFilePaths : IO (Array FilePath) := do
   allFilePaths.go (#[] : Array FilePath) "./Physlib" ("./Physlib" : FilePath)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -65,6 +65,11 @@ srcDir = "scripts/PhyslibAlpha"
 supportInterpreter = true
 
 [[lean_exe]]
+name = "noAlphaImports"
+srcDir = "scripts/PhyslibAlpha"
+supportInterpreter = true
+
+[[lean_exe]]
 name = "free_simps"
 srcDir = "scripts/MetaPrograms"
 

--- a/scripts/PhyslibAlpha/noAlphaImports.lean
+++ b/scripts/PhyslibAlpha/noAlphaImports.lean
@@ -1,0 +1,60 @@
+import Lean
+import Physlib.Meta.AllFilePaths
+
+/-!
+Copyright (c) 2026 Fergus Munro. All rights reserved.
+Released under Apache 2.0 license.
+Authors: Fergus Munro
+
+This module validates that no files in the Physlib and QuantumInfo directories
+contain import statements that reference PhyslibAlpha. It walks through all .lean
+files in these directories and reports any violations found, returning an exit code
+indicating success or failure of the validation check.
+-/
+
+open Lean
+open System
+
+/-- 
+  Returns True if not files in Physlib or QuantumInfo import import any 
+  PhyslibAlpha files, and False otherwise, printing the offending files and 
+  imports to the standard output.
+  -/
+def areNoAlphaImports : IO Bool := do
+  let mut violations : Array (FilePath × Name) := #[]
+
+  let modules : Array String := #["./Physlib", "./QuantumInfo"]
+  for module in modules do
+
+    let filePaths ← getFilePaths module
+    for filePath in filePaths do 
+      
+      let contents ← IO.FS.readFile filePath
+      let (imports, _pos, _messages) ← Elab.parseImports contents filePath.toString
+      
+      for imp in imports do
+        if imp.module.toString.contains "PhyslibAlpha" then
+          violations := violations.push (
+            filePath, imp.module
+          )
+
+  if violations.size > 0 then
+    IO.println "Found Violations:"
+    for violation in violations do
+      IO.println s!"  {violation.fst} : {violation.snd}"
+
+    return False
+  else 
+    IO.println "No violations found. All files passed the check."
+    return True
+
+unsafe def main (_ : List String) : IO Unit := do
+  let success ← areNoAlphaImports 
+
+  if !success then
+    IO.Process.exit 1
+  
+
+
+
+    


### PR DESCRIPTION
Replaces the `noAlphaImports.py` Python script with `noAlphaImports.lean` build target in Github actions and changes instructions for agents in `AGENTS.md`. 

Does not delete `noAlphaImports.py`. Additionally, new script does not display line number of any illegal imports.

Finally, the github actions changes might not be set up correctly, as I'm not very familiar with using actions.