### PR TITLE
Add coordinate-axis boosts in SL(2, ℂ)

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -374,6 +374,7 @@ public import Physlib.Relativity.LorentzAlgebra.Basis
 public import Physlib.Relativity.LorentzAlgebra.ExponentialMap
 public import Physlib.Relativity.LorentzGroup.Basic
 public import Physlib.Relativity.LorentzGroup.Boosts.Apply
+public import Physlib.Relativity.LorentzGroup.Boosts.Axis
 public import Physlib.Relativity.LorentzGroup.Boosts.Basic
 public import Physlib.Relativity.LorentzGroup.Boosts.Generalized
 public import Physlib.Relativity.LorentzGroup.Orthochronous.Basic

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -390,6 +390,7 @@ public import Physlib.Relativity.PauliMatrices.CliffordAlgebra
 public import Physlib.Relativity.PauliMatrices.Relations
 public import Physlib.Relativity.PauliMatrices.SelfAdjoint
 public import Physlib.Relativity.PauliMatrices.ToTensor
+public import Physlib.Relativity.SL2C.AxisRotations
 public import Physlib.Relativity.SL2C.Basic
 public import Physlib.Relativity.SL2C.SelfAdjoint
 public import Physlib.Relativity.Special.ProperTime

--- a/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
@@ -5,9 +5,7 @@ Authors: Jinzheng Li, Nathaneal Sajan, Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Relativity.SL2C.Basic
-public import Physlib.Relativity.PauliMatrices.Basic
-public import Physlib.Relativity.MinkowskiMatrix
+public import Physlib.Relativity.SL2C.AxisRotations
 /-!
 # Coordinate-axis boosts in `SL(2,ℂ)` and the Lorentz group
 
@@ -16,7 +14,7 @@ public import Physlib.Relativity.MinkowskiMatrix
 We define the axis-indexed lift `Lorentz.SL2C.boostAxis` in `SL(2,ℂ)` and its image
 `LorentzGroup.boostAxis` in the Lorentz group.
 
-The parameter `t ≠ 0` is multiplicative: replacing `t` by `t⁻¹` reverses the boost. For
+The parameter `t ≠ 0` is multiplicative; replacing `t` by `t⁻¹` reverses the boost. For
 `t > 0`, its rapidity is `2 * log t`; negative values retain the action of the central
 element `-1 : SL(2,ℂ)`.
 
@@ -96,6 +94,19 @@ noncomputable def boostAxis : Fin 3 → (t : ℝ) → t ≠ 0 → SL(2,ℂ)
         rw [Matrix.det_fin_two_of]
         simp [mul_inv_cancel₀ htc]⟩
 
+/-- The matrix entries of an `SL(2,ℂ)` axis-boost lift. -/
+@[simp] lemma boostAxis_apply (i : Fin 3) (t : ℝ) (ht : t ≠ 0) (j k : Fin 2) :
+    (boostAxis i t ht).1 j k =
+      match i with
+      | 0 => (!![((t : ℂ) + (t : ℂ)⁻¹) / 2, ((t : ℂ) - (t : ℂ)⁻¹) / 2;
+          ((t : ℂ) - (t : ℂ)⁻¹) / 2, ((t : ℂ) + (t : ℂ)⁻¹) / 2]) j k
+      | 1 => (!![((t : ℂ) + (t : ℂ)⁻¹) / 2,
+          -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2;
+          Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2,
+          ((t : ℂ) + (t : ℂ)⁻¹) / 2]) j k
+      | 2 => (!![(t : ℂ), 0; 0, (t : ℂ)⁻¹]) j k := by
+  fin_cases i <;> rfl
+
 /-- Inverting an axis boost replaces its multiplicative parameter `t` by `t⁻¹`. -/
 lemma boostAxis_inv (i : Fin 3) (t : ℝ) (ht : t ≠ 0) :
     (boostAxis i t ht)⁻¹ = boostAxis i t⁻¹ (inv_ne_zero ht) := by
@@ -103,13 +114,13 @@ lemma boostAxis_inv (i : Fin 3) (t : ℝ) (ht : t ≠ 0) :
   · ext j k
     rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
     fin_cases j <;> fin_cases k <;>
-      · simp [boostAxis, Complex.ofReal_inv, inv_inv]
-        try ring
+      simp [boostAxis, Complex.ofReal_inv, inv_inv] <;>
+      ring
   · ext j k
     rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
     fin_cases j <;> fin_cases k <;>
-      · simp [boostAxis, Complex.ofReal_inv, inv_inv]
-        try ring
+      simp [boostAxis, Complex.ofReal_inv, inv_inv] <;>
+      ring
   · ext j k
     rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
     fin_cases j <;> fin_cases k <;>
@@ -138,31 +149,11 @@ noncomputable def boostAxis (i : Fin 3) (t : ℝ) (ht : t ≠ 0) : LorentzGroup 
 /-- The entries of an axis boost in the Lorentz group. -/
 lemma boostAxis_apply (i : Fin 3) (t : ℝ) (ht : t ≠ 0) (a b : Fin 1 ⊕ Fin 3) :
     (boostAxis i t ht).1 a b =
