### PR TITLE
docs(temperature): temperature API map

### DIFF
--- a/Physlib/Thermodynamics/Temperature/API-map.yaml
+++ b/Physlib/Thermodynamics/Temperature/API-map.yaml
@@ -3,33 +3,36 @@ version: v0.1
 Title: Temperature
 
 Overview: |
-    Temperature measured from absolute zero is a nonnegative quantity: there is a
-    coldest state, and no scale used here places anything below it. A choice of
-    scale is a choice of how large one degree is, and nothing more, so two such
-    choices differ by a positive ratio and any statement of physics must be
-    unchanged when that ratio is applied. Kelvin is taken as the reference
-    scale and the others are built from it by rescaling.
+    Temperature here is measured from absolute zero and is taken to be
+    nonnegative: no scale used here places a state below absolute zero, which
+    excludes the negative absolute temperatures a system with a bounded energy
+    spectrum can carry. A choice of scale is a choice of how large one degree
+    is, and nothing more, so two such choices differ by a positive ratio, and
+    kelvin is the scale from which the others here are obtained by rescaling.
 
     In statistical mechanics the quantity that actually appears is not the
     temperature itself but its reciprocal, weighted by the Boltzmann constant:
-    the inverse temperature that multiplies an energy in a Boltzmann factor.
-    The correspondence is a bijection between positive temperatures and positive
-    inverse temperatures, and it reverses order, so a hot system is one with a
-    small inverse temperature. The two limits matter physically and are recorded
-    here: sending the inverse temperature to infinity drives the temperature to
-    absolute zero, which is the regime where a system settles into its lowest
-    energy states.
+    the inverse temperature that multiplies an energy in a Boltzmann factor. On
+    positive temperatures the correspondence is a bijection onto the positive
+    inverse temperatures and reverses order, so a hot system is one with a small
+    inverse temperature; the boundary value zero is paired with itself, which is
+    a convention of the underlying nonnegative reals rather than a physical
+    statement. The limit of large inverse temperature is the one recorded here:
+    sending the inverse temperature to infinity drives the temperature to
+    absolute zero, the regime in which a system settles into its lowest energy
+    states.
 
-    Because thermodynamic quantities are usually differentiated with respect to
-    one or the other, the change of variable between temperature and inverse
-    temperature needs to be available as a smooth one away from absolute zero,
-    together with the chain rule that converts a derivative in one variable into
-    a derivative in the other.
+    Thermodynamic quantities are differentiated with respect to one or the other
+    of these variables, so the change of variable between them is smooth at
+    positive temperature, and a derivative in one variable determines the
+    derivative in the other.
 
 ParentAPIs:
-  - "Units (Physlib/Units)"
+  - "Boltzmann constant (Physlib/StatisticalMechanics/BoltzmannConstant.lean)"
 
-References: []
+References:
+  - L. D. Landau & E. M. Lifshitz, Statistical Physics, Part 1 (§9 temperature, §31 the Gibbs distribution).
+  - N. F. Ramsey, Thermodynamics and statistical mechanics at negative absolute temperatures, Physical Review 103 (1956), 20-28.
 
 Requirements:
 
@@ -49,11 +52,11 @@ Requirements:
     done: true
     location: "Physlib/Thermodynamics/Temperature/Basic.lean (beta_pos)"
 
-  - description: "The API contains the continuity and differentiability of the temperature as a function of the inverse temperature away from zero."
+  - description: "The API contains the continuity of the temperature as a function of the inverse temperature at positive inverse temperature, and the differentiability of its real coordinate on the positive reals."
     done: true
     location: "Physlib/Thermodynamics/Temperature/Basic.lean (ofβ_continuousOn, ofβ_differentiableOn)"
 
-  - description: "The API contains the behaviour in the limit of large inverse temperature, namely eventual positivity and convergence of the temperature to absolute zero."
+  - description: "The API contains the behaviour in the limit of large inverse temperature, namely eventual positivity and convergence of the temperature to absolute zero from above."
     done: true
     location: "Physlib/Thermodynamics/Temperature/Basic.lean (eventually_pos_ofβ, tendsto_toReal_ofβ_atTop, tendsto_ofβ_atTop)"
 
