### PR TITLE
docs(reference-frame): reference frame API map

### DIFF
--- a/Physlib/SpaceAndTime/ReferenceFrame/API-map.yaml
+++ b/Physlib/SpaceAndTime/ReferenceFrame/API-map.yaml
@@ -1,0 +1,107 @@
+version: v0.1
+
+Title: Reference frame
+
+Overview: |
+    An observer describing motion needs a coordinate grid, and the grid is a
+    choice rather than a feature of space. Space is affine: two points determine
+    a displacement, but no point is singled out as zero, and a displacement has
+    numerical components only once axes have been picked. A reference frame is
+    that pair of choices, an origin and a set of axes, carried along through
+    time.
+
+    An inertial frame is one whose grid is not being pushed around. Its axes
+    neither rotate nor change scale as time passes, and its origin drifts in a
+    straight line at constant speed. This is a restriction on the observer, not
+    on whatever is being observed, and it is the setting in which the familiar
+    Newtonian statements about free motion hold.
+
+    A vector quantity measured by an observer, a relative position, a velocity,
+    an acceleration, a force, a momentum, is a list of components read off that
+    observer's axes. Such lists add and scale componentwise regardless of which
+    quantity they stand for, so they share one carrier here; the physical
+    dimension, units and transformation law belong to whatever definition
+    supplies the quantity. Lengths and angles are the exception, since they are
+    geometric facts about the displacement rather than about the numbers: they
+    are taken from the underlying space through the frame's axes, so that a
+    grid with skew or unequal axes cannot make the same physical displacement
+    appear to change length. When the axes are orthonormal this reduces to the
+    school formulas, the square root of the sum of the squared components and
+    the sum of the componentwise products.
+
+ParentAPIs:
+  - "Space (Physlib/SpaceAndTime/Space)"
+  - "Time (Physlib/SpaceAndTime/Time)"
+  - "Galilean group (Physlib/SpaceAndTime/GalileanGroup)"
+
+References: []
+
+Requirements:
+
+  - description: "The key data structure `ReferenceFrame d`, recording an affine origin and a displacement basis at each time, is defined."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame, origin, basis)"
+
+  - description: "The API contains a construction of a frame from the trajectories of a collection of reference points forming an affine basis at each time."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame.fromReferencePoints)"
+
+  - description: "The API contains the condition that a frame induces the same inner product on coordinates at every time."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (IsMetricConserved)"
+
+  - description: "The API contains the condition that a frame's axes are orthonormal at every time, and the result that such a frame conserves its coordinate metric."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (Orthonormal, Orthonormal.isMetricConserved)"
+
+  - description: "The API contains the condition for a frame to be inertial, namely that its origin moves with constant velocity and its axes neither rotate nor rescale."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (IsInertial, origin_moves_uniformly, basis_conserved)"
+
+  - description: "The API contains the constant velocity of an inertial frame's origin."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (IsInertial.velocity)"
+
+  - description: "The API contains the result that an inertial frame conserves its coordinate metric."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (IsInertial.isMetricConserved)"
+
+  - description: "The API contains the carrier `frame.Vector` for the components of a vector quantity measured relative to a frame, together with its equivalence to coordinate tuples."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (Vector, components, componentEquiv, componentLinearEquiv)"
+
+  - description: "The API contains the additive and scalar structure on frame vectors, inherited componentwise."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (AddCommGroup frame.Vector, Module ℝ frame.Vector)"
+
+  - description: "The API contains the identification of a frame vector with a geometric displacement in space at a given time, through the frame's basis."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (dispEquiv, contDispEquiv)"
+
+  - description: "The API contains the topology on frame vectors, its continuous linear equivalence with coordinate tuples, and finite dimensionality."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (componentContLinearEquiv, TopologicalSpace frame.Vector, FiniteDimensional ℝ frame.Vector)"
+
+  - description: "The API contains the norm and inner product on frame vectors of a frame with conserved coordinate metric, pulled back through the frame basis from geometric displacement space, so that a displacement keeps its length and its angles when the axes are skew or unequally scaled."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (NormedAddCommGroup frame.Vector, InnerProductSpace ℝ frame.Vector)"
+
+  - description: "The API contains the Euclidean component formulas for the norm and inner product in an orthonormal frame."
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (norm_euclidean_if_orthonormal, inner_euclidean_if_orthonormal)"
+
+  - description: "The API shall contain a choice of time origin for a frame, so that time translations can act on frames."
+    done: false
+    location: N/A
+
+  - description: "The API shall contain the Galilean transformation relating any two inertial frames, and the resulting transformation law for frame vectors."
+    done: false
+    location: N/A
+
+  - description: "The API shall contain the derivative of a trajectory expressed in a frame, giving the velocity and acceleration measured by that frame."
+    done: false
+    location: N/A
+
+  - description: "The API shall contain the statement that a frame whose axes are constant and whose origin moves with constant velocity relative to an inertial frame is itself inertial."
+    done: false
+    location: N/A

