### PR TITLE
Update OperatorAlgebra.Basic

### DIFF
--- a/Physlib/QuantumMechanics/OperatorAlgebra/Basic.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Basic.lean
@@ -6,6 +6,7 @@ Authors: Tom Ole Diem
 module
 
 public import Mathlib.Analysis.CStarAlgebra.CompletelyPositiveMap
+public import Mathlib.Analysis.CStarAlgebra.ContinuousLinearMap
 public import Mathlib.Analysis.InnerProductSpace.StarOrder
 
 /-!
@@ -48,18 +49,15 @@ variable {A : Type*} [OperatorAlgebra A]
 /-- An observable is a self-adjoint element of `A`: position, momentum, energy, spin, ... .
 Self-adjointness is exactly what makes an element a *measurable* quantity — it is what forces its
 spectrum, the possible measurement outcomes, to be real. -/
-noncomputable abbrev Observable (A : Type*) [CStarAlgebra A] :=
-  selfAdjoint A
+noncomputable abbrev Observable (A : Type*) [OperatorAlgebra A] := selfAdjoint A
 
 /-- A positive element of `A`: an observable whose measurement outcomes are all `≥ 0`.
 Positivity is what gives observables a meaningful order (`a ≤ b` meaning `b - a` is positive). -/
-abbrev PositiveElement (A : Type*) [OperatorAlgebra A] :=
-  {a : Observable A // 0 ≤ (a : A)}
+abbrev PositiveElement (A : Type*) [OperatorAlgebra A] := {a : Observable A // 0 ≤ (a : A)}
 
 /-- An effect is an observable between zero and the identity, representing a yes/no measurement
 outcome. -/
-abbrev Effect (A : Type*) [OperatorAlgebra A] :=
-  Set.Icc (0 : Observable A) 1
+abbrev Effect (A : Type*) [OperatorAlgebra A] := Set.Icc (0 : Observable A) 1
 
 /-- A finite POVM on `A`: the most general notion of a measurement with outcomes in `X`,
 generalizing a single yes/no `Effect` to several possible outcomes. -/
@@ -71,8 +69,7 @@ structure POVM (A : Type*) [OperatorAlgebra A] (X : Type*) [Fintype X] where
 
 /-- A unitary element of `A`: implements a reversible transformation of the system — a symmetry,
 or time evolution under a Hamiltonian — acting on observables by conjugation, `a ↦ U a U⋆`. -/
-noncomputable abbrev Unitary (A : Type*) [CStarAlgebra A] :=
-  unitary A
+noncomputable abbrev Unitary (A : Type*) [OperatorAlgebra A] := unitary A
 
 /-- A state on `A`: a positive complex-linear functional normalized by `ω 1 = 1`. `ω a` is the
 expected outcome of measuring observable `a` in this state — a state records everything that can
@@ -91,6 +88,32 @@ abbrev Channel (A₁ A₂ : Type*) [OperatorAlgebra A₁] [OperatorAlgebra A₂]
 end ObservableAlgebra
 
 /-!
+## Bounded operators on Hilbert space
+
+The bounded operators on any complex Hilbert space form a C⋆-algebra. Equip them with the
+canonical spectral order so they can be used as an `OperatorAlgebra`.
+-/
+
+section HilbertSpaceOperatorAlgebra
+
+/-- The bounded operators on a complex Hilbert space, written in the usual physics notation. -/
+notation "B(" H ")" => H →L[ℂ] H
+
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
+
+/-- The physical operator algebra of bounded operators on a complex Hilbert space. -/
+abbrev HilbertSpaceOperatorAlgebra (H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H] :=
+  OperatorAlgebra B(H)
+
+noncomputable instance : PartialOrder B(H) := CStarAlgebra.spectralOrder _
+instance : StarOrderedRing B(H) := CStarAlgebra.spectralOrderedRing _
+
+/-- Bounded operators on a complex Hilbert space form an operator algebra via the spectral order. -/
+noncomputable instance : HilbertSpaceOperatorAlgebra H := {}
+
+end HilbertSpaceOperatorAlgebra
+
+/-!
 ## Hilbert-space representations
 
 The abstract observable algebra need not initially be presented as operators on
@@ -104,14 +127,13 @@ This is also the target of the GNS construction associated with a state.
 
 section Representation
 
-variable {A : Type*} {H : Type*} [CStarAlgebra A] [NormedAddCommGroup H] [InnerProductSpace ℂ H]
-  [CompleteSpace H]
+variable {A : Type*} {H : Type*} [OperatorAlgebra A] [NormedAddCommGroup H]
+  [InnerProductSpace ℂ H] [CompleteSpace H]
 
 /-- A Hilbert-space representation of `A`: a unital ⋆-homomorphism from `A` into the algebra of
 bounded operators on the Hilbert space `H`. -/
-abbrev Representation (A : Type*) (H : Type*) [CStarAlgebra A] [NormedAddCommGroup H]
-    [InnerProductSpace ℂ H] [CompleteSpace H] :=
-  A →⋆ₐ[ℂ] (H →L[ℂ] H)
+abbrev Representation (A H : Type*) [OperatorAlgebra A] [NormedAddCommGroup H]
+    [InnerProductSpace ℂ H] [CompleteSpace H] := A →⋆ₐ[ℂ] B(H)
 
 end Representation
 


### PR DESCRIPTION
Update the existing operator-algebra basics to use OperatorAlgebra consistently, add the canonical B(H) Hilbert-space operator algebra, and expose Hilbert-space representations through B(H).