@@ -61,7 +64,7 @@ Requirements:
     done: true
     location: "Physlib/Thermodynamics/Temperature/Basic.lean (ofNNReal, ofNNReal_val, coe_ofNNReal_coe, coe_ofNNReal_real, ofRealNonneg, ofRealNonneg_val)"
 
-  - description: "The API contains the derivative of the inverse temperature with respect to the temperature, and the chain rule converting a derivative in one variable into a derivative in the other."
+  - description: "The API contains the derivative of the inverse temperature with respect to the temperature at positive temperature, and the chain rule converting a derivative with respect to the inverse temperature into a derivative with respect to the temperature."
     done: true
     location: "Physlib/Thermodynamics/Temperature/Basic.lean (betaFromReal, beta_fun_T_formula, beta_fun_T_eq_on_Ioi, deriv_beta_wrt_T, chain_rule_T_beta)"
 
@@ -89,6 +92,6 @@ Requirements:
     done: false
     location: N/A
 
-  - description: "The API shall contain scales whose zero is not absolute zero, such as degrees Celsius and degrees Fahrenheit, and their conversion to absolute scales."
+  - description: "The API shall contain scales whose zero is offset from absolute zero, namely degrees Celsius and degrees Fahrenheit as ordinarily used, as opposed to the absolute Fahrenheit-sized degree already present, together with their conversion to absolute scales."
     done: false
     location: N/A

--- a/Physlib/Thermodynamics/Temperature/API-map.yaml
+++ b/Physlib/Thermodynamics/Temperature/API-map.yaml
@@ -1,0 +1,94 @@
+version: v0.1
+
+Title: Temperature
+
+Overview: |
+    Temperature measured from absolute zero is a nonnegative quantity: there is a
+    coldest state, and no scale used here places anything below it. A choice of
+    scale is a choice of how large one degree is, and nothing more, so two such
+    choices differ by a positive ratio and any statement of physics must be
+    unchanged when that ratio is applied. Kelvin is taken as the reference
+    scale and the others are built from it by rescaling.
+
+    In statistical mechanics the quantity that actually appears is not the
+    temperature itself but its reciprocal, weighted by the Boltzmann constant:
+    the inverse temperature that multiplies an energy in a Boltzmann factor.
+    The correspondence is a bijection between positive temperatures and positive
+    inverse temperatures, and it reverses order, so a hot system is one with a
+    small inverse temperature. The two limits matter physically and are recorded
+    here: sending the inverse temperature to infinity drives the temperature to
+    absolute zero, which is the regime where a system settles into its lowest
+    energy states.
+
+    Because thermodynamic quantities are usually differentiated with respect to
+    one or the other, the change of variable between temperature and inverse
+    temperature needs to be available as a smooth one away from absolute zero,
+    together with the chain rule that converts a derivative in one variable into
+    a derivative in the other.
+
+ParentAPIs:
+  - "Units (Physlib/Units)"
+
+References: []
+
+Requirements:
+
+  - description: "The key data structure `Temperature`, an absolute temperature in an arbitrary scale that puts absolute zero at zero, is defined, with its coercions, topology, zero and extensionality."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/Basic.lean (Temperature, val, toReal, ext, Coe Temperature ℝ≥0, Coe Temperature ℝ, TopologicalSpace Temperature, Zero Temperature)"
+
+  - description: "The API contains the inverse temperature attached to a temperature, its defining formula in terms of the Boltzmann constant, and the construction of a temperature from an inverse temperature."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/Basic.lean (β, β_toReal, ofβ, ofβ_eq, ofβ_toReal)"
+
+  - description: "The API contains the result that passing to the inverse temperature and back is the identity in both directions."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/Basic.lean (β_ofβ, ofβ_β)"
+
+  - description: "The API contains the result that a strictly positive temperature has strictly positive inverse temperature."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/Basic.lean (beta_pos)"
+
+  - description: "The API contains the continuity and differentiability of the temperature as a function of the inverse temperature away from zero."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/Basic.lean (ofβ_continuousOn, ofβ_differentiableOn)"
+
+  - description: "The API contains the behaviour in the limit of large inverse temperature, namely eventual positivity and convergence of the temperature to absolute zero."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/Basic.lean (eventually_pos_ofβ, tendsto_toReal_ofβ_atTop, tendsto_ofβ_atTop)"
+
+  - description: "The API contains constructions of a temperature from a nonnegative real and from a real together with a proof of nonnegativity, with their defining equations."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/Basic.lean (ofNNReal, ofNNReal_val, coe_ofNNReal_coe, coe_ofNNReal_real, ofRealNonneg, ofRealNonneg_val)"
+
+  - description: "The API contains the derivative of the inverse temperature with respect to the temperature, and the chain rule converting a derivative in one variable into a derivative in the other."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/Basic.lean (betaFromReal, beta_fun_T_formula, beta_fun_T_eq_on_Ioi, deriv_beta_wrt_T, chain_rule_T_beta)"
+
+  - description: "The key data structure `TemperatureUnit`, a choice of temperature scale carrying a positive scale factor, is defined."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/TemperatureUnits.lean (TemperatureUnit, val_ne_zero, val_pos, Inhabited TemperatureUnit)"
+
+  - description: "The API contains the ratio of two temperature units as a nonnegative real, with its positivity and its reflexivity, symmetry and composition properties."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/TemperatureUnits.lean (HDiv TemperatureUnit TemperatureUnit ℝ≥0, div_eq_val, div_ne_zero, div_pos, div_self, div_symm, div_mul_div, div_mul_div_coe)"
+
+  - description: "The API contains the rescaling of a temperature unit by a positive real, with the ratios it induces and its composition law."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/TemperatureUnits.lean (scale, scale_div_self, self_div_scale, scale_one, scale_div_scale, scale_scale)"
+
+  - description: "The API contains kelvin as the reference temperature unit, together with the units obtained from it by rescaling."
+    done: true
+    location: "Physlib/Thermodynamics/Temperature/TemperatureUnits.lean (kelvin, nanokelvin, microkelvin, millikelvin, absoluteFahrenheit)"
+
+  - description: "The API shall contain the temperature manifold, diffeomorphic to the nonnegative reals, of which a temperature unit is a translationally invariant metric."
+    done: false
+    location: N/A
+
+  - description: "The API shall contain the conversion of a temperature value between two temperature units."
+    done: false
+    location: N/A
+
+  - description: "The API shall contain scales whose zero is not absolute zero, such as degrees Celsius and degrees Fahrenheit, and their conversion to absolute scales."
+    done: false
+    location: N/A


