### PR TITLE
feat(Mathematics): shared gradient lemmas, used by the oscillators

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -99,6 +99,7 @@ public import Physlib.FluidDynamics.ThermodynamicCauchyFlow.Bernoulli
 public import Physlib.FluidDynamics.ThermodynamicCauchyFlow.Isentropic
 public import Physlib.Mathematics.Calculus.AdjFDeriv
 public import Physlib.Mathematics.Calculus.Divergence
+public import Physlib.Mathematics.Calculus.Gradient
 public import Physlib.Mathematics.Calculus.ParametricIntegration
 public import Physlib.Mathematics.Calculus.Wirtinger.Basic
 public import Physlib.Mathematics.Calculus.Wirtinger.Coordinate

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -504,11 +504,6 @@ lagrangian, using that the gradient scales with the constant `exp (γ/m * t)`.
 
 -/
 
-private lemma gradient_const_mul {f : EuclideanSpace ℝ (Fin 1) → ℝ} {x : EuclideanSpace ℝ (Fin 1)}
-    (c : ℝ) (hf : DifferentiableAt ℝ f x) :
-    gradient (fun y => c * f y) x = c • gradient f x := by
-  simp [gradient, fderiv_const_mul hf, map_smul]
-
 lemma gradient_lagrangian_position_eq (t : Time) (x v : EuclideanSpace ℝ (Fin 1)) :
     gradient (fun x => S.lagrangian t x v) x = -(exp (S.γ / S.m * t) * S.k) • x := by
   have hf : DifferentiableAt ℝ (fun y => S.toHarmonicOscillator.lagrangian t y v) x := by

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.ClassicalMechanics.EulerLagrange
 public import Physlib.ClassicalMechanics.HamiltonsEquations
+public import Physlib.Mathematics.Calculus.Gradient
 public import Mathlib.Algebra.Order.Archimedean.Real.Hom
 /-!
 
@@ -337,25 +338,6 @@ lemma contDiff_lagrangian (n : WithTop ℕ∞) : ContDiff ℝ n ↿S.lagrangian 
   rw [lagrangian_eq]
   fun_prop
 
-lemma toDual_symm_innerSL (x : EuclideanSpace ℝ (Fin 1)) :
-    (InnerProductSpace.toDual ℝ (EuclideanSpace ℝ (Fin 1))).symm (innerSL ℝ x) = x :=
-  (InnerProductSpace.toDual ℝ (EuclideanSpace ℝ (Fin 1))).symm_apply_apply x
-
-lemma gradient_inner_self (x : EuclideanSpace ℝ (Fin 1)) :
-    gradient (fun y : EuclideanSpace ℝ (Fin 1) => ⟪y, y⟫_ℝ) x = (2 : ℝ) • x := by
-  refine ext_inner_right (𝕜 := ℝ) fun y => ?_
-  unfold gradient
-  rw [InnerProductSpace.toDual_symm_apply,
-    fderiv_inner_apply (𝕜 := ℝ) differentiableAt_fun_id differentiableAt_fun_id]
-  simp [real_inner_comm, inner_smul_right, two_mul]
-
-lemma gradient_const_mul_inner_self (c : ℝ) (x : EuclideanSpace ℝ (Fin 1)) :
-    gradient (fun y : EuclideanSpace ℝ (Fin 1) => c * ⟪y, y⟫_ℝ) x = (2 * c) • x := by
-  unfold gradient
-  rw [fderiv_const_mul (by fun_prop) c, map_smul]
-  show c • gradient (fun y : EuclideanSpace ℝ (Fin 1) => ⟪y, y⟫_ℝ) x = (2 * c) • x
-  rw [gradient_inner_self, smul_smul, mul_comm]
-
 /-!
 
 #### D.1.3. Gradients of the lagrangian
@@ -365,18 +347,13 @@ position and velocity.
 
 -/
 