-      match i with
-      | 0 => match a, b with
-        | Sum.inl _, Sum.inl _ => (t ^ 2 + (t⁻¹) ^ 2) / 2
-        | Sum.inl _, Sum.inr 0 => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
-        | Sum.inr 0, Sum.inl _ => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
-        | Sum.inr 0, Sum.inr 0 => (t ^ 2 + (t⁻¹) ^ 2) / 2
-        | Sum.inr 1, Sum.inr 1 => 1
-        | Sum.inr 2, Sum.inr 2 => 1
-        | _, _ => 0
-      | 1 => match a, b with
-        | Sum.inl _, Sum.inl _ => (t ^ 2 + (t⁻¹) ^ 2) / 2
-        | Sum.inl _, Sum.inr 1 => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
-        | Sum.inr 1, Sum.inl _ => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
-        | Sum.inr 0, Sum.inr 0 => 1
-        | Sum.inr 1, Sum.inr 1 => (t ^ 2 + (t⁻¹) ^ 2) / 2
-        | Sum.inr 2, Sum.inr 2 => 1
-        | _, _ => 0
-      | 2 => match a, b with
-        | Sum.inl _, Sum.inl _ => (t ^ 2 + (t⁻¹) ^ 2) / 2
-        | Sum.inl _, Sum.inr 2 => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
-        | Sum.inr 2, Sum.inl _ => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
-        | Sum.inr 0, Sum.inr 0 => 1
-        | Sum.inr 1, Sum.inr 1 => 1
-        | Sum.inr 2, Sum.inr 2 => (t ^ 2 + (t⁻¹) ^ 2) / 2
-        | _, _ => 0 := by
+      if a = Sum.inl 0 ∧ b = Sum.inl 0 then (t ^ 2 + (t⁻¹) ^ 2) / 2
+      else if a = Sum.inl 0 ∧ b = Sum.inr i then -((t ^ 2 - (t⁻¹) ^ 2) / 2)
+      else if a = Sum.inr i ∧ b = Sum.inl 0 then -((t ^ 2 - (t⁻¹) ^ 2) / 2)
+      else if a = Sum.inr i ∧ b = Sum.inr i then (t ^ 2 + (t⁻¹) ^ 2) / 2
+      else if a = b then 1 else 0 := by
   have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
   refine Complex.ofReal_injective ?_
   rw [boostAxis, Lorentz.SL2C.toLorentzGroup_eq_trace,
@@ -187,72 +178,36 @@ namespace Lorentz.SL2C
 
 -/
 
-private lemma sqrtTwo_sq : (((Real.sqrt 2 : ℝ) : ℂ)) ^ 2 = 2 := by
-  rw [← Complex.ofReal_pow, Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 2)]
-  norm_num
-
-private lemma sqrtTwo_ne_zero : (((Real.sqrt 2 : ℝ) : ℂ)) ≠ 0 := by
-  simp []
-
-private lemma sqrtTwo_inv_mul :
-    ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹) * ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹) = 2⁻¹ := by
-  rw [← mul_inv, ← sq, sqrtTwo_sq]
-
-/-- The `SL(2,ℂ)` rotation carrying the `z`-axis to the `x`-axis. -/
-noncomputable def rotZX : SL(2,ℂ) :=
-  ⟨(((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, -1; 1, 1], by
-    rw [Matrix.det_smul, Matrix.det_fin_two_of, Fintype.card_fin, inv_pow, sqrtTwo_sq]
-    norm_num⟩
-
-/-- The `SL(2,ℂ)` rotation carrying the `z`-axis to the `y`-axis. -/
-noncomputable def rotZY : SL(2,ℂ) :=
-  ⟨(((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, Complex.I; Complex.I, 1], by
-    rw [Matrix.det_smul, Matrix.det_fin_two_of, Fintype.card_fin, inv_pow, sqrtTwo_sq,
-      Complex.I_mul_I]
-    norm_num⟩
-
-set_option backward.isDefEq.respectTransparency false in
-/-- The `x`-axis boost is obtained by conjugating the `z`-axis boost by `rotZX`. -/
-lemma boostAxis_zero_eq_conj (t : ℝ) (ht : t ≠ 0) :
-    boostAxis 0 t ht = rotZX * boostAxis 2 t ht * rotZX⁻¹ := by
-  have h0 := sqrtTwo_ne_zero
-  have hc := sqrtTwo_inv_mul
-  have htc : ((t : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
-  refine Subtype.ext ?_
-  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
-  ext i j
-  fin_cases i <;> fin_cases j <;>
-    · simp [Matrix.SpecialLinearGroup.coe_mul, rotZX, boostAxis,
-        Matrix.mul_apply, Fin.sum_univ_two]
-      field_simp
-      simp only [sqrtTwo_sq]
-      try ring
-
-set_option backward.isDefEq.respectTransparency false in
-/-- The `y`-axis boost is obtained by conjugating the `z`-axis boost by `rotZY`. -/
-lemma boostAxis_one_eq_conj (t : ℝ) (ht : t ≠ 0) :
-    boostAxis 1 t ht = rotZY * boostAxis 2 t ht * rotZY⁻¹ := by
-  have h0 := sqrtTwo_ne_zero
-  have hc := sqrtTwo_inv_mul
-  have htc : ((t : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
-  refine Subtype.ext ?_
-  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
-  ext i j
-  fin_cases i <;> fin_cases j <;>
-    · simp [Matrix.SpecialLinearGroup.coe_mul, rotZY, boostAxis,
-        Matrix.mul_apply, Fin.sum_univ_two]
-      field_simp
-      simp only [sqrtTwo_sq, Complex.I_sq]
-      try ring
+/-- Every axis boost is obtained by conjugating the `z`-axis boost by `rotationZToAxis`. -/
+lemma boostAxis_eq_conj (i : Fin 3) (t : ℝ) (ht : t ≠ 0) :
+    boostAxis i t ht =
+      rotationZToAxis i * boostAxis 2 t ht * (rotationZToAxis i)⁻¹ := by
+  fin_cases i
+  · refine Subtype.ext ?_
+    change !![((t : ℂ) + (t : ℂ)⁻¹) / 2, ((t : ℂ) - (t : ℂ)⁻¹) / 2;
+        ((t : ℂ) - (t : ℂ)⁻¹) / 2, ((t : ℂ) + (t : ℂ)⁻¹) / 2] =
+      (rotationZToAxis 0).1 * !![(t : ℂ), 0; 0, (t : ℂ)⁻¹] *
+        ((rotationZToAxis 0)⁻¹).1
+    rw [rotationZToAxis_mul_diagonal_mul_inv]
+  · refine Subtype.ext ?_
+    change !![((t : ℂ) + (t : ℂ)⁻¹) / 2,
+        -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2;
+        Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2,
+        ((t : ℂ) + (t : ℂ)⁻¹) / 2] =
+      (rotationZToAxis 1).1 * !![(t : ℂ), 0; 0, (t : ℂ)⁻¹] *
+        ((rotationZToAxis 1)⁻¹).1
+    rw [rotationZToAxis_mul_diagonal_mul_inv]
+  · refine Subtype.ext ?_
+    change !![(t : ℂ), 0; 0, (t : ℂ)⁻¹] =
+      (rotationZToAxis 2).1 * !![(t : ℂ), 0; 0, (t : ℂ)⁻¹] *
+        ((rotationZToAxis 2)⁻¹).1
+    rw [rotationZToAxis_mul_diagonal_mul_inv]
 
 /-- Every coordinate-axis boost is conjugate to the `z`-axis boost. -/
 lemma exists_conj_boostAxis (i : Fin 3) :
     ∃ R : SL(2,ℂ), ∀ (t : ℝ) (ht : t ≠ 0),
       boostAxis i t ht = R * boostAxis 2 t ht * R⁻¹ := by
-  fin_cases i
-  · exact ⟨rotZX, fun t ht => boostAxis_zero_eq_conj t ht⟩
-  · exact ⟨rotZY, fun t ht => boostAxis_one_eq_conj t ht⟩
-  · exact ⟨1, fun t ht => by simp⟩
+  exact ⟨rotationZToAxis i, fun t ht => boostAxis_eq_conj i t ht⟩
 
 end Lorentz.SL2C
 

--- a/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joseph Tooby-Smith
+Authors: Jinzheng Li, Nathaneal Sajan, Joseph Tooby-Smith
 -/
 module
 

--- a/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
@@ -1,0 +1,372 @@
+/-
+Copyright (c) 2026 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+module
+
+public import Physlib.Relativity.SL2C.Basic
+public import Physlib.Relativity.PauliMatrices.Basic
+public import Physlib.Relativity.MinkowskiMatrix
+/-!
+# Coordinate-axis boosts in `SL(2,ℂ)`
+
+## i. Overview
+
+We define explicit elements `boostZel`, `boostXel`, and `boostYel` of `SL(2,ℂ)`
+representing boosts along the three coordinate axes. We also prove that their images under
+`Lorentz.SL2C.toLorentzGroup` are the corresponding explicit Lorentz matrices.
+
+The parameter `t ≠ 0` is multiplicative: replacing `t` by `t⁻¹` reverses the boost. For
+`t > 0`, its rapidity is `2 * log t`; negative values retain the action of the central
+element `-1 : SL(2,ℂ)`.
+
+The three lifts are Hermitian, and the `x`- and `y`-axis lifts are conjugates of the
+diagonal `z`-axis lift.
+
+The index `Sum.inl 0` is the time coordinate, while `Sum.inr 0`, `Sum.inr 1`, and
+`Sum.inr 2` are the `x`, `y`, and `z` coordinates. Accordingly, `boostAxis 0`,
+`boostAxis 1`, and `boostAxis 2` select the `x`-, `y`-, and `z`-axis lifts. The covering
+map uses the action `X ↦ M X Mᴴ` on self-adjoint matrices.
+
+## ii. Key results
+
+- `boostZel`, `boostXel`, and `boostYel` define the three axis-boost lifts.
+- `toLorentzGroup_boostZel`, `toLorentzGroup_boostXel`, and `toLorentzGroup_boostYel`
+  identify their Lorentz matrices.
+- `boostZel_inv`, `boostXel_inv`, and `boostYel_inv` identify their inverses.
+- `boostAxis` packages the three families using a spatial-axis index.
+- `exists_conj_boostAxis` proves that every axis boost is conjugate to the `z`-boost.
+
+## iii. Table of contents
+
+- A. The axis-boost lifts
+- B. Their Lorentz matrices
+- C. Their inverses
+- D. Axis indexing and conjugation
+
+-/
+
+@[expose] public section
+
+namespace Lorentz
+
+open scoped minkowskiMatrix PauliMatrix
+open Matrix MatrixGroups
+
+/-!
+
+## A. The axis-boost lifts
+
+The `z`-axis lift is diagonal. The `x`- and `y`-axis lifts are the same family expressed in
+bases rotated toward the corresponding spatial axes.
+
+-/
+
+
+/-- The diagonal `SL(2,ℂ)` lift of the `z`-axis boost. For `t > 0`, its rapidity is
+`2 * log t`; replacing `t` by `t⁻¹` reverses the boost. -/
+noncomputable def boostZel (t : ℝ) (ht : t ≠ 0) : SL(2,ℂ) :=
+  ⟨!![(t : ℂ), 0; 0, (t : ℂ)⁻¹], by
+    have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+    rw [Matrix.det_fin_two_of]
+    simp [mul_inv_cancel₀ htc]⟩
+
+/-- The `SL(2,ℂ)` lift of the `x`-axis boost, obtained from the `z`-axis family by rotation. -/
+noncomputable def boostXel (t : ℝ) (ht : t ≠ 0) : SL(2,ℂ) :=
+  ⟨!![((t : ℂ) + (t : ℂ)⁻¹)/2, ((t : ℂ) - (t : ℂ)⁻¹)/2;
+      ((t : ℂ) - (t : ℂ)⁻¹)/2, ((t : ℂ) + (t : ℂ)⁻¹)/2], by
+    have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+    rw [Matrix.det_fin_two_of]
+    field_simp
+    ring⟩
+
+/-- The `SL(2,ℂ)` lift of the `y`-axis boost, obtained from the `z`-axis family by rotation. -/
+noncomputable def boostYel (t : ℝ) (ht : t ≠ 0) : SL(2,ℂ) :=
+  ⟨!![((t : ℂ) + (t : ℂ)⁻¹)/2, -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹)/2;
+      Complex.I * ((t : ℂ) - (t : ℂ)⁻¹)/2, ((t : ℂ) + (t : ℂ)⁻¹)/2], by
+    have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+    have h2 : -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2 *
+        (Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2) =
+        ((t : ℂ) - (t : ℂ)⁻¹) / 2 * (((t : ℂ) - (t : ℂ)⁻¹) / 2) := by
+      have hI : -Complex.I * Complex.I = 1 := by
+        rw [neg_mul, Complex.I_mul_I, neg_neg]
+      calc -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2 *
+            (Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2)
+          = (-Complex.I * Complex.I) *
+              (((t : ℂ) - (t : ℂ)⁻¹) / 2 * (((t : ℂ) - (t : ℂ)⁻¹) / 2)) := by
+            ring
+        _ = ((t : ℂ) - (t : ℂ)⁻¹) / 2 * (((t : ℂ) - (t : ℂ)⁻¹) / 2) := by
+            rw [hI, one_mul]
+    rw [Matrix.det_fin_two_of, h2]
+    field_simp
+    ring⟩
+
+/-!
+
+## B. Their Lorentz matrices
+
+The following definitions give the explicit Lorentz matrices of the three lifts. Their
+identification with the images under `Lorentz.SL2C.toLorentzGroup` uses Hermiticity and the
+trace pairing with the covariant Pauli basis.
+
+-/
+
+/-- The Lorentz matrix of `boostZel t`, mixing the time and `z` coordinates. -/
+noncomputable def boostMatZ (t : ℝ) : (Fin 1 ⊕ Fin 3) → (Fin 1 ⊕ Fin 3) → ℝ
+  | Sum.inl _, Sum.inl _ => (t^2 + (t⁻¹)^2)/2
+  | Sum.inl _, Sum.inr 2 => -((t^2 - (t⁻¹)^2)/2)
+  | Sum.inr 2, Sum.inl _ => -((t^2 - (t⁻¹)^2)/2)
+  | Sum.inr 0, Sum.inr 0 => 1
+  | Sum.inr 1, Sum.inr 1 => 1
+  | Sum.inr 2, Sum.inr 2 => (t^2 + (t⁻¹)^2)/2
+  | _, _ => 0
+
+/-- The Lorentz matrix of `boostXel t`, mixing the time and `x` coordinates. -/
+noncomputable def boostMatX (t : ℝ) : (Fin 1 ⊕ Fin 3) → (Fin 1 ⊕ Fin 3) → ℝ
+  | Sum.inl _, Sum.inl _ => (t^2 + (t⁻¹)^2)/2
+  | Sum.inl _, Sum.inr 0 => -((t^2 - (t⁻¹)^2)/2)
+  | Sum.inr 0, Sum.inl _ => -((t^2 - (t⁻¹)^2)/2)
+  | Sum.inr 0, Sum.inr 0 => (t^2 + (t⁻¹)^2)/2
+  | Sum.inr 1, Sum.inr 1 => 1
+  | Sum.inr 2, Sum.inr 2 => 1
+  | _, _ => 0
+
+/-- The Lorentz matrix of `boostYel t`, mixing the time and `y` coordinates. -/
+noncomputable def boostMatY (t : ℝ) : (Fin 1 ⊕ Fin 3) → (Fin 1 ⊕ Fin 3) → ℝ
+  | Sum.inl _, Sum.inl _ => (t^2 + (t⁻¹)^2)/2
+  | Sum.inl _, Sum.inr 1 => -((t^2 - (t⁻¹)^2)/2)
+  | Sum.inr 1, Sum.inl _ => -((t^2 - (t⁻¹)^2)/2)
+  | Sum.inr 0, Sum.inr 0 => 1
+  | Sum.inr 1, Sum.inr 1 => (t^2 + (t⁻¹)^2)/2
+  | Sum.inr 2, Sum.inr 2 => 1
+  | _, _ => 0
+
+/-- The underlying matrix of the `z`-axis boost lift is Hermitian. -/
+lemma boostZel_conjTranspose (t : ℝ) (ht : t ≠ 0) :
+    (boostZel t ht).1ᴴ = (boostZel t ht).1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [boostZel]
+
+/-- The underlying matrix of the `x`-axis boost lift is Hermitian. -/
+lemma boostXel_conjTranspose (t : ℝ) (ht : t ≠ 0) :
+    (boostXel t ht).1ᴴ = (boostXel t ht).1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [boostXel]
+
+/-- The underlying matrix of the `y`-axis boost lift is Hermitian. -/
+lemma boostYel_conjTranspose (t : ℝ) (ht : t ≠ 0) :
+    (boostYel t ht).1ᴴ = (boostYel t ht).1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [boostYel]
+
+/-- The image of `boostZel t` under `toLorentzGroup` is `boostMatZ t`. -/
+lemma toLorentzGroup_boostZel (t : ℝ) (ht : t ≠ 0) (a b : Fin 1 ⊕ Fin 3) :
+    (Lorentz.SL2C.toLorentzGroup (boostZel t ht)).1 a b = boostMatZ t a b := by
+  have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+  refine Complex.ofReal_injective ?_
+  rw [Lorentz.SL2C.toLorentzGroup_eq_trace,
+    PauliMatrix.trace_pauliSelfAdjoint'_mul_apply, boostZel_conjTranspose]
+  rcases a with a | a <;> rcases b with b | b <;> fin_cases a <;> fin_cases b <;>
+    simp [boostZel, boostMatZ, PauliMatrix.pauliSelfAdjoint', PauliMatrix.pauliMatrix,
+      Matrix.mul_apply, Fin.sum_univ_two] <;>
+    field_simp <;>
+    ring_nf
+  all_goals simp only [Complex.I_sq]
+  all_goals ring
+
+/-- The image of `boostXel t` under `toLorentzGroup` is `boostMatX t`. -/
+lemma toLorentzGroup_boostXel (t : ℝ) (ht : t ≠ 0) (a b : Fin 1 ⊕ Fin 3) :
+    (Lorentz.SL2C.toLorentzGroup (boostXel t ht)).1 a b = boostMatX t a b := by
+  have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+  refine Complex.ofReal_injective ?_
+  rw [Lorentz.SL2C.toLorentzGroup_eq_trace,
+    PauliMatrix.trace_pauliSelfAdjoint'_mul_apply, boostXel_conjTranspose]
+  rcases a with a | a <;> rcases b with b | b <;> fin_cases a <;> fin_cases b <;>
+    simp [boostXel, boostMatX, PauliMatrix.pauliSelfAdjoint', PauliMatrix.pauliMatrix,
+      Matrix.mul_apply, Fin.sum_univ_two] <;>
+    field_simp <;>
+    ring_nf
+  all_goals simp only [Complex.I_sq]
+  all_goals ring
+
+/-- The image of `boostYel t` under `toLorentzGroup` is `boostMatY t`. -/
+lemma toLorentzGroup_boostYel (t : ℝ) (ht : t ≠ 0) (a b : Fin 1 ⊕ Fin 3) :
+    (Lorentz.SL2C.toLorentzGroup (boostYel t ht)).1 a b = boostMatY t a b := by
+  have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+  refine Complex.ofReal_injective ?_
+  rw [Lorentz.SL2C.toLorentzGroup_eq_trace,
+    PauliMatrix.trace_pauliSelfAdjoint'_mul_apply, boostYel_conjTranspose]
+  rcases a with a | a <;> rcases b with b | b <;> fin_cases a <;> fin_cases b <;>
+    simp [boostYel, boostMatY, PauliMatrix.pauliSelfAdjoint', PauliMatrix.pauliMatrix,
+      Matrix.mul_apply, Fin.sum_univ_two] <;>
+    field_simp <;>
+    ring_nf
+  all_goals simp only [Complex.I_sq, Complex.I_pow_four]
+  all_goals ring
+
+
+/-!
+
+## C. Their inverses
+
+Replacing the multiplicative parameter `t` by `t⁻¹` reverses an axis boost. We record this
+both at the level of the boost families and through their explicit matrix entries.
+
+-/
+
+/-- Inverting the `z`-axis boost replaces `t` by `t⁻¹`. -/
+lemma boostZel_inv (t : ℝ) (ht : t ≠ 0) :
+    (boostZel t ht)⁻¹ = boostZel t⁻¹ (inv_ne_zero ht) := by
+  ext i j
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  fin_cases i <;> fin_cases j <;>
+    simp [boostZel, Complex.ofReal_inv, inv_inv]
+
+/-- Inverting the `x`-axis boost replaces `t` by `t⁻¹`. -/
+lemma boostXel_inv (t : ℝ) (ht : t ≠ 0) :
+    (boostXel t ht)⁻¹ = boostXel t⁻¹ (inv_ne_zero ht) := by
+  ext i j
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  fin_cases i <;> fin_cases j <;>
+    · simp [boostXel, Complex.ofReal_inv, inv_inv]
+      try ring
+
+/-- Inverting the `y`-axis boost replaces `t` by `t⁻¹`. -/
+lemma boostYel_inv (t : ℝ) (ht : t ≠ 0) :
+    (boostYel t ht)⁻¹ = boostYel t⁻¹ (inv_ne_zero ht) := by
+  ext i j
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  fin_cases i <;> fin_cases j <;>
+    · simp [boostYel, Complex.ofReal_inv, inv_inv]
+      try ring
+
+
+/-- The inverse of the parametric `z`-boost, entrywise, with real entries. -/
+lemma boostZel_inv_coe (t : ℝ) (ht : t ≠ 0) :
+    ((boostZel t ht)⁻¹ : SL(2,ℂ)).1 =
+      !![(((t⁻¹ : ℝ)) : ℂ), 0; 0, ((t : ℝ) : ℂ)] := by
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [boostZel]
+
+/-- The inverse of the parametric `x`-boost, entrywise. -/
+lemma boostXel_inv_coe (t : ℝ) (ht : t ≠ 0) :
+    ((boostXel t ht)⁻¹ : SL(2,ℂ)).1 =
+      !![((t : ℂ) + (t : ℂ)⁻¹)/2, -(((t : ℂ) - (t : ℂ)⁻¹)/2);
+         -(((t : ℂ) - (t : ℂ)⁻¹)/2), ((t : ℂ) + (t : ℂ)⁻¹)/2] := by
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [boostXel]
+
+/-- The inverse of the parametric `y`-boost, entrywise. -/
+lemma boostYel_inv_coe (t : ℝ) (ht : t ≠ 0) :
+    ((boostYel t ht)⁻¹ : SL(2,ℂ)).1 =
+      !![((t : ℂ) + (t : ℂ)⁻¹)/2, Complex.I * ((t : ℂ) - (t : ℂ)⁻¹)/2;
+         -(Complex.I * ((t : ℂ) - (t : ℂ)⁻¹)/2), ((t : ℂ) + (t : ℂ)⁻¹)/2] := by
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  ext i j
+  fin_cases i <;> fin_cases j <;> · simp [boostYel]; try ring
+
+/-!
+
+## D. Axis indexing and conjugation
+
+The three families are packaged into one axis-indexed construction. Explicit rotations show
+that the `x`- and `y`-axis boosts are conjugates of the diagonal `z`-axis boost.
+
+-/
+
+/-- The axis-indexed boost lift, with `0 = x`, `1 = y`, and `2 = z`. -/
+noncomputable def boostAxis : Fin 3 → (t : ℝ) → t ≠ 0 → SL(2,ℂ)
+  | 0, t, ht => boostXel t ht
+  | 1, t, ht => boostYel t ht
+  | 2, t, ht => boostZel t ht
+
+/-- The axis-indexed boost along axis `0` is the `x`-axis boost. -/
+@[simp] lemma boostAxis_zero (t : ℝ) (ht : t ≠ 0) : boostAxis 0 t ht = boostXel t ht := rfl
+
+/-- The axis-indexed boost along axis `1` is the `y`-axis boost. -/
+@[simp] lemma boostAxis_one (t : ℝ) (ht : t ≠ 0) : boostAxis 1 t ht = boostYel t ht := rfl
+
+/-- The axis-indexed boost along axis `2` is the `z`-axis boost. -/
+@[simp] lemma boostAxis_two (t : ℝ) (ht : t ≠ 0) : boostAxis 2 t ht = boostZel t ht := rfl
+
+/-- Inverting an axis-indexed boost replaces `t` by `t⁻¹`. -/
+lemma boostAxis_inv (i : Fin 3) (t : ℝ) (ht : t ≠ 0) :
+    (boostAxis i t ht)⁻¹ = boostAxis i t⁻¹ (inv_ne_zero ht) := by
+  fin_cases i
+  · exact boostXel_inv t ht
+  · exact boostYel_inv t ht
+  · exact boostZel_inv t ht
+
+private lemma sqrtTwo_sq : (((Real.sqrt 2 : ℝ) : ℂ)) ^ 2 = 2 := by
+  rw [← Complex.ofReal_pow, Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 2)]
+  norm_num
+
+private lemma sqrtTwo_ne_zero : (((Real.sqrt 2 : ℝ) : ℂ)) ≠ 0 := by
+  simp []
+
+private lemma sqrtTwo_inv_mul :
+    ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹) * ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹) = 2⁻¹ := by
+  rw [← mul_inv, ← sq, sqrtTwo_sq]
+
+/-- The `SL(2,ℂ)` rotation carrying the `z`-axis to the `x`-axis. -/
+noncomputable def rotZX : SL(2,ℂ) :=
+  ⟨(((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, -1; 1, 1], by
+    rw [Matrix.det_smul, Matrix.det_fin_two_of, Fintype.card_fin, inv_pow, sqrtTwo_sq]
+    norm_num⟩
+
+/-- The `SL(2,ℂ)` rotation carrying the `z`-axis to the `y`-axis. -/
+noncomputable def rotZY : SL(2,ℂ) :=
+  ⟨(((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, Complex.I; Complex.I, 1], by
+    rw [Matrix.det_smul, Matrix.det_fin_two_of, Fintype.card_fin, inv_pow, sqrtTwo_sq,
+      Complex.I_mul_I]
+    norm_num⟩
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The `x`-axis boost is obtained by conjugating the `z`-axis boost by `rotZX`. -/
+lemma boostXel_eq_conj (t : ℝ) (ht : t ≠ 0) :
+    boostXel t ht = rotZX * boostZel t ht * rotZX⁻¹ := by
+  have h0 := sqrtTwo_ne_zero
+  have hc := sqrtTwo_inv_mul
+  have htc : ((t : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+  refine Subtype.ext ?_
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    · simp [Matrix.SpecialLinearGroup.coe_mul, rotZX, boostZel, boostXel,
+        Matrix.mul_apply, Fin.sum_univ_two]
+      field_simp
+      simp only [sqrtTwo_sq]
+      try ring
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The `y`-axis boost is obtained by conjugating the `z`-axis boost by `rotZY`. -/
+lemma boostYel_eq_conj (t : ℝ) (ht : t ≠ 0) :
+    boostYel t ht = rotZY * boostZel t ht * rotZY⁻¹ := by
+  have h0 := sqrtTwo_ne_zero
+  have hc := sqrtTwo_inv_mul
+  have htc : ((t : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+  refine Subtype.ext ?_
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    · simp [Matrix.SpecialLinearGroup.coe_mul, rotZY, boostZel, boostYel,
+        Matrix.mul_apply, Fin.sum_univ_two]
+      field_simp
+      simp only [sqrtTwo_sq, Complex.I_sq]
+      try ring
+
+/-- Every coordinate-axis boost is conjugate to the `z`-axis boost. -/
+lemma exists_conj_boostAxis (i : Fin 3) :
+    ∃ R : SL(2,ℂ), ∀ (t : ℝ) (ht : t ≠ 0),
+      boostAxis i t ht = R * boostAxis 2 t ht * R⁻¹ := by
+  fin_cases i
+  · exact ⟨rotZX, fun t ht => boostXel_eq_conj t ht⟩
+  · exact ⟨rotZY, fun t ht => boostYel_eq_conj t ht⟩
+  · exact ⟨1, fun t ht => by simp⟩
+
+end Lorentz
+
+end

--- a/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
@@ -41,8 +41,8 @@ The index `Sum.inl 0` is the time coordinate, while `Sum.inr 0`, `Sum.inr 1`, an
 ## iii. Table of contents
 
 - A. The axis-boost lift
-- B. The induced Lorentz transformation
-- C. Axis conjugation
+- B. Axis conjugation
+- C. The induced Lorentz transformation
 
 -/
 
@@ -136,50 +136,9 @@ lemma boostAxis_conjTranspose (i : Fin 3) (t : ℝ) (ht : t ≠ 0) :
     (boostAxis i t ht).1ᴴ = (boostAxis i t ht).1 := by
   fin_cases i <;> ext j k <;> fin_cases j <;> fin_cases k <;> simp [boostAxis]
 
-end Lorentz.SL2C
-
-namespace LorentzGroup
-
 /-!
 
-## B. The induced Lorentz transformation
-
--/
-
-/-- The Lorentz transformation induced by the multiplicatively parameterized `SL(2,ℂ)` boost
-along spatial axis `i`. -/
-noncomputable def boostAxis (i : Fin 3) (t : ℝ) (ht : t ≠ 0) : LorentzGroup 3 :=
-  Lorentz.SL2C.toLorentzGroup (Lorentz.SL2C.boostAxis i t ht)
-
-/-- The entries of an axis boost in the Lorentz group. -/
-lemma boostAxis_apply (i : Fin 3) (t : ℝ) (ht : t ≠ 0) (a b : Fin 1 ⊕ Fin 3) :
-    (boostAxis i t ht).1 a b =
-      if a = Sum.inl 0 ∧ b = Sum.inl 0 then (t ^ 2 + (t⁻¹) ^ 2) / 2
-      else if a = Sum.inl 0 ∧ b = Sum.inr i then -((t ^ 2 - (t⁻¹) ^ 2) / 2)
-      else if a = Sum.inr i ∧ b = Sum.inl 0 then -((t ^ 2 - (t⁻¹) ^ 2) / 2)
-      else if a = Sum.inr i ∧ b = Sum.inr i then (t ^ 2 + (t⁻¹) ^ 2) / 2
-      else if a = b then 1 else 0 := by
-  have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
-  refine Complex.ofReal_injective ?_
-  rw [boostAxis, Lorentz.SL2C.toLorentzGroup_eq_trace,
-    PauliMatrix.trace_pauliSelfAdjoint'_mul_apply, Lorentz.SL2C.boostAxis_conjTranspose]
-  fin_cases i
-  all_goals
-    rcases a with a | a <;> rcases b with b | b <;> fin_cases a <;> fin_cases b <;>
-      simp [Lorentz.SL2C.boostAxis, PauliMatrix.pauliSelfAdjoint', PauliMatrix.pauliMatrix,
-        Matrix.mul_apply, Fin.sum_univ_two] <;>
-      field_simp <;>
-      ring_nf
-  all_goals simp only [Complex.I_sq, Complex.I_pow_four]
-  all_goals ring
-
-end LorentzGroup
-
-namespace Lorentz.SL2C
-
-/-!
-
-## C. Axis conjugation
+## B. Axis conjugation
 
 -/
 
@@ -215,5 +174,42 @@ lemma exists_conj_boostAxis (i : Fin 3) :
   exact ⟨rotationZToAxis i, fun t ht => boostAxis_eq_conj i t ht⟩
 
 end Lorentz.SL2C
+
+namespace LorentzGroup
+
+/-!
+
+## C. The induced Lorentz transformation
+
+-/
+
+/-- The Lorentz transformation induced by the multiplicatively parameterized `SL(2,ℂ)` boost
+along spatial axis `i`. -/
+noncomputable def boostAxis (i : Fin 3) (t : ℝ) (ht : t ≠ 0) : LorentzGroup 3 :=
+  Lorentz.SL2C.toLorentzGroup (Lorentz.SL2C.boostAxis i t ht)
+
+/-- The entries of an axis boost in the Lorentz group. -/
+lemma boostAxis_apply (i : Fin 3) (t : ℝ) (ht : t ≠ 0) (a b : Fin 1 ⊕ Fin 3) :
+    (boostAxis i t ht).1 a b =
+      if a = Sum.inl 0 ∧ b = Sum.inl 0 then (t ^ 2 + (t⁻¹) ^ 2) / 2
+      else if a = Sum.inl 0 ∧ b = Sum.inr i then -((t ^ 2 - (t⁻¹) ^ 2) / 2)
+      else if a = Sum.inr i ∧ b = Sum.inl 0 then -((t ^ 2 - (t⁻¹) ^ 2) / 2)
+      else if a = Sum.inr i ∧ b = Sum.inr i then (t ^ 2 + (t⁻¹) ^ 2) / 2
+      else if a = b then 1 else 0 := by
+  have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+  refine Complex.ofReal_injective ?_
+  rw [boostAxis, Lorentz.SL2C.toLorentzGroup_eq_trace,
+    PauliMatrix.trace_pauliSelfAdjoint'_mul_apply, Lorentz.SL2C.boostAxis_conjTranspose]
+  fin_cases i
+  all_goals
+    rcases a with a | a <;> rcases b with b | b <;> fin_cases a <;> fin_cases b <;>
+      simp [Lorentz.SL2C.boostAxis, PauliMatrix.pauliSelfAdjoint', PauliMatrix.pauliMatrix,
+        Matrix.mul_apply, Fin.sum_univ_two] <;>
+      field_simp <;>
+      ring_nf
+  all_goals simp only [Complex.I_sq, Complex.I_pow_four]
+  all_goals ring
+
+end LorentzGroup
 
 end

--- a/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
@@ -188,7 +188,7 @@ lemma boostAxis_eq_conj (i : Fin 3) (t : ℝ) (ht : t ≠ 0) :
         ((t : ℂ) - (t : ℂ)⁻¹) / 2, ((t : ℂ) + (t : ℂ)⁻¹) / 2] =
       (rotationZToAxis 0).1 * !![(t : ℂ), 0; 0, (t : ℂ)⁻¹] *
         ((rotationZToAxis 0)⁻¹).1
-    rw [rotationZToAxis_mul_diagonal_mul_inv]
+    rw [rotationZToAxis_zero_mul_diagonal_mul_inv]
   · refine Subtype.ext ?_
     change !![((t : ℂ) + (t : ℂ)⁻¹) / 2,
         -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2;
@@ -196,12 +196,12 @@ lemma boostAxis_eq_conj (i : Fin 3) (t : ℝ) (ht : t ≠ 0) :
         ((t : ℂ) + (t : ℂ)⁻¹) / 2] =
       (rotationZToAxis 1).1 * !![(t : ℂ), 0; 0, (t : ℂ)⁻¹] *
         ((rotationZToAxis 1)⁻¹).1
-    rw [rotationZToAxis_mul_diagonal_mul_inv]
+    rw [rotationZToAxis_one_mul_diagonal_mul_inv]
   · refine Subtype.ext ?_
     change !![(t : ℂ), 0; 0, (t : ℂ)⁻¹] =
       (rotationZToAxis 2).1 * !![(t : ℂ), 0; 0, (t : ℂ)⁻¹] *
         ((rotationZToAxis 2)⁻¹).1
-    rw [rotationZToAxis_mul_diagonal_mul_inv]
+    rw [rotationZToAxis_two_mul_diagonal_mul_inv]
 
 /-- Every coordinate-axis boost is conjugate to the `z`-axis boost. -/
 lemma exists_conj_boostAxis (i : Fin 3) :

--- a/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
@@ -21,6 +21,9 @@ The parameter `t ≠ 0` is multiplicative: replacing `t` by `t⁻¹` reverses th
 `t > 0`, its rapidity is `2 * log t`; negative values retain the action of the central
 element `-1 : SL(2,ℂ)`.
 
+For the `z`-axis, `boostMatZ t` agrees with the velocity-parameterized boost
+`LorentzGroup.boost 2 β` at `β = (t² - t⁻²) / (t² + t⁻²)`.
+
 The three lifts are Hermitian, and the `x`- and `y`-axis lifts are conjugates of the
 diagonal `z`-axis lift.
 

--- a/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
@@ -9,299 +9,183 @@ public import Physlib.Relativity.SL2C.Basic
 public import Physlib.Relativity.PauliMatrices.Basic
 public import Physlib.Relativity.MinkowskiMatrix
 /-!
-# Coordinate-axis boosts in `SL(2,ℂ)`
+# Coordinate-axis boosts in `SL(2,ℂ)` and the Lorentz group
 
 ## i. Overview
 
-We define explicit elements `boostZel`, `boostXel`, and `boostYel` of `SL(2,ℂ)`
-representing boosts along the three coordinate axes. We also prove that their images under
-`Lorentz.SL2C.toLorentzGroup` are the corresponding explicit Lorentz matrices.
+We define the axis-indexed lift `Lorentz.SL2C.boostAxis` in `SL(2,ℂ)` and its image
+`LorentzGroup.boostAxis` in the Lorentz group.
 
 The parameter `t ≠ 0` is multiplicative: replacing `t` by `t⁻¹` reverses the boost. For
 `t > 0`, its rapidity is `2 * log t`; negative values retain the action of the central
 element `-1 : SL(2,ℂ)`.
 
-For the `z`-axis, `boostMatZ t` agrees with the velocity-parameterized boost
+For the `z`-axis, `LorentzGroup.boostAxis 2 t ht` agrees with the velocity-parameterized boost
 `LorentzGroup.boost 2 β` at `β = (t² - t⁻²) / (t² + t⁻²)`.
 
-The three lifts are Hermitian, and the `x`- and `y`-axis lifts are conjugates of the
-diagonal `z`-axis lift.
+The lift is Hermitian along every axis, and the `x`- and `y`-axis lifts are conjugates of
+the diagonal `z`-axis lift.
 
 The index `Sum.inl 0` is the time coordinate, while `Sum.inr 0`, `Sum.inr 1`, and
-`Sum.inr 2` are the `x`, `y`, and `z` coordinates. Accordingly, `boostAxis 0`,
-`boostAxis 1`, and `boostAxis 2` select the `x`-, `y`-, and `z`-axis lifts. The covering
-map uses the action `X ↦ M X Mᴴ` on self-adjoint matrices.
+`Sum.inr 2` are the `x`, `y`, and `z` coordinates. Accordingly, axis indices `0`, `1`, and
+`2` select the `x`-, `y`-, and `z`-axis boosts. The covering map uses the action
+`X ↦ M X Mᴴ` on self-adjoint matrices.
 
 ## ii. Key results
 
-- `boostZel`, `boostXel`, and `boostYel` define the three axis-boost lifts.
-- `toLorentzGroup_boostZel`, `toLorentzGroup_boostXel`, and `toLorentzGroup_boostYel`
-  identify their Lorentz matrices.
-- `boostZel_inv`, `boostXel_inv`, and `boostYel_inv` identify their inverses.
-- `boostAxis` packages the three families using a spatial-axis index.
-- `exists_conj_boostAxis` proves that every axis boost is conjugate to the `z`-boost.
+- `Lorentz.SL2C.boostAxis` defines the axis-boost lifts.
+- `Lorentz.SL2C.boostAxis_inv` and `Lorentz.SL2C.boostAxis_conjTranspose` give their
+  inverses and Hermiticity.
+- `LorentzGroup.boostAxis` defines the induced Lorentz transformations, with entries given by
+  `LorentzGroup.boostAxis_apply`.
+- `Lorentz.SL2C.exists_conj_boostAxis` proves that every lift is conjugate to the `z`-boost.
 
 ## iii. Table of contents
 
-- A. The axis-boost lifts
-- B. Their Lorentz matrices
-- C. Their inverses
-- D. Axis indexing and conjugation
+- A. The axis-boost lift
+- B. The induced Lorentz transformation
+- C. Axis conjugation
 
 -/
 
 @[expose] public section
 
-namespace Lorentz
-
 open scoped minkowskiMatrix PauliMatrix
 open Matrix MatrixGroups
 
-/-!
-
-## A. The axis-boost lifts
-
-The `z`-axis lift is diagonal. The `x`- and `y`-axis lifts are the same family expressed in
-bases rotated toward the corresponding spatial axes.
-
--/
-
-
-/-- The diagonal `SL(2,ℂ)` lift of the `z`-axis boost. For `t > 0`, its rapidity is
-`2 * log t`; replacing `t` by `t⁻¹` reverses the boost. -/
-noncomputable def boostZel (t : ℝ) (ht : t ≠ 0) : SL(2,ℂ) :=
-  ⟨!![(t : ℂ), 0; 0, (t : ℂ)⁻¹], by
-    have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
-    rw [Matrix.det_fin_two_of]
-    simp [mul_inv_cancel₀ htc]⟩
-
-/-- The `SL(2,ℂ)` lift of the `x`-axis boost, obtained from the `z`-axis family by rotation. -/
-noncomputable def boostXel (t : ℝ) (ht : t ≠ 0) : SL(2,ℂ) :=
-  ⟨!![((t : ℂ) + (t : ℂ)⁻¹)/2, ((t : ℂ) - (t : ℂ)⁻¹)/2;
-      ((t : ℂ) - (t : ℂ)⁻¹)/2, ((t : ℂ) + (t : ℂ)⁻¹)/2], by
-    have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
-    rw [Matrix.det_fin_two_of]
-    field_simp
-    ring⟩
-
-/-- The `SL(2,ℂ)` lift of the `y`-axis boost, obtained from the `z`-axis family by rotation. -/
-noncomputable def boostYel (t : ℝ) (ht : t ≠ 0) : SL(2,ℂ) :=
-  ⟨!![((t : ℂ) + (t : ℂ)⁻¹)/2, -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹)/2;
-      Complex.I * ((t : ℂ) - (t : ℂ)⁻¹)/2, ((t : ℂ) + (t : ℂ)⁻¹)/2], by
-    have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
-    have h2 : -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2 *
-        (Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2) =
-        ((t : ℂ) - (t : ℂ)⁻¹) / 2 * (((t : ℂ) - (t : ℂ)⁻¹) / 2) := by
-      have hI : -Complex.I * Complex.I = 1 := by
-        rw [neg_mul, Complex.I_mul_I, neg_neg]
-      calc -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2 *
-            (Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2)
-          = (-Complex.I * Complex.I) *
-              (((t : ℂ) - (t : ℂ)⁻¹) / 2 * (((t : ℂ) - (t : ℂ)⁻¹) / 2)) := by
-            ring
-        _ = ((t : ℂ) - (t : ℂ)⁻¹) / 2 * (((t : ℂ) - (t : ℂ)⁻¹) / 2) := by
-            rw [hI, one_mul]
-    rw [Matrix.det_fin_two_of, h2]
-    field_simp
-    ring⟩
+namespace Lorentz.SL2C
 
 /-!
 
-## B. Their Lorentz matrices
-
-The following definitions give the explicit Lorentz matrices of the three lifts. Their
-identification with the images under `Lorentz.SL2C.toLorentzGroup` uses Hermiticity and the
-trace pairing with the covariant Pauli basis.
+## A. The axis-boost lift
 
 -/
 
-/-- The Lorentz matrix of `boostZel t`, mixing the time and `z` coordinates. -/
-noncomputable def boostMatZ (t : ℝ) : (Fin 1 ⊕ Fin 3) → (Fin 1 ⊕ Fin 3) → ℝ
-  | Sum.inl _, Sum.inl _ => (t^2 + (t⁻¹)^2)/2
-  | Sum.inl _, Sum.inr 2 => -((t^2 - (t⁻¹)^2)/2)
-  | Sum.inr 2, Sum.inl _ => -((t^2 - (t⁻¹)^2)/2)
-  | Sum.inr 0, Sum.inr 0 => 1
-  | Sum.inr 1, Sum.inr 1 => 1
-  | Sum.inr 2, Sum.inr 2 => (t^2 + (t⁻¹)^2)/2
-  | _, _ => 0
-
-/-- The Lorentz matrix of `boostXel t`, mixing the time and `x` coordinates. -/
-noncomputable def boostMatX (t : ℝ) : (Fin 1 ⊕ Fin 3) → (Fin 1 ⊕ Fin 3) → ℝ
-  | Sum.inl _, Sum.inl _ => (t^2 + (t⁻¹)^2)/2
-  | Sum.inl _, Sum.inr 0 => -((t^2 - (t⁻¹)^2)/2)
-  | Sum.inr 0, Sum.inl _ => -((t^2 - (t⁻¹)^2)/2)
-  | Sum.inr 0, Sum.inr 0 => (t^2 + (t⁻¹)^2)/2
-  | Sum.inr 1, Sum.inr 1 => 1
-  | Sum.inr 2, Sum.inr 2 => 1
-  | _, _ => 0
-
-/-- The Lorentz matrix of `boostYel t`, mixing the time and `y` coordinates. -/
-noncomputable def boostMatY (t : ℝ) : (Fin 1 ⊕ Fin 3) → (Fin 1 ⊕ Fin 3) → ℝ
-  | Sum.inl _, Sum.inl _ => (t^2 + (t⁻¹)^2)/2
-  | Sum.inl _, Sum.inr 1 => -((t^2 - (t⁻¹)^2)/2)
-  | Sum.inr 1, Sum.inl _ => -((t^2 - (t⁻¹)^2)/2)
-  | Sum.inr 0, Sum.inr 0 => 1
-  | Sum.inr 1, Sum.inr 1 => (t^2 + (t⁻¹)^2)/2
-  | Sum.inr 2, Sum.inr 2 => 1
-  | _, _ => 0
-
-/-- The underlying matrix of the `z`-axis boost lift is Hermitian. -/
-lemma boostZel_conjTranspose (t : ℝ) (ht : t ≠ 0) :
-    (boostZel t ht).1ᴴ = (boostZel t ht).1 := by
-  ext i j
-  fin_cases i <;> fin_cases j <;> simp [boostZel]
-
-/-- The underlying matrix of the `x`-axis boost lift is Hermitian. -/
-lemma boostXel_conjTranspose (t : ℝ) (ht : t ≠ 0) :
-    (boostXel t ht).1ᴴ = (boostXel t ht).1 := by
-  ext i j
-  fin_cases i <;> fin_cases j <;> simp [boostXel]
-
-/-- The underlying matrix of the `y`-axis boost lift is Hermitian. -/
-lemma boostYel_conjTranspose (t : ℝ) (ht : t ≠ 0) :
-    (boostYel t ht).1ᴴ = (boostYel t ht).1 := by
-  ext i j
-  fin_cases i <;> fin_cases j <;> simp [boostYel]
-
-/-- The image of `boostZel t` under `toLorentzGroup` is `boostMatZ t`. -/
-lemma toLorentzGroup_boostZel (t : ℝ) (ht : t ≠ 0) (a b : Fin 1 ⊕ Fin 3) :
-    (Lorentz.SL2C.toLorentzGroup (boostZel t ht)).1 a b = boostMatZ t a b := by
-  have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
-  refine Complex.ofReal_injective ?_
-  rw [Lorentz.SL2C.toLorentzGroup_eq_trace,
-    PauliMatrix.trace_pauliSelfAdjoint'_mul_apply, boostZel_conjTranspose]
-  rcases a with a | a <;> rcases b with b | b <;> fin_cases a <;> fin_cases b <;>
-    simp [boostZel, boostMatZ, PauliMatrix.pauliSelfAdjoint', PauliMatrix.pauliMatrix,
-      Matrix.mul_apply, Fin.sum_univ_two] <;>
-    field_simp <;>
-    ring_nf
-  all_goals simp only [Complex.I_sq]
-  all_goals ring
-
-/-- The image of `boostXel t` under `toLorentzGroup` is `boostMatX t`. -/
-lemma toLorentzGroup_boostXel (t : ℝ) (ht : t ≠ 0) (a b : Fin 1 ⊕ Fin 3) :
-    (Lorentz.SL2C.toLorentzGroup (boostXel t ht)).1 a b = boostMatX t a b := by
-  have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
-  refine Complex.ofReal_injective ?_
-  rw [Lorentz.SL2C.toLorentzGroup_eq_trace,
-    PauliMatrix.trace_pauliSelfAdjoint'_mul_apply, boostXel_conjTranspose]
-  rcases a with a | a <;> rcases b with b | b <;> fin_cases a <;> fin_cases b <;>
-    simp [boostXel, boostMatX, PauliMatrix.pauliSelfAdjoint', PauliMatrix.pauliMatrix,
-      Matrix.mul_apply, Fin.sum_univ_two] <;>
-    field_simp <;>
-    ring_nf
-  all_goals simp only [Complex.I_sq]
-  all_goals ring
-
-/-- The image of `boostYel t` under `toLorentzGroup` is `boostMatY t`. -/
-lemma toLorentzGroup_boostYel (t : ℝ) (ht : t ≠ 0) (a b : Fin 1 ⊕ Fin 3) :
-    (Lorentz.SL2C.toLorentzGroup (boostYel t ht)).1 a b = boostMatY t a b := by
-  have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
-  refine Complex.ofReal_injective ?_
-  rw [Lorentz.SL2C.toLorentzGroup_eq_trace,
-    PauliMatrix.trace_pauliSelfAdjoint'_mul_apply, boostYel_conjTranspose]
-  rcases a with a | a <;> rcases b with b | b <;> fin_cases a <;> fin_cases b <;>
-    simp [boostYel, boostMatY, PauliMatrix.pauliSelfAdjoint', PauliMatrix.pauliMatrix,
-      Matrix.mul_apply, Fin.sum_univ_two] <;>
-    field_simp <;>
-    ring_nf
-  all_goals simp only [Complex.I_sq, Complex.I_pow_four]
-  all_goals ring
-
-
-/-!
-
-## C. Their inverses
-
-Replacing the multiplicative parameter `t` by `t⁻¹` reverses an axis boost. We record this
-both at the level of the boost families and through their explicit matrix entries.
-
--/
-
-/-- Inverting the `z`-axis boost replaces `t` by `t⁻¹`. -/
-lemma boostZel_inv (t : ℝ) (ht : t ≠ 0) :
-    (boostZel t ht)⁻¹ = boostZel t⁻¹ (inv_ne_zero ht) := by
-  ext i j
-  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
-  fin_cases i <;> fin_cases j <;>
-    simp [boostZel, Complex.ofReal_inv, inv_inv]
-
-/-- Inverting the `x`-axis boost replaces `t` by `t⁻¹`. -/
-lemma boostXel_inv (t : ℝ) (ht : t ≠ 0) :
-    (boostXel t ht)⁻¹ = boostXel t⁻¹ (inv_ne_zero ht) := by
-  ext i j
-  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
-  fin_cases i <;> fin_cases j <;>
-    · simp [boostXel, Complex.ofReal_inv, inv_inv]
-      try ring
-
-/-- Inverting the `y`-axis boost replaces `t` by `t⁻¹`. -/
-lemma boostYel_inv (t : ℝ) (ht : t ≠ 0) :
-    (boostYel t ht)⁻¹ = boostYel t⁻¹ (inv_ne_zero ht) := by
-  ext i j
-  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
-  fin_cases i <;> fin_cases j <;>
-    · simp [boostYel, Complex.ofReal_inv, inv_inv]
-      try ring
-
-
-/-- The inverse of the parametric `z`-boost, entrywise, with real entries. -/
-lemma boostZel_inv_coe (t : ℝ) (ht : t ≠ 0) :
-    ((boostZel t ht)⁻¹ : SL(2,ℂ)).1 =
-      !![(((t⁻¹ : ℝ)) : ℂ), 0; 0, ((t : ℝ) : ℂ)] := by
-  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
-  ext i j
-  fin_cases i <;> fin_cases j <;> simp [boostZel]
-
-/-- The inverse of the parametric `x`-boost, entrywise. -/
-lemma boostXel_inv_coe (t : ℝ) (ht : t ≠ 0) :
-    ((boostXel t ht)⁻¹ : SL(2,ℂ)).1 =
-      !![((t : ℂ) + (t : ℂ)⁻¹)/2, -(((t : ℂ) - (t : ℂ)⁻¹)/2);
-         -(((t : ℂ) - (t : ℂ)⁻¹)/2), ((t : ℂ) + (t : ℂ)⁻¹)/2] := by
-  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
-  ext i j
-  fin_cases i <;> fin_cases j <;> simp [boostXel]
-
-/-- The inverse of the parametric `y`-boost, entrywise. -/
-lemma boostYel_inv_coe (t : ℝ) (ht : t ≠ 0) :
-    ((boostYel t ht)⁻¹ : SL(2,ℂ)).1 =
-      !![((t : ℂ) + (t : ℂ)⁻¹)/2, Complex.I * ((t : ℂ) - (t : ℂ)⁻¹)/2;
-         -(Complex.I * ((t : ℂ) - (t : ℂ)⁻¹)/2), ((t : ℂ) + (t : ℂ)⁻¹)/2] := by
-  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
-  ext i j
-  fin_cases i <;> fin_cases j <;> · simp [boostYel]; try ring
-
-/-!
-
-## D. Axis indexing and conjugation
-
-The three families are packaged into one axis-indexed construction. Explicit rotations show
-that the `x`- and `y`-axis boosts are conjugates of the diagonal `z`-axis boost.
-
--/
-
-/-- The axis-indexed boost lift, with `0 = x`, `1 = y`, and `2 = z`. -/
+/-- The `SL(2,ℂ)` lift of the boost along spatial axis `i`, with `0 = x`, `1 = y`, and
+`2 = z`. The parameter `t` is multiplicative, and for `t > 0` the rapidity is `2 * log t`. -/
 noncomputable def boostAxis : Fin 3 → (t : ℝ) → t ≠ 0 → SL(2,ℂ)
-  | 0, t, ht => boostXel t ht
-  | 1, t, ht => boostYel t ht
-  | 2, t, ht => boostZel t ht
+  | 0, t, ht =>
+      ⟨!![((t : ℂ) + (t : ℂ)⁻¹) / 2, ((t : ℂ) - (t : ℂ)⁻¹) / 2;
+          ((t : ℂ) - (t : ℂ)⁻¹) / 2, ((t : ℂ) + (t : ℂ)⁻¹) / 2], by
+        have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+        rw [Matrix.det_fin_two_of]
+        field_simp
+        ring⟩
+  | 1, t, ht =>
+      ⟨!![((t : ℂ) + (t : ℂ)⁻¹) / 2, -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2;
+          Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2, ((t : ℂ) + (t : ℂ)⁻¹) / 2], by
+        have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+        have h2 : -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2 *
+            (Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2) =
+            ((t : ℂ) - (t : ℂ)⁻¹) / 2 * (((t : ℂ) - (t : ℂ)⁻¹) / 2) := by
+          have hI : -Complex.I * Complex.I = 1 := by
+            rw [neg_mul, Complex.I_mul_I, neg_neg]
+          calc -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2 *
+                (Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2)
+              = (-Complex.I * Complex.I) *
+                  (((t : ℂ) - (t : ℂ)⁻¹) / 2 * (((t : ℂ) - (t : ℂ)⁻¹) / 2)) := by
+                ring
+            _ = ((t : ℂ) - (t : ℂ)⁻¹) / 2 * (((t : ℂ) - (t : ℂ)⁻¹) / 2) := by
+                rw [hI, one_mul]
+        rw [Matrix.det_fin_two_of, h2]
+        field_simp
+        ring⟩
+  | 2, t, ht =>
+      ⟨!![(t : ℂ), 0; 0, (t : ℂ)⁻¹], by
+        have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+        rw [Matrix.det_fin_two_of]
+        simp [mul_inv_cancel₀ htc]⟩
 
-/-- The axis-indexed boost along axis `0` is the `x`-axis boost. -/
-@[simp] lemma boostAxis_zero (t : ℝ) (ht : t ≠ 0) : boostAxis 0 t ht = boostXel t ht := rfl
-
-/-- The axis-indexed boost along axis `1` is the `y`-axis boost. -/
-@[simp] lemma boostAxis_one (t : ℝ) (ht : t ≠ 0) : boostAxis 1 t ht = boostYel t ht := rfl
-
-/-- The axis-indexed boost along axis `2` is the `z`-axis boost. -/
-@[simp] lemma boostAxis_two (t : ℝ) (ht : t ≠ 0) : boostAxis 2 t ht = boostZel t ht := rfl
-
-/-- Inverting an axis-indexed boost replaces `t` by `t⁻¹`. -/
+/-- Inverting an axis boost replaces its multiplicative parameter `t` by `t⁻¹`. -/
 lemma boostAxis_inv (i : Fin 3) (t : ℝ) (ht : t ≠ 0) :
     (boostAxis i t ht)⁻¹ = boostAxis i t⁻¹ (inv_ne_zero ht) := by
   fin_cases i
-  · exact boostXel_inv t ht
-  · exact boostYel_inv t ht
-  · exact boostZel_inv t ht
+  · ext j k
+    rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+    fin_cases j <;> fin_cases k <;>
+      · simp [boostAxis, Complex.ofReal_inv, inv_inv]
+        try ring
+  · ext j k
+    rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+    fin_cases j <;> fin_cases k <;>
+      · simp [boostAxis, Complex.ofReal_inv, inv_inv]
+        try ring
+  · ext j k
+    rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+    fin_cases j <;> fin_cases k <;>
+      simp [boostAxis, Complex.ofReal_inv, inv_inv]
+
+/-- The matrix underlying an axis-boost lift is Hermitian. -/
+lemma boostAxis_conjTranspose (i : Fin 3) (t : ℝ) (ht : t ≠ 0) :
+    (boostAxis i t ht).1ᴴ = (boostAxis i t ht).1 := by
+  fin_cases i <;> ext j k <;> fin_cases j <;> fin_cases k <;> simp [boostAxis]
+
+end Lorentz.SL2C
+
+namespace LorentzGroup
+
+/-!
+
+## B. The induced Lorentz transformation
+
+-/
+
+/-- The Lorentz transformation induced by the multiplicatively parameterized `SL(2,ℂ)` boost
+along spatial axis `i`. -/
+noncomputable def boostAxis (i : Fin 3) (t : ℝ) (ht : t ≠ 0) : LorentzGroup 3 :=
+  Lorentz.SL2C.toLorentzGroup (Lorentz.SL2C.boostAxis i t ht)
+
+/-- The entries of an axis boost in the Lorentz group. -/
+lemma boostAxis_apply (i : Fin 3) (t : ℝ) (ht : t ≠ 0) (a b : Fin 1 ⊕ Fin 3) :
+    (boostAxis i t ht).1 a b =
+      match i with
+      | 0 => match a, b with
+        | Sum.inl _, Sum.inl _ => (t ^ 2 + (t⁻¹) ^ 2) / 2
+        | Sum.inl _, Sum.inr 0 => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
+        | Sum.inr 0, Sum.inl _ => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
+        | Sum.inr 0, Sum.inr 0 => (t ^ 2 + (t⁻¹) ^ 2) / 2
+        | Sum.inr 1, Sum.inr 1 => 1
+        | Sum.inr 2, Sum.inr 2 => 1
+        | _, _ => 0
+      | 1 => match a, b with
+        | Sum.inl _, Sum.inl _ => (t ^ 2 + (t⁻¹) ^ 2) / 2
+        | Sum.inl _, Sum.inr 1 => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
+        | Sum.inr 1, Sum.inl _ => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
+        | Sum.inr 0, Sum.inr 0 => 1
+        | Sum.inr 1, Sum.inr 1 => (t ^ 2 + (t⁻¹) ^ 2) / 2
+        | Sum.inr 2, Sum.inr 2 => 1
+        | _, _ => 0
+      | 2 => match a, b with
+        | Sum.inl _, Sum.inl _ => (t ^ 2 + (t⁻¹) ^ 2) / 2
+        | Sum.inl _, Sum.inr 2 => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
+        | Sum.inr 2, Sum.inl _ => -((t ^ 2 - (t⁻¹) ^ 2) / 2)
+        | Sum.inr 0, Sum.inr 0 => 1
+        | Sum.inr 1, Sum.inr 1 => 1
+        | Sum.inr 2, Sum.inr 2 => (t ^ 2 + (t⁻¹) ^ 2) / 2
+        | _, _ => 0 := by
+  have htc : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
+  refine Complex.ofReal_injective ?_
+  rw [boostAxis, Lorentz.SL2C.toLorentzGroup_eq_trace,
+    PauliMatrix.trace_pauliSelfAdjoint'_mul_apply, Lorentz.SL2C.boostAxis_conjTranspose]
+  fin_cases i
+  all_goals
+    rcases a with a | a <;> rcases b with b | b <;> fin_cases a <;> fin_cases b <;>
+      simp [Lorentz.SL2C.boostAxis, PauliMatrix.pauliSelfAdjoint', PauliMatrix.pauliMatrix,
+        Matrix.mul_apply, Fin.sum_univ_two] <;>
+      field_simp <;>
+      ring_nf
+  all_goals simp only [Complex.I_sq, Complex.I_pow_four]
+  all_goals ring
+
+end LorentzGroup
+
+namespace Lorentz.SL2C
+
+/-!
+
+## C. Axis conjugation
+
+-/
 
 private lemma sqrtTwo_sq : (((Real.sqrt 2 : ℝ) : ℂ)) ^ 2 = 2 := by
   rw [← Complex.ofReal_pow, Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 2)]
@@ -329,8 +213,8 @@ noncomputable def rotZY : SL(2,ℂ) :=
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The `x`-axis boost is obtained by conjugating the `z`-axis boost by `rotZX`. -/
-lemma boostXel_eq_conj (t : ℝ) (ht : t ≠ 0) :
-    boostXel t ht = rotZX * boostZel t ht * rotZX⁻¹ := by
+lemma boostAxis_zero_eq_conj (t : ℝ) (ht : t ≠ 0) :
+    boostAxis 0 t ht = rotZX * boostAxis 2 t ht * rotZX⁻¹ := by
   have h0 := sqrtTwo_ne_zero
   have hc := sqrtTwo_inv_mul
   have htc : ((t : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
@@ -338,7 +222,7 @@ lemma boostXel_eq_conj (t : ℝ) (ht : t ≠ 0) :
   rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
   ext i j
   fin_cases i <;> fin_cases j <;>
-    · simp [Matrix.SpecialLinearGroup.coe_mul, rotZX, boostZel, boostXel,
+    · simp [Matrix.SpecialLinearGroup.coe_mul, rotZX, boostAxis,
         Matrix.mul_apply, Fin.sum_univ_two]
       field_simp
       simp only [sqrtTwo_sq]
@@ -346,8 +230,8 @@ lemma boostXel_eq_conj (t : ℝ) (ht : t ≠ 0) :
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The `y`-axis boost is obtained by conjugating the `z`-axis boost by `rotZY`. -/
-lemma boostYel_eq_conj (t : ℝ) (ht : t ≠ 0) :
-    boostYel t ht = rotZY * boostZel t ht * rotZY⁻¹ := by
+lemma boostAxis_one_eq_conj (t : ℝ) (ht : t ≠ 0) :
+    boostAxis 1 t ht = rotZY * boostAxis 2 t ht * rotZY⁻¹ := by
   have h0 := sqrtTwo_ne_zero
   have hc := sqrtTwo_inv_mul
   have htc : ((t : ℝ) : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
@@ -355,7 +239,7 @@ lemma boostYel_eq_conj (t : ℝ) (ht : t ≠ 0) :
   rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
   ext i j
   fin_cases i <;> fin_cases j <;>
-    · simp [Matrix.SpecialLinearGroup.coe_mul, rotZY, boostZel, boostYel,
+    · simp [Matrix.SpecialLinearGroup.coe_mul, rotZY, boostAxis,
         Matrix.mul_apply, Fin.sum_univ_two]
       field_simp
       simp only [sqrtTwo_sq, Complex.I_sq]
@@ -366,10 +250,10 @@ lemma exists_conj_boostAxis (i : Fin 3) :
     ∃ R : SL(2,ℂ), ∀ (t : ℝ) (ht : t ≠ 0),
       boostAxis i t ht = R * boostAxis 2 t ht * R⁻¹ := by
   fin_cases i
-  · exact ⟨rotZX, fun t ht => boostXel_eq_conj t ht⟩
-  · exact ⟨rotZY, fun t ht => boostYel_eq_conj t ht⟩
+  · exact ⟨rotZX, fun t ht => boostAxis_zero_eq_conj t ht⟩
+  · exact ⟨rotZY, fun t ht => boostAxis_one_eq_conj t ht⟩
   · exact ⟨1, fun t ht => by simp⟩
 
-end Lorentz
+end Lorentz.SL2C
 
 end

--- a/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
+++ b/Physlib/Relativity/LorentzGroup/Boosts/Axis.lean
@@ -94,18 +94,23 @@ noncomputable def boostAxis : Fin 3 → (t : ℝ) → t ≠ 0 → SL(2,ℂ)
         rw [Matrix.det_fin_two_of]
         simp [mul_inv_cancel₀ htc]⟩
 
-/-- The matrix entries of an `SL(2,ℂ)` axis-boost lift. -/
-@[simp] lemma boostAxis_apply (i : Fin 3) (t : ℝ) (ht : t ≠ 0) (j k : Fin 2) :
-    (boostAxis i t ht).1 j k =
-      match i with
-      | 0 => (!![((t : ℂ) + (t : ℂ)⁻¹) / 2, ((t : ℂ) - (t : ℂ)⁻¹) / 2;
-          ((t : ℂ) - (t : ℂ)⁻¹) / 2, ((t : ℂ) + (t : ℂ)⁻¹) / 2]) j k
-      | 1 => (!![((t : ℂ) + (t : ℂ)⁻¹) / 2,
-          -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2;
-          Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2,
-          ((t : ℂ) + (t : ℂ)⁻¹) / 2]) j k
-      | 2 => (!![(t : ℂ), 0; 0, (t : ℂ)⁻¹]) j k := by
-  fin_cases i <;> rfl
+/-- The matrix entries of the `SL(2,ℂ)` boost lift along the `x`-axis. -/
+@[simp] lemma boostAxis_zero_apply (t : ℝ) (ht : t ≠ 0) (j k : Fin 2) :
+    (boostAxis 0 t ht).1 j k =
+      (!![((t : ℂ) + (t : ℂ)⁻¹) / 2, ((t : ℂ) - (t : ℂ)⁻¹) / 2;
+        ((t : ℂ) - (t : ℂ)⁻¹) / 2, ((t : ℂ) + (t : ℂ)⁻¹) / 2]) j k := rfl
+
+/-- The matrix entries of the `SL(2,ℂ)` boost lift along the `y`-axis. -/
+@[simp] lemma boostAxis_one_apply (t : ℝ) (ht : t ≠ 0) (j k : Fin 2) :
+    (boostAxis 1 t ht).1 j k =
+      (!![((t : ℂ) + (t : ℂ)⁻¹) / 2,
+        -Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2;
+        Complex.I * ((t : ℂ) - (t : ℂ)⁻¹) / 2,
+        ((t : ℂ) + (t : ℂ)⁻¹) / 2]) j k := rfl
+
+/-- The matrix entries of the diagonal `SL(2,ℂ)` boost lift along the `z`-axis. -/
+@[simp] lemma boostAxis_two_apply (t : ℝ) (ht : t ≠ 0) (j k : Fin 2) :
+    (boostAxis 2 t ht).1 j k = (!![(t : ℂ), 0; 0, (t : ℂ)⁻¹]) j k := rfl
 
 /-- Inverting an axis boost replaces its multiplicative parameter `t` by `t⁻¹`. -/
 lemma boostAxis_inv (i : Fin 3) (t : ℝ) (ht : t ≠ 0) :

--- a/Physlib/Relativity/PauliMatrices/SelfAdjoint.lean
+++ b/Physlib/Relativity/PauliMatrices/SelfAdjoint.lean
@@ -278,6 +278,21 @@ lemma trace_pauliSelfAdjoint'_mul (a b : Fin 1 ⊕ Fin 3) :
       KroneckerDelta.kroneckerDelta] <;>
     simp
 
+/-- The trace pairing of a covariant Pauli matrix with an arbitrary matrix, expressed through the
+matrix entries. -/
+lemma trace_pauliSelfAdjoint'_mul_apply (l : Fin 1 ⊕ Fin 3)
+    (N : Matrix (Fin 2) (Fin 2) ℂ) :
+    Matrix.trace ((pauliSelfAdjoint' l).1 * N) =
+      match l with
+      | Sum.inl 0 => N 0 0 + N 1 1
+      | Sum.inr 0 => -(N 0 1 + N 1 0)
+      | Sum.inr 1 => -(Complex.I * (N 0 1 - N 1 0))
+      | Sum.inr 2 => -(N 0 0 - N 1 1) := by
+  rcases l with l | l <;> fin_cases l <;>
+    simp [pauliSelfAdjoint', pauliMatrix, Matrix.trace, Matrix.mul_apply,
+      Fin.sum_univ_two, Matrix.diag] <;>
+    ring
+
 /-- The Pauli matrices where `σi` are negated are linearly independent. -/
 lemma pauliSelfAdjoint'_linearly_independent : LinearIndependent ℝ pauliSelfAdjoint' := by
   apply Fintype.linearIndependent_iff.mpr

--- a/Physlib/Relativity/PauliMatrices/SelfAdjoint.lean
+++ b/Physlib/Relativity/PauliMatrices/SelfAdjoint.lean
@@ -266,6 +266,18 @@ def pauliSelfAdjoint' (i : Fin 1 ⊕ Fin 3) : selfAdjoint (Matrix (Fin 2) (Fin 2
   | Sum.inr 1 => ⟨-σ2, by rw [AddSubgroup.neg_mem_iff]; exact pauliMatrix_selfAdjoint _⟩
   | Sum.inr 2 => ⟨-σ3, by rw [AddSubgroup.neg_mem_iff]; exact pauliMatrix_selfAdjoint _⟩
 
+/-- Trace orthogonality of the covariant Pauli basis:
+  `tr (σ'_a σ'_b) = 2 δ_{a b}`. -/
+lemma trace_pauliSelfAdjoint'_mul (a b : Fin 1 ⊕ Fin 3) :
+    Matrix.trace ((pauliSelfAdjoint' a).1 * (pauliSelfAdjoint' b).1) =
+      if a = b then 2 else 0 := by
+  rcases a with a | a <;> rcases b with b | b <;>
+    fin_cases a <;> fin_cases b <;>
+    simp only [pauliSelfAdjoint', Matrix.neg_mul, Matrix.mul_neg,
+      Matrix.trace_neg, neg_neg, trace_pauliMatrix_mul_pauliMatrix,
+      KroneckerDelta.kroneckerDelta] <;>
+    simp
+
 /-- The Pauli matrices where `σi` are negated are linearly independent. -/
 lemma pauliSelfAdjoint'_linearly_independent : LinearIndependent ℝ pauliSelfAdjoint' := by
   apply Fintype.linearIndependent_iff.mpr

--- a/Physlib/Relativity/SL2C/AxisRotations.lean
+++ b/Physlib/Relativity/SL2C/AxisRotations.lean
@@ -9,8 +9,19 @@ public import Physlib.Relativity.SL2C.Basic
 /-!
 # Coordinate-axis rotations in `SL(2,ℂ)`
 
-This file defines rotations carrying the `z`-axis to a selected coordinate axis. The spatial
-axis convention is `0 = x`, `1 = y`, and `2 = z`.
+This file defines chosen `SL(2,ℂ)` rotations carrying the `z`-axis to a selected coordinate axis.
+The spatial-axis convention is `0 = x`, `1 = y`, and `2 = z`; consequently, the rotation associated
+with axis `2` is the identity.
+
+Conjugation by these rotations transports a matrix written in the diagonal `z`-axis basis to
+the corresponding coordinate-axis basis. This provides the common change of basis used by
+coordinate-axis boosts and later constructions based on diagonal representatives.
+
+The main declarations are:
+
+- `rotationZToAxis`, the indexed family of rotations;
+- `rotationZToAxis_inv_apply`, their inverse matrix entries;
+- `rotationZToAxis_mul_diagonal_mul_inv`, their action on a diagonal matrix.
 -/
 
 @[expose] public section
@@ -59,8 +70,8 @@ noncomputable def rotationZToAxis : Fin 3 → SL(2,ℂ)
     rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
     fin_cases j <;> fin_cases k <;> simp [rotationZToAxis]
 
-/-- Conjugating a diagonal matrix by `rotationZToAxis i` expresses it in the basis for axis
-`i`. -/
+/-- Conjugating `diag(a, b)` by `rotationZToAxis i` transports its diagonal `z`-axis expression
+to the basis associated with axis `i`. -/
 lemma rotationZToAxis_mul_diagonal_mul_inv (i : Fin 3) (a b : ℂ) :
     (rotationZToAxis i).1 * !![a, 0; 0, b] * ((rotationZToAxis i)⁻¹).1 =
       match i with

--- a/Physlib/Relativity/SL2C/AxisRotations.lean
+++ b/Physlib/Relativity/SL2C/AxisRotations.lean
@@ -31,21 +31,17 @@ namespace Lorentz.SL2C
 
 open Matrix MatrixGroups
 
-private lemma sqrtTwo_sq : (((Real.sqrt 2 : ℝ) : ℂ)) ^ 2 = 2 := by
-  rw [← Complex.ofReal_pow, Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
-  norm_num
-
 /-- The `SL(2,ℂ)` rotation carrying the `z`-axis to axis `i`. -/
 noncomputable def rotationZToAxis : Fin 3 → SL(2,ℂ)
   | 0 =>
       ⟨(((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, -1; 1, 1], by
-        rw [Matrix.det_smul, Matrix.det_fin_two_of, Fintype.card_fin, inv_pow, sqrtTwo_sq]
-        norm_num⟩
+        rw [Matrix.det_smul, Matrix.det_fin_two_of, Fintype.card_fin, inv_pow]
+        norm_num [← Complex.ofReal_pow, Real.sq_sqrt]⟩
   | 1 =>
       ⟨(((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, Complex.I; Complex.I, 1], by
-        rw [Matrix.det_smul, Matrix.det_fin_two_of, Fintype.card_fin, inv_pow, sqrtTwo_sq,
+        rw [Matrix.det_smul, Matrix.det_fin_two_of, Fintype.card_fin, inv_pow,
           Complex.I_mul_I]
-        norm_num⟩
+        norm_num [← Complex.ofReal_pow, Real.sq_sqrt]⟩
   | 2 => 1
 
 /-- The matrix entries of the rotation carrying the `z`-axis to the `x`-axis. -/
@@ -94,7 +90,7 @@ lemma rotationZToAxis_zero_mul_diagonal_mul_inv (a b : ℂ) :
       rotationZToAxis_zero_inv_apply] <;>
     simp <;>
     field_simp <;>
-    rw [sqrtTwo_sq] <;>
+    norm_num [← Complex.ofReal_pow, Real.sq_sqrt] <;>
     ring
 
 /-- Conjugating `diag(a, b)` by the rotation to the `y`-axis expresses it in the `y`-axis
@@ -113,13 +109,8 @@ lemma rotationZToAxis_one_mul_diagonal_mul_inv (a b : ℂ) :
       cons_val_zero, cons_val_fin_one, smul_eq_mul, mul_one, cons_val_one, mul_zero,
       add_zero, zero_add, mul_neg, neg_mul, Fin.mk_one]
     field_simp
-    rw [sqrtTwo_sq]
-  · rw [Complex.I_sq]
-    ring
-  · ring
-  · ring
-  · rw [Complex.I_sq]
-    ring
+    norm_num [← Complex.ofReal_pow, Real.sq_sqrt]
+  all_goals ring
 
 /-- Conjugating `diag(a, b)` by the identity rotation leaves it unchanged. -/
 lemma rotationZToAxis_two_mul_diagonal_mul_inv (a b : ℂ) :

--- a/Physlib/Relativity/SL2C/AxisRotations.lean
+++ b/Physlib/Relativity/SL2C/AxisRotations.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jinzheng Li, Nathaneal Sajan, Joseph Tooby-Smith
+-/
+module
+
+public import Physlib.Relativity.SL2C.Basic
+/-!
+# Coordinate-axis rotations in `SL(2,ℂ)`
+
+This file defines rotations carrying the `z`-axis to a selected coordinate axis. The spatial
+axis convention is `0 = x`, `1 = y`, and `2 = z`.
+-/
+
+@[expose] public section
+
+namespace Lorentz.SL2C
+
+open Matrix MatrixGroups
+
+private lemma sqrtTwo_sq : (((Real.sqrt 2 : ℝ) : ℂ)) ^ 2 = 2 := by
+  rw [← Complex.ofReal_pow, Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
+  norm_num
+
+/-- The `SL(2,ℂ)` rotation carrying the `z`-axis to axis `i`. -/
+noncomputable def rotationZToAxis : Fin 3 → SL(2,ℂ)
+  | 0 =>
+      ⟨(((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, -1; 1, 1], by
+        rw [Matrix.det_smul, Matrix.det_fin_two_of, Fintype.card_fin, inv_pow, sqrtTwo_sq]
+        norm_num⟩
+  | 1 =>
+      ⟨(((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, Complex.I; Complex.I, 1], by
+        rw [Matrix.det_smul, Matrix.det_fin_two_of, Fintype.card_fin, inv_pow, sqrtTwo_sq,
+          Complex.I_mul_I]
+        norm_num⟩
+  | 2 => 1
+
+/-- The matrix entries of the rotation carrying the `z`-axis to axis `i`. -/
+@[simp] lemma rotationZToAxis_apply (i : Fin 3) (j k : Fin 2) :
+    (rotationZToAxis i).1 j k =
+      match i with
+      | 0 => ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, -1; 1, 1]) j k
+      | 1 => ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ •
+          !![1, Complex.I; Complex.I, 1]) j k
+      | 2 => (1 : Matrix (Fin 2) (Fin 2) ℂ) j k := by
+  fin_cases i <;> rfl
+
+/-- The matrix entries of the inverse rotation from axis `i` back to the `z`-axis. -/
+@[simp] lemma rotationZToAxis_inv_apply (i : Fin 3) (j k : Fin 2) :
+    ((rotationZToAxis i)⁻¹).1 j k =
+      match i with
+      | 0 => ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, 1; -1, 1]) j k
+      | 1 => ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ •
+          !![1, -Complex.I; -Complex.I, 1]) j k
+      | 2 => (1 : Matrix (Fin 2) (Fin 2) ℂ) j k := by
+  fin_cases i
+  all_goals
+    rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+    fin_cases j <;> fin_cases k <;> simp [rotationZToAxis]
+
+/-- Conjugating a diagonal matrix by `rotationZToAxis i` expresses it in the basis for axis
+`i`. -/
+lemma rotationZToAxis_mul_diagonal_mul_inv (i : Fin 3) (a b : ℂ) :
+    (rotationZToAxis i).1 * !![a, 0; 0, b] * ((rotationZToAxis i)⁻¹).1 =
+      match i with
+      | 0 => !![(a + b) / 2, (a - b) / 2; (a - b) / 2, (a + b) / 2]
+      | 1 => !![(a + b) / 2, -Complex.I * (a - b) / 2;
+          Complex.I * (a - b) / 2, (a + b) / 2]
+      | 2 => !![a, 0; 0, b] := by
+  have hsqrt_ne : (((Real.sqrt 2 : ℝ) : ℂ)) ≠ 0 := by simp
+  fin_cases i
+  · ext j k
+    fin_cases j <;> fin_cases k <;>
+      simp only [Matrix.mul_apply, Fin.sum_univ_two, rotationZToAxis_apply,
+        rotationZToAxis_inv_apply] <;>
+      simp <;>
+      field_simp <;>
+      rw [sqrtTwo_sq] <;>
+      ring
+  · ext j k
+    fin_cases j <;> fin_cases k
+    all_goals
+      simp only [Matrix.mul_apply, Fin.sum_univ_two, rotationZToAxis_apply,
+        rotationZToAxis_inv_apply]
+      simp only [Fin.zero_eta, Fin.isValue, Matrix.smul_apply, of_apply, cons_val',
+        cons_val_zero, cons_val_fin_one, smul_eq_mul, mul_one, cons_val_one, mul_zero,
+        add_zero, zero_add, mul_neg, neg_mul, Fin.mk_one]
+      field_simp
+      rw [sqrtTwo_sq]
+    · rw [Complex.I_sq]
+      ring
+    · ring
+    · ring
+    · rw [Complex.I_sq]
+      ring
+  · ext j k
+    fin_cases j <;> fin_cases k <;>
+      simp only [Matrix.mul_apply, Fin.sum_univ_two, rotationZToAxis_apply,
+        rotationZToAxis_inv_apply] <;>
+      simp [Matrix.one_apply]
+
+end Lorentz.SL2C
+
+end

--- a/Physlib/Relativity/SL2C/AxisRotations.lean
+++ b/Physlib/Relativity/SL2C/AxisRotations.lean
@@ -20,8 +20,9 @@ coordinate-axis boosts and later constructions based on diagonal representatives
 The main declarations are:
 
 - `rotationZToAxis`, the indexed family of rotations;
-- `rotationZToAxis_inv_apply`, their inverse matrix entries;
-- `rotationZToAxis_mul_diagonal_mul_inv`, their action on a diagonal matrix.
+- `rotationZToAxis_zero_apply` and its companions, their matrix entries;
+- `rotationZToAxis_zero_mul_diagonal_mul_inv` and its companions, their action on a
+  diagonal matrix.
 -/
 
 @[expose] public section
@@ -47,69 +48,88 @@ noncomputable def rotationZToAxis : Fin 3 → SL(2,ℂ)
         norm_num⟩
   | 2 => 1
 
-/-- The matrix entries of the rotation carrying the `z`-axis to axis `i`. -/
-@[simp] lemma rotationZToAxis_apply (i : Fin 3) (j k : Fin 2) :
-    (rotationZToAxis i).1 j k =
-      match i with
-      | 0 => ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, -1; 1, 1]) j k
-      | 1 => ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ •
-          !![1, Complex.I; Complex.I, 1]) j k
-      | 2 => (1 : Matrix (Fin 2) (Fin 2) ℂ) j k := by
-  fin_cases i <;> rfl
+/-- The matrix entries of the rotation carrying the `z`-axis to the `x`-axis. -/
+@[simp] lemma rotationZToAxis_zero_apply (j k : Fin 2) :
+    (rotationZToAxis 0).1 j k =
+      ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, -1; 1, 1]) j k := rfl
 
-/-- The matrix entries of the inverse rotation from axis `i` back to the `z`-axis. -/
-@[simp] lemma rotationZToAxis_inv_apply (i : Fin 3) (j k : Fin 2) :
-    ((rotationZToAxis i)⁻¹).1 j k =
-      match i with
-      | 0 => ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, 1; -1, 1]) j k
-      | 1 => ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ •
-          !![1, -Complex.I; -Complex.I, 1]) j k
-      | 2 => (1 : Matrix (Fin 2) (Fin 2) ℂ) j k := by
-  fin_cases i
-  all_goals
-    rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
-    fin_cases j <;> fin_cases k <;> simp [rotationZToAxis]
+/-- The matrix entries of the rotation carrying the `z`-axis to the `y`-axis. -/
+@[simp] lemma rotationZToAxis_one_apply (j k : Fin 2) :
+    (rotationZToAxis 1).1 j k =
+      ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, Complex.I; Complex.I, 1]) j k := rfl
 
-/-- Conjugating `diag(a, b)` by `rotationZToAxis i` transports its diagonal `z`-axis expression
-to the basis associated with axis `i`. -/
-lemma rotationZToAxis_mul_diagonal_mul_inv (i : Fin 3) (a b : ℂ) :
-    (rotationZToAxis i).1 * !![a, 0; 0, b] * ((rotationZToAxis i)⁻¹).1 =
-      match i with
-      | 0 => !![(a + b) / 2, (a - b) / 2; (a - b) / 2, (a + b) / 2]
-      | 1 => !![(a + b) / 2, -Complex.I * (a - b) / 2;
-          Complex.I * (a - b) / 2, (a + b) / 2]
-      | 2 => !![a, 0; 0, b] := by
+/-- The rotation carrying the `z`-axis to itself is the identity matrix. -/
+@[simp] lemma rotationZToAxis_two_apply (j k : Fin 2) :
+    (rotationZToAxis 2).1 j k = (1 : Matrix (Fin 2) (Fin 2) ℂ) j k := rfl
+
+/-- The matrix entries of the inverse rotation from the `x`-axis to the `z`-axis. -/
+@[simp] lemma rotationZToAxis_zero_inv_apply (j k : Fin 2) :
+    ((rotationZToAxis 0)⁻¹).1 j k =
+      ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, 1; -1, 1]) j k := by
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  fin_cases j <;> fin_cases k <;> simp [rotationZToAxis]
+
+/-- The matrix entries of the inverse rotation from the `y`-axis to the `z`-axis. -/
+@[simp] lemma rotationZToAxis_one_inv_apply (j k : Fin 2) :
+    ((rotationZToAxis 1)⁻¹).1 j k =
+      ((((Real.sqrt 2 : ℝ) : ℂ))⁻¹ • !![1, -Complex.I; -Complex.I, 1]) j k := by
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  fin_cases j <;> fin_cases k <;> simp [rotationZToAxis]
+
+/-- The inverse rotation from the `z`-axis to itself is the identity matrix. -/
+@[simp] lemma rotationZToAxis_two_inv_apply (j k : Fin 2) :
+    ((rotationZToAxis 2)⁻¹).1 j k = (1 : Matrix (Fin 2) (Fin 2) ℂ) j k := by
+  rw [Matrix.SpecialLinearGroup.SL2_inv_expl]
+  fin_cases j <;> fin_cases k <;> simp [rotationZToAxis]
+
+/-- Conjugating `diag(a, b)` by the rotation to the `x`-axis expresses it in the `x`-axis
+basis. -/
+lemma rotationZToAxis_zero_mul_diagonal_mul_inv (a b : ℂ) :
+    (rotationZToAxis 0).1 * !![a, 0; 0, b] * ((rotationZToAxis 0)⁻¹).1 =
+      !![(a + b) / 2, (a - b) / 2; (a - b) / 2, (a + b) / 2] := by
   have hsqrt_ne : (((Real.sqrt 2 : ℝ) : ℂ)) ≠ 0 := by simp
-  fin_cases i
-  · ext j k
-    fin_cases j <;> fin_cases k <;>
-      simp only [Matrix.mul_apply, Fin.sum_univ_two, rotationZToAxis_apply,
-        rotationZToAxis_inv_apply] <;>
-      simp <;>
-      field_simp <;>
-      rw [sqrtTwo_sq] <;>
-      ring
-  · ext j k
-    fin_cases j <;> fin_cases k
-    all_goals
-      simp only [Matrix.mul_apply, Fin.sum_univ_two, rotationZToAxis_apply,
-        rotationZToAxis_inv_apply]
-      simp only [Fin.zero_eta, Fin.isValue, Matrix.smul_apply, of_apply, cons_val',
-        cons_val_zero, cons_val_fin_one, smul_eq_mul, mul_one, cons_val_one, mul_zero,
-        add_zero, zero_add, mul_neg, neg_mul, Fin.mk_one]
-      field_simp
-      rw [sqrtTwo_sq]
-    · rw [Complex.I_sq]
-      ring
-    · ring
-    · ring
-    · rw [Complex.I_sq]
-      ring
-  · ext j k
-    fin_cases j <;> fin_cases k <;>
-      simp only [Matrix.mul_apply, Fin.sum_univ_two, rotationZToAxis_apply,
-        rotationZToAxis_inv_apply] <;>
-      simp [Matrix.one_apply]
+  ext j k
+  fin_cases j <;> fin_cases k <;>
+    simp only [Matrix.mul_apply, Fin.sum_univ_two, rotationZToAxis_zero_apply,
+      rotationZToAxis_zero_inv_apply] <;>
+    simp <;>
+    field_simp <;>
+    rw [sqrtTwo_sq] <;>
+    ring
+
+/-- Conjugating `diag(a, b)` by the rotation to the `y`-axis expresses it in the `y`-axis
+basis. -/
+lemma rotationZToAxis_one_mul_diagonal_mul_inv (a b : ℂ) :
+    (rotationZToAxis 1).1 * !![a, 0; 0, b] * ((rotationZToAxis 1)⁻¹).1 =
+      !![(a + b) / 2, -Complex.I * (a - b) / 2;
+        Complex.I * (a - b) / 2, (a + b) / 2] := by
+  have hsqrt_ne : (((Real.sqrt 2 : ℝ) : ℂ)) ≠ 0 := by simp
+  ext j k
+  fin_cases j <;> fin_cases k
+  all_goals
+    simp only [Matrix.mul_apply, Fin.sum_univ_two, rotationZToAxis_one_apply,
+      rotationZToAxis_one_inv_apply]
+    simp only [Fin.zero_eta, Fin.isValue, Matrix.smul_apply, of_apply, cons_val',
+      cons_val_zero, cons_val_fin_one, smul_eq_mul, mul_one, cons_val_one, mul_zero,
+      add_zero, zero_add, mul_neg, neg_mul, Fin.mk_one]
+    field_simp
+    rw [sqrtTwo_sq]
+  · rw [Complex.I_sq]
+    ring
+  · ring
+  · ring
+  · rw [Complex.I_sq]
+    ring
+
+/-- Conjugating `diag(a, b)` by the identity rotation leaves it unchanged. -/
+lemma rotationZToAxis_two_mul_diagonal_mul_inv (a b : ℂ) :
+    (rotationZToAxis 2).1 * !![a, 0; 0, b] * ((rotationZToAxis 2)⁻¹).1 =
+      !![a, 0; 0, b] := by
+  ext j k
+  fin_cases j <;> fin_cases k <;>
+    simp only [Matrix.mul_apply, Fin.sum_univ_two, rotationZToAxis_two_apply,
+      rotationZToAxis_two_inv_apply] <;>
+    simp [Matrix.one_apply]
 
 end Lorentz.SL2C
 

--- a/Physlib/Relativity/SL2C/Basic.lean
+++ b/Physlib/Relativity/SL2C/Basic.lean
@@ -204,14 +204,14 @@ lemma toSelfAdjointMap_pauliBasis (i : Fin 1 ⊕ Fin 3) :
   exact Eq.symm (minkowskiMatrix.dual_apply_minkowskiMatrix ((toLorentzGroup M).1) i j)
 
 /-- The matrix elements of the covering map through the trace pairing:
-  `L(M)_{l i} = ½ tr (σ'_l · M σ'_i M†)`. -/
-lemma toLorentzGroup_eq_trace (M : SL(2,ℂ)) (l i : Fin 1 ⊕ Fin 3) :
-    (((toLorentzGroup M).1 l i : ℝ) : ℂ) =
-      Matrix.trace ((PauliMatrix.pauliSelfAdjoint' l).1 *
-        (M.1 * (PauliMatrix.pauliSelfAdjoint' i).1 * M.1ᴴ)) / 2 := by
+  `L(M)_{i j} = ½ tr (σ'_i · M σ'_j M†)`. -/
+lemma toLorentzGroup_eq_trace (M : SL(2,ℂ)) (i j : Fin 1 ⊕ Fin 3) :
+    (((toLorentzGroup M).1 i j : ℝ) : ℂ) =
+      Matrix.trace ((PauliMatrix.pauliSelfAdjoint' i).1 *
+        (M.1 * (PauliMatrix.pauliSelfAdjoint' j).1 * M.1ᴴ)) / 2 := by
   have h := congrArg (fun A : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ) =>
-    Matrix.trace ((PauliMatrix.pauliSelfAdjoint' l).1 * A.1))
-    (toSelfAdjointMap_basis (M := M) i)
+    Matrix.trace ((PauliMatrix.pauliSelfAdjoint' i).1 * A.1))
+    (toSelfAdjointMap_basis (M := M) j)
   simp only [toSelfAdjointMap_apply_coe, PauliMatrix.pauliBasis',
     Module.Basis.coe_mk, AddSubmonoidClass.coe_finsetSum, selfAdjoint.val_smul,
     Matrix.mul_sum, Matrix.trace_sum, Matrix.mul_smul, Matrix.trace_smul,

--- a/Physlib/Relativity/SL2C/Basic.lean
+++ b/Physlib/Relativity/SL2C/Basic.lean
@@ -203,6 +203,23 @@ lemma toSelfAdjointMap_pauliBasis (i : Fin 1 ⊕ Fin 3) :
   apply congrArg
   exact Eq.symm (minkowskiMatrix.dual_apply_minkowskiMatrix ((toLorentzGroup M).1) i j)
 
+/-- The matrix elements of the covering map through the trace pairing:
+  `L(M)_{l i} = ½ tr (σ'_l · M σ'_i M†)`. -/
+lemma toLorentzGroup_eq_trace (M : SL(2,ℂ)) (l i : Fin 1 ⊕ Fin 3) :
+    (((toLorentzGroup M).1 l i : ℝ) : ℂ) =
+      Matrix.trace ((PauliMatrix.pauliSelfAdjoint' l).1 *
+        (M.1 * (PauliMatrix.pauliSelfAdjoint' i).1 * M.1ᴴ)) / 2 := by
+  have h := congrArg (fun A : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ) =>
+    Matrix.trace ((PauliMatrix.pauliSelfAdjoint' l).1 * A.1))
+    (toSelfAdjointMap_basis (M := M) i)
+  simp only [toSelfAdjointMap_apply_coe, PauliMatrix.pauliBasis',
+    Module.Basis.coe_mk, AddSubmonoidClass.coe_finsetSum, selfAdjoint.val_smul,
+    Matrix.mul_sum, Matrix.trace_sum, Matrix.mul_smul, Matrix.trace_smul,
+    PauliMatrix.trace_pauliSelfAdjoint'_mul, smul_ite, smul_zero, Finset.sum_ite_eq,
+    Finset.mem_univ, if_true] at h
+  rw [h, real_smul]
+  ring
+
 /-- The first column of the Lorentz matrix formed from an element of `SL(2, ℂ)`. -/
 lemma toLorentzGroup_fst_col (M : SL(2, ℂ)) :
     (fun μ => (toLorentzGroup M).1 μ (Sum.inl 0)) = fun μ =>

--- a/scripts/MetaPrograms/spellingWords.txt
+++ b/scripts/MetaPrograms/spellingWords.txt
@@ -2187,6 +2187,7 @@ raising
 range
 rank
 rapidly
+rapidity
 rather
 ratio
 rational


### PR DESCRIPTION
Adds explicit `SL(2, ℂ)` lifts of boosts along the three coordinate axes, together with their Lorentz matrices, inverses, and conjugation relations.