### PR TITLE
fix doc: correct FiedOpAlgebra to FieldOpFreeAlgebra in section heading

### DIFF
--- a/Physlib/QFT/PerturbationTheory/WickAlgebra/TimeOrder.lean
+++ b/Physlib/QFT/PerturbationTheory/WickAlgebra/TimeOrder.lean
@@ -288,7 +288,7 @@ lemma ι_timeOrderF_superCommuteF_ne_time {φ ψ : 𝓕.CrAnFieldOp}
 
 /-!
 
-## Defining time order for `FiedOpAlgebra`.
+## Defining time order for `FieldOpFreeAlgebra`.
 
 -/
 


### PR DESCRIPTION
## Summary
Correct typo in doc comment heading (TimeOrder.lean:291):
- Before: `## Defining time order for `FiedOpAlgebra`.`
- After: `## Defining time order for `FieldOpFreeAlgebra`.`

## Why
The section documents time order for the `FieldOpFreeAlgebra` type (as used throughout the file), but the heading incorrectly referenced `FiedOpAlgebra` — a misspelled type that does not exist in the codebase.

## Testing
No code changes; this is a documentation comment fix only.