-private lemma gradient_add_const' {f : EuclideanSpace ℝ (Fin 1) → ℝ} {c : ℝ}
-    (x : EuclideanSpace ℝ (Fin 1)) :
-    gradient (fun y => f y + c) x = gradient f x :=
-  congrArg (InnerProductSpace.toDual ℝ (EuclideanSpace ℝ (Fin 1))).symm (fderiv_add_const c)
-
 lemma gradient_lagrangian_position_eq (t : Time) (x : EuclideanSpace ℝ (Fin 1))
     (v : EuclideanSpace ℝ (Fin 1)) :
     gradient (fun x => lagrangian S t x v) x = - S.k • x := by
   have h_eq : (fun y : EuclideanSpace ℝ (Fin 1) => lagrangian S t y v) =
       fun y => (-(1 / (2 : ℝ)) * S.k) * ⟪y, y⟫_ℝ + (1 / (2 : ℝ) * S.m * ⟪v, v⟫_ℝ) := by
     funext y; simp only [lagrangian_eq]; ring
-  rw [h_eq, gradient_add_const', gradient_const_mul_inner_self]
+  rw [h_eq, gradient_add_const, gradient_const_mul_inner_self]
   module
 
 lemma gradient_lagrangian_velocity_eq (t : Time) (x : EuclideanSpace ℝ (Fin 1))
@@ -386,7 +363,7 @@ lemma gradient_lagrangian_velocity_eq (t : Time) (x : EuclideanSpace ℝ (Fin 1)
       fun y => ((1 / (2 : ℝ)) * S.m) * ⟪y, y⟫_ℝ + (-(1 / (2 : ℝ)) * S.k * ⟪x, x⟫_ℝ) := by
     funext y; simp only [lagrangian_eq]; ring
   change gradient (fun y : EuclideanSpace ℝ (Fin 1) => lagrangian S t x y) v = S.m • v
-  rw [h_eq, gradient_add_const', gradient_const_mul_inner_self]
+  rw [h_eq, gradient_add_const, gradient_const_mul_inner_self]
   module
 
 /-!
@@ -679,7 +656,7 @@ lemma gradient_hamiltonian_position_eq (t : Time) (x : EuclideanSpace ℝ (Fin 1
     simp only [hamiltonian_eq]
     ring
   change gradient (fun y : EuclideanSpace ℝ (Fin 1) => hamiltonian S t p y) x = S.k • x
-  rw [h_eq, gradient_add_const', gradient_const_mul_inner_self]
+  rw [h_eq, gradient_add_const, gradient_const_mul_inner_self]
   module
 
 lemma gradient_hamiltonian_momentum_eq (t : Time) (x : EuclideanSpace ℝ (Fin 1))
@@ -691,7 +668,7 @@ lemma gradient_hamiltonian_momentum_eq (t : Time) (x : EuclideanSpace ℝ (Fin 1
     funext y
     simp only [hamiltonian_eq]
   change gradient (fun y : EuclideanSpace ℝ (Fin 1) => hamiltonian S t y x) p = (1 / S.m) • p
-  rw [h_eq, gradient_add_const', gradient_const_mul_inner_self]
+  rw [h_eq, gradient_add_const, gradient_const_mul_inner_self]
   module
 
 /-!

--- a/Physlib/Mathematics/Calculus/Gradient.lean
+++ b/Physlib/Mathematics/Calculus/Gradient.lean
@@ -37,6 +37,8 @@ product space. The file is deliberately real: two of its rules (`gradient_const_
 - `gradient_inner_self` : `∇ (fun y => ⟪y, y⟫) x = 2 • x`.
 - `gradient_const_mul_inner_self` : `∇ (fun y => c * ⟪y, y⟫) x = (2 * c) • x`.
 - `gradient_coord` : `∇ (fun y => y i) x = EuclideanSpace.single i 1`.
+- `gradient_comp_coord` : `∇ (fun y => f (y i)) x = f' • EuclideanSpace.single i 1` when
+  `HasDerivAt f f' (x i)`.
 
 ## iii. Table of contents
 
@@ -120,6 +122,17 @@ lemma gradient_coord {ι : Type*} [Fintype ι] [DecidableEq ι] (i : ι) (x : Eu
       (innerSL ℝ (EuclideanSpace.single i (1 : ℝ))) x :=
     (EuclideanSpace.proj (𝕜 := ℝ) i).hasFDerivAt.congr_fderiv
       (by ext y; simp [EuclideanSpace.inner_single_left])
+  exact h.hasGradientAt.gradient.trans ((toDual ℝ _).symm_apply_apply _)
+
+/-- Chain rule for a function of one coordinate: the gradient of `y ↦ f (y i)` at `x` is
+`f' • EuclideanSpace.single i 1`, where `f'` is the derivative of `f` at `x i`. -/
+lemma gradient_comp_coord {ι : Type*} [Fintype ι] [DecidableEq ι] {f : ℝ → ℝ} {f' : ℝ}
+    (i : ι) (x : EuclideanSpace ℝ ι) (hf : HasDerivAt f f' (x i)) :
+    gradient (fun y : EuclideanSpace ℝ ι => f (y i)) x = f' • EuclideanSpace.single i 1 := by
+  have h : HasFDerivAt (fun y : EuclideanSpace ℝ ι => f (y i))
+      (innerSL ℝ (f' • EuclideanSpace.single i (1 : ℝ))) x :=
+    (hf.comp_hasFDerivAt x (EuclideanSpace.proj (𝕜 := ℝ) i).hasFDerivAt).congr_fderiv
+      (by ext y; simp [EuclideanSpace.inner_single_left, smul_eq_mul])
   exact h.hasGradientAt.gradient.trans ((toDual ℝ _).symm_apply_apply _)
 
 end

--- a/Physlib/Mathematics/Calculus/Gradient.lean
+++ b/Physlib/Mathematics/Calculus/Gradient.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 Aadarsh Agarwal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aadarsh Agarwal
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Gradient.Basic
+public import Mathlib.Analysis.InnerProductSpace.Calculus
+public import Mathlib.Analysis.InnerProductSpace.PiL2
+/-!
+
+# Elementary rules for the gradient
+
+## i. Overview
+
+Mathlib defines the gradient `∇ f x` of a real-valued function on a real Hilbert space as the
+Riesz representative of its Fréchet derivative, but at present records only its value on constants.
+This file collects the elementary rules used throughout the classical mechanics of Physlib: a
+gradient is unchanged by adding a constant, it commutes with multiplication by a constant, the
+gradient of the quadratic form `⟪y, y⟫` is `2 • y`, and the gradient of a coordinate functional on
+Euclidean space is the corresponding basis vector.
+
+These are the rules needed to differentiate Lagrangians and Hamiltonians of the form
+`kinetic − potential` with respect to positions and velocities.
+
+## ii. Key results
+
+- `gradient_add_const` : `∇ (f + c) = ∇ f`.
+- `gradient_const_mul` : `∇ (c * f) = c • ∇ f` for differentiable `f`.
+- `gradient_inner_self` : `∇ (fun y => ⟪y, y⟫) x = 2 • x`.
+- `gradient_const_mul_inner_self` : `∇ (fun y => c * ⟪y, y⟫) x = (2 * c) • x`.
+- `gradient_coord` : `∇ (fun y => y i) x = EuclideanSpace.single i 1`.
+
+## iii. Table of contents
+
+- A. Gradients and constants
+- B. Gradients of quadratic forms
+- C. Coordinate functionals on Euclidean space
+
+## iv. References
+
+- Mathlib, `Mathlib.Analysis.Calculus.Gradient.Basic`.
+
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open InnerProductSpace
+
+variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] [CompleteSpace F]
+
+/-!
+
+## A. Gradients and constants
+
+Adding a constant does not change the Fréchet derivative, hence not the gradient; multiplying by a
+constant scales both.
+
+-/
+
+lemma gradient_add_const {f : F → ℝ} (c : ℝ) (x : F) :
+    gradient (fun y => f y + c) x = gradient f x := by
+  unfold gradient
+  rw [fderiv_add_const]
+
+lemma gradient_const_mul {f : F → ℝ} {x : F} (c : ℝ) (hf : DifferentiableAt ℝ f x) :
+    gradient (fun y => c * f y) x = c • gradient f x := by
+  unfold gradient
+  rw [fderiv_const_mul hf, map_smul]
+
+/-!
+
+## B. Gradients of quadratic forms
+
+The quadratic form `y ↦ ⟪y, y⟫` has derivative `v ↦ 2 ⟪x, v⟫` at `x`, whose Riesz representative
+is `2 • x`.
+
+-/
+
+lemma gradient_inner_self (x : F) : gradient (fun y : F => ⟪y, y⟫_ℝ) x = (2 : ℝ) • x := by
+  refine ext_inner_right (𝕜 := ℝ) fun y => ?_
+  unfold gradient
+  rw [InnerProductSpace.toDual_symm_apply,
+    fderiv_inner_apply (𝕜 := ℝ) differentiableAt_fun_id differentiableAt_fun_id]
+  simp [real_inner_comm, inner_smul_right, two_mul]
+
+lemma gradient_const_mul_inner_self (c : ℝ) (x : F) :
+    gradient (fun y : F => c * ⟪y, y⟫_ℝ) x = (2 * c) • x := by
+  rw [gradient_const_mul c (differentiableAt_fun_id.inner ℝ differentiableAt_fun_id),
+    gradient_inner_self, smul_smul, mul_comm]
+
+/-!
+
+## C. Coordinate functionals on Euclidean space
+
+The coordinate functional `y ↦ y i` on `EuclideanSpace ℝ ι` is the continuous linear map
+`EuclideanSpace.proj i`, whose Riesz representative is the basis vector `EuclideanSpace.single i 1`.
+
+-/
+
+lemma gradient_coord {ι : Type*} [Fintype ι] [DecidableEq ι] (i : ι) (x : EuclideanSpace ℝ ι) :
+    gradient (fun y : EuclideanSpace ℝ ι => y i) x = EuclideanSpace.single i 1 := by
+  have h : HasFDerivAt (fun y : EuclideanSpace ℝ ι => y i)
+      (innerSL ℝ (EuclideanSpace.single i (1 : ℝ))) x :=
+    (EuclideanSpace.proj (𝕜 := ℝ) i).hasFDerivAt.congr_fderiv
+      (by ext y; simp [EuclideanSpace.inner_single_left])
+  exact h.hasGradientAt.gradient.trans ((toDual ℝ _).symm_apply_apply _)
+
+end
+
+end

--- a/Physlib/Mathematics/Calculus/Gradient.lean
+++ b/Physlib/Mathematics/Calculus/Gradient.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Analysis.Calculus.Gradient.Basic
 public import Mathlib.Analysis.InnerProductSpace.Calculus
-public import Mathlib.Analysis.InnerProductSpace.PiL2
 /-!
 
 # Elementary rules for the gradient
@@ -15,14 +14,21 @@ public import Mathlib.Analysis.InnerProductSpace.PiL2
 ## i. Overview
 
 Mathlib defines the gradient `∇ f x` of a real-valued function on a real Hilbert space as the
-Riesz representative of its Fréchet derivative, but at present records only its value on constants.
-This file collects the elementary rules used throughout the classical mechanics of Physlib: a
-gradient is unchanged by adding a constant, it commutes with multiplication by a constant, the
-gradient of the quadratic form `⟪y, y⟫` is `2 • y`, and the gradient of a coordinate functional on
-Euclidean space is the corresponding basis vector.
+Riesz representative of its Fréchet derivative, but records no rules for the algebraic operations
+on `f` beyond constants. This file collects the elementary rules used throughout the classical
+mechanics of Physlib: a gradient is unchanged by adding a constant, it commutes with
+multiplication by a constant, the gradient of the quadratic form `⟪y, y⟫` is `2 • y`, and the
+gradient of a coordinate functional on Euclidean space is the corresponding basis vector.
 
 These are the rules needed to differentiate Lagrangians and Hamiltonians of the form
 `kinetic − potential` with respect to positions and velocities.
+
+These are rules for Mathlib's `gradient` on an abstract real Hilbert space. They are distinct from
+`Physlib.SpaceAndTime.Space.Derivatives.Grad`, whose `Space.grad` is a coordinate-valued operator on
+the structure `Space d`; nothing there applies to `EuclideanSpace ℝ (Fin 1)` or to a general inner
+product space. The file is deliberately real: two of its rules (`gradient_const_mul` and
+`gradient_inner_self`) are specific to real scalars, so the remaining ones are stated over
+`ℝ` as well.
 
 ## ii. Key results
 
@@ -61,11 +67,14 @@ constant scales both.
 
 -/
 
+/-- Adding a constant to a function does not change its gradient. -/
 lemma gradient_add_const {f : F → ℝ} (c : ℝ) (x : F) :
     gradient (fun y => f y + c) x = gradient f x := by
   unfold gradient
   rw [fderiv_add_const]
 
+/-- The gradient of a constant multiple of a differentiable function is the constant multiple of
+the gradient. -/
 lemma gradient_const_mul {f : F → ℝ} {x : F} (c : ℝ) (hf : DifferentiableAt ℝ f x) :
     gradient (fun y => c * f y) x = c • gradient f x := by
   unfold gradient
@@ -80,13 +89,15 @@ is `2 • x`.
 
 -/
 
+/-- The gradient of `y ↦ ⟪y, y⟫` at `x` is `2 • x`. -/
 lemma gradient_inner_self (x : F) : gradient (fun y : F => ⟪y, y⟫_ℝ) x = (2 : ℝ) • x := by
   refine ext_inner_right (𝕜 := ℝ) fun y => ?_
   unfold gradient
-  rw [InnerProductSpace.toDual_symm_apply,
+  rw [toDual_symm_apply,
     fderiv_inner_apply (𝕜 := ℝ) differentiableAt_fun_id differentiableAt_fun_id]
   simp [real_inner_comm, inner_smul_right, two_mul]
 
+/-- The gradient of `y ↦ c * ⟪y, y⟫` at `x` is `(2 * c) • x`. -/
 lemma gradient_const_mul_inner_self (c : ℝ) (x : F) :
     gradient (fun y : F => c * ⟪y, y⟫_ℝ) x = (2 * c) • x := by
   rw [gradient_const_mul c (differentiableAt_fun_id.inner ℝ differentiableAt_fun_id),
@@ -101,6 +112,8 @@ The coordinate functional `y ↦ y i` on `EuclideanSpace ℝ ι` is the continuo
 
 -/
 
+/-- The gradient of the `i`-th coordinate functional on Euclidean space is the `i`-th basis
+vector. -/
 lemma gradient_coord {ι : Type*} [Fintype ι] [DecidableEq ι] (i : ι) (x : EuclideanSpace ℝ ι) :
     gradient (fun y : EuclideanSpace ℝ ι => y i) x = EuclideanSpace.single i 1 := by
   have h : HasFDerivAt (fun y : EuclideanSpace ℝ ι => y i)


### PR DESCRIPTION

Adds `Physlib/Mathematics/Calculus/Gradient.lean` (140 lines): six general lemmas about `gradient`
over a real inner-product space, and refactors the two oscillators to use them. These facts
currently live as private or namespace-local lemmas inside `HarmonicOscillator/Basic.lean` and
`DampedHarmonicOscillator/Basic.lean`; upcoming work on the pendulum (#883) needs the same facts,
and promoting them beats copying them.

### Declarations added (root namespace, over `[NormedAddCommGroup F] [InnerProductSpace ℝ F] [CompleteSpace F]`)

| Lemma | Statement |
|---|---|
| `gradient_add_const` | `∇(f + c) = ∇f` |
| `gradient_const_mul` | `∇(c • f) x = c • ∇f x` (for `f` differentiable at `x`) |
| `gradient_inner_self` | `∇⟪y, y⟫ x = 2 • x` |
| `gradient_const_mul_inner_self` | `∇(c⟪y, y⟫) x = (2c) • x` |
| `gradient_coord` | `∇(y ↦ y i) x = EuclideanSpace.single i 1` |
| `gradient_comp_coord` | `∇(y ↦ f (y i)) x = f' • single i 1` when `HasDerivAt f f' (x i)` |

### Public names removed (all consumers updated in this PR; no others exist in the repo)
- `HarmonicOscillator.gradient_inner_self`, `HarmonicOscillator.gradient_const_mul_inner_self`
  (moved to root, generalized), and the dead `HarmonicOscillator.toDual_symm_innerSL`.
Happy to add deprecation aliases if you prefer that over a clean removal.

### Reviewer reading order
1. `Gradient.lean` — the six lemmas and the module doc's scope note (real scalars only, and why).
2. The `HarmonicOscillator/Basic.lean` diff — deletions replaced by the shared lemmas, proofs
   otherwise untouched.
3. The one-hunk `DampedHarmonicOscillator/Basic.lean` diff.

### Verification
- `lake build` — clean.
- `lake exe runPhyslibLinters Physlib`, `lake exe check_file_imports`, `lake exe check_dup_tags`,
  `lake exe sorry_lint` — all pass.
- `./scripts/lint-style.sh`, `python scripts/api_map_linter.py --repo .`, codespell — all pass.

Developed with assistance from AI; all mathematics and proofs were reviewed and verified to compile.