### PR DESCRIPTION
Adds an API map for temperature, covering `Physlib/Thermodynamics/Temperature/Basic.lean` and
`Physlib/Thermodynamics/Temperature/TemperatureUnits.lean`.

The Units map already lists Temperature as one of its parent APIs, so this fills in the map that
entry points at.

Twelve requirements are marked done, across 49 named declarations: the `Temperature` structure with
its coercions, topology, zero and extensionality; the inverse temperature with its defining formula,
the construction going the other way, and the round trips in both directions; positivity; continuity
in the inverse temperature and differentiability of the real coordinate on the positive reals; the
large inverse temperature limit; the constructions from a nonnegative real and from a real with a
nonnegativity proof; the derivative of the inverse temperature with respect to the temperature and
the chain rule between the two variables; and on the units side the `TemperatureUnit` structure,
the ratio of two units with its algebraic properties, rescaling with its composition law, and kelvin
with the units built from it.

Three requirements are marked not done: the temperature manifold that the units file's own
documentation refers to but does not yet define, conversion of a temperature value between two
units, and scales whose zero is offset from absolute zero such as ordinary Celsius and Fahrenheit,
as distinct from the absolute Fahrenheit-sized degree that is already there.

The linter is clean: 12 checked, 49 names verified, no missing files or names.

Two things worth flagging. The differentiability requirement is deliberately worded around the real
coordinate rather than the temperature itself, because `ofβ_differentiableOn` is stated for
`fun x : ℝ => ((ofβ (Real.toNNReal x)).val : ℝ)` and `Temperature` carries no normed structure.
And the overview notes that taking temperature nonnegative excludes negative absolute temperatures,
which are physically real in systems with a bounded energy spectrum, since the module scopes itself
to the usual undergraduate notion.