--- a/Physlib/SpaceAndTime/ReferenceFrame/API-map.yaml
+++ b/Physlib/SpaceAndTime/ReferenceFrame/API-map.yaml
@@ -4,17 +4,19 @@ Title: Reference frame
 
 Overview: |
     An observer describing motion needs a coordinate grid, and the grid is a
-    choice rather than a feature of space. Space is affine: two points determine
-    a displacement, but no point is singled out as zero, and a displacement has
-    numerical components only once axes have been picked. A reference frame is
-    that pair of choices, an origin and a set of axes, carried along through
-    time.
+    choice rather than a feature of space. Two points of space determine a
+    displacement, and a displacement acquires numerical components only once
+    axes have been picked. Space carries a zero point of its own, but an
+    observer is under no obligation to use it: which point the coordinates call
+    zero is part of the observer's choice. A reference frame is that pair of
+    choices, an origin and a set of axes, carried along through time.
 
-    An inertial frame is one whose grid is not being pushed around. Its axes
-    neither rotate nor change scale as time passes, and its origin drifts in a
-    straight line at constant speed. This is a restriction on the observer, not
-    on whatever is being observed, and it is the setting in which the familiar
-    Newtonian statements about free motion hold.
+    An inertial frame is one whose grid is not being pushed around. Its axes are
+    the same at every time, and its origin drifts in a straight line at constant
+    speed, both measured against the affine structure that space itself
+    supplies. This is a restriction on the observer rather than on whatever is
+    being observed, and it is the setting in which the familiar Newtonian
+    statements about free motion hold.
 
     A vector quantity measured by an observer, a relative position, a velocity,
     an acceleration, a force, a momentum, is a list of components read off that
@@ -23,16 +25,15 @@ Overview: |
     dimension, units and transformation law belong to whatever definition
     supplies the quantity. Lengths and angles are the exception, since they are
     geometric facts about the displacement rather than about the numbers: they
-    are taken from the underlying space through the frame's axes, so that a
-    grid with skew or unequal axes cannot make the same physical displacement
-    appear to change length. When the axes are orthonormal this reduces to the
-    school formulas, the square root of the sum of the squared components and
-    the sum of the componentwise products.
+    are taken from the underlying space through the frame's axes, so that a grid
+    with skew or unequal axes cannot make the same physical displacement appear
+    to change length. When the axes are orthonormal this reduces to the familiar
+    Euclidean formulas, the sum of the squared components giving the squared
+    length and the sum of the componentwise products giving the inner product.
 
 ParentAPIs:
   - "Space (Physlib/SpaceAndTime/Space)"
   - "Time (Physlib/SpaceAndTime/Time)"
-  - "Galilean group (Physlib/SpaceAndTime/GalileanGroup)"
 
 References: []
 
@@ -40,7 +41,7 @@ Requirements:
 
   - description: "The key data structure `ReferenceFrame d`, recording an affine origin and a displacement basis at each time, is defined."
     done: true
-    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame, origin, basis)"
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame, ReferenceFrame.origin, ReferenceFrame.basis)"
 
   - description: "The API contains a construction of a frame from the trajectories of a collection of reference points forming an affine basis at each time."
     done: true
@@ -48,33 +49,33 @@ Requirements:
 
   - description: "The API contains the condition that a frame induces the same inner product on coordinates at every time."
     done: true
-    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (IsMetricConserved)"
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame.IsMetricConserved)"
 
-  - description: "The API contains the condition that a frame's axes are orthonormal at every time, and the result that such a frame conserves its coordinate metric."
+  - description: "The API contains the condition that a frame's axes are orthonormal at every time, the result that such a frame conserves its coordinate metric, and the instance making that available to typeclass inference."
     done: true
-    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (Orthonormal, Orthonormal.isMetricConserved)"
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame.Orthonormal, Orthonormal.isMetricConserved, Fact frame.IsMetricConserved)"
 
-  - description: "The API contains the condition for a frame to be inertial, namely that its origin moves with constant velocity and its axes neither rotate nor rescale."
+  - description: "The API contains the condition for a frame to be inertial, namely that its origin moves with constant velocity and its axes are the same at every time."
     done: true
-    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (IsInertial, origin_moves_uniformly, basis_conserved)"
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame.IsInertial, origin_moves_uniformly, basis_conserved)"
 
   - description: "The API contains the constant velocity of an inertial frame's origin."
     done: true
     location: "Physlib/SpaceAndTime/ReferenceFrame.lean (IsInertial.velocity)"
 
-  - description: "The API contains the result that an inertial frame conserves its coordinate metric."
+  - description: "The API contains the result that an inertial frame conserves its coordinate metric, and the instance making that available to typeclass inference."
     done: true
-    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (IsInertial.isMetricConserved)"
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (IsInertial.isMetricConserved, Fact frame.IsMetricConserved)"
 
   - description: "The API contains the carrier `frame.Vector` for the components of a vector quantity measured relative to a frame, together with its equivalence to coordinate tuples."
     done: true
-    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (Vector, components, componentEquiv, componentLinearEquiv)"
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame.Vector, components, componentEquiv, componentLinearEquiv)"
 
   - description: "The API contains the additive and scalar structure on frame vectors, inherited componentwise."
     done: true
     location: "Physlib/SpaceAndTime/ReferenceFrame.lean (AddCommGroup frame.Vector, Module ℝ frame.Vector)"
 
-  - description: "The API contains the identification of a frame vector with a geometric displacement in space at a given time, through the frame's basis."
+  - description: "The API contains the identification of a frame vector with a geometric displacement in space at a given time, through the frame's basis, in both linear and continuous linear form."
     done: true
     location: "Physlib/SpaceAndTime/ReferenceFrame.lean (dispEquiv, contDispEquiv)"
 
@@ -94,11 +95,15 @@ Requirements:
     done: false
     location: N/A
 
-  - description: "The API shall contain the Galilean transformation relating any two inertial frames, and the resulting transformation law for frame vectors."
+  - description: "The API shall contain the defining property of an inertial frame's origin velocity, and the origin and basis of a frame built from reference points."
     done: false
     location: N/A
 
-  - description: "The API shall contain the derivative of a trajectory expressed in a frame, giving the velocity and acceleration measured by that frame."
+  - description: "The API shall contain the relative motion of two inertial frames, expressed as the boost, rotation and translation carrying one to the other, together with the induced transformation law for frame vectors."
+    done: false
+    location: N/A
+
+  - description: "The API shall contain the derivative of a trajectory expressed in a frame, giving the velocity and acceleration measured by that frame as the time derivative of its coordinate components."
     done: false
     location: N/A
 


### PR DESCRIPTION
Adds an API map for reference frames, covering `Physlib/SpaceAndTime/ReferenceFrame.lean`.

Thirteen requirements are marked done and point at declarations in that file: the `ReferenceFrame`
structure and the construction from reference-point trajectories, the metric-conservation and
orthonormality conditions with the implication between them and the `Fact` instances that carry it
to typeclass inference, the inertiality condition with its origin velocity, and the `Vector` carrier
with its component equivalences, module and topological structure, displacement identification,
pulled-back norm and inner product, and the Euclidean component formulas in an orthonormal frame.

Five requirements are marked not done: a time origin so that time translations can act on frames
(the source already marks this one as pending), the defining property of the origin velocity and of a frame
built from reference points (both are currently opaque, the velocity being a `Classical.choose` with
no exported spec), the relative motion of two inertial frames with the induced transformation law on
frame vectors, the derivative of a trajectory in a frame as the time derivative of its coordinate
components, and the statement that a frame with constant axes whose origin moves uniformly relative
to an inertial frame is itself inertial.

The linter is clean: 13 checked, 21 names verified, no missing files or names. The eight instance
claims are reported as needing the Lean environment, which is the same treatment the other maps get.

On placement. The source here is a single file, `SpaceAndTime/ReferenceFrame.lean`, rather than a
directory, so the map goes in a new `SpaceAndTime/ReferenceFrame/` directory holding only the map.
Three merged maps already sit in directories with no Lean files of their own (GaugeTheory, Qubit,
TopologicalFieldTheory), and this path is what makes `APIMapIndex.lean` derive the module context
`Physlib.SpaceAndTime.ReferenceFrame`, which is the file's actual module name. The tidier end state
would be to move the source to `ReferenceFrame/Basic.lean` so it matches Space, Time, SpaceTime and
TimeAndSpace, but that edits already-merged source in a docs-only change, so I have left it. Happy
to do either.

One note on the overview. The source docstring says space has no automatic zero point. `Space d`
does in fact carry a distinguished zero from `Space/Origin.lean`, so I have phrased it as space
having a zero that an observer is free not to use, which is what the frame structure actually
expresses